### PR TITLE
Information de l'utilisateur·ice dans le frontend 

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -1,1 +1,2 @@
 from .blogpost import BlogPostSerializer  # noqa: F401
+from .user import LoggedUserSerializer  # noqa: F401

--- a/api/serializers/user.py
+++ b/api/serializers/user.py
@@ -9,3 +9,16 @@ class BlogPostAuthor(serializers.ModelSerializer):
             "first_name",
             "last_name",
         )
+
+
+class LoggedUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = get_user_model()
+        fields = (
+            "id",
+            "email",
+            "username",
+            "first_name",
+            "last_name",
+        )
+        read_only_fields = fields

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -1,0 +1,30 @@
+import json
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from .utils import authenticate
+
+
+class TestLoggedUserApi(APITestCase):
+    def test_unauthenticated_logged_user_call(self):
+        """
+        When calling this API unathenticated we expect a 204
+        """
+        response = self.client.get(reverse("logged_user"))
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    @authenticate
+    def test_authenticated_logged_user_call(self):
+        """
+        When calling this API athenticated we expect to get a
+        JSON representation of the authenticated user
+        """
+        response = self.client.get(reverse("logged_user"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = json.loads(response.content.decode())
+        self.assertEqual(body.get("username"), authenticate.user.username)
+        self.assertEqual(body.get("email"), authenticate.user.email)
+        self.assertEqual(body.get("firstName"), authenticate.user.first_name)
+        self.assertEqual(body.get("lastName"), authenticate.user.last_name)
+        self.assertIn("id", body)

--- a/api/tests/utils.py
+++ b/api/tests/utils.py
@@ -1,0 +1,12 @@
+import functools
+from data.factories import UserFactory
+
+
+def authenticate(func):
+    @functools.wraps(func)
+    def authenticate_and_func(*args, **kwargs):
+        authenticate.user = UserFactory.create()
+        args[0].client.force_login(user=authenticate.user)
+        return func(*args, **kwargs)
+
+    return authenticate_and_func

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api.views import BlogPostsView, BlogPostView, SubscribeNewsletter
+from api.views import BlogPostsView, BlogPostView, SubscribeNewsletter, LoggedUserView
 
 urlpatterns = {
     path("blogPosts/", BlogPostsView.as_view(), name="blog_posts_list"),
     path("blogPosts/<int:pk>", BlogPostView.as_view(), name="single_blog_post"),
     path("subscribeNewsletter/", SubscribeNewsletter.as_view(), name="subscribe_newsletter"),
+    path("loggedUser/", LoggedUserView.as_view(), name="logged_user"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,2 +1,3 @@
 from .blog import BlogPostsView, BlogPostView  # noqa: F401
 from .newsletter import SubscribeNewsletter  # noqa: F401
+from .user import LoggedUserView  # noqa: F401

--- a/api/views/user.py
+++ b/api/views/user.py
@@ -1,0 +1,20 @@
+from rest_framework.generics import RetrieveAPIView
+from rest_framework.response import Response
+from rest_framework import permissions
+from rest_framework import status
+from api.serializers import LoggedUserSerializer
+from django.contrib.auth import get_user_model
+
+
+class LoggedUserView(RetrieveAPIView):
+    model = get_user_model()
+    serializer_class = LoggedUserSerializer
+    queryset = get_user_model().objects.all()
+
+    def get(self, request, *args, **kwargs):
+        if permissions.IsAuthenticated().has_permission(self.request, self):
+            return super().get(request, *args, **kwargs)
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+    def get_object(self):
+        return self.request.user

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <DsfrHeader :logo-text="logoText" service-title="Compléments alimentaires" />
+  <AppHeader />
   <router-view></router-view>
   <DsfrFooter :logo-text="logoText">
     <template v-slot:description>
@@ -9,5 +9,5 @@
 </template>
 
 <script setup>
-const logoText = ["Ministère", "de l'Agriculture", "et de la Souveraineté", "Alimentaire"]
+import AppHeader from "@/components/AppHeader.vue"
 </script>

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -1,0 +1,25 @@
+<template>
+  <DsfrHeader :logo-text="logoText" service-title="Compléments alimentaires" :quickLinks="quickLinks" />
+</template>
+
+<script setup>
+import { computed, onMounted } from "vue"
+import { useStore } from "vuex"
+
+const logoText = ["Ministère", "de l'Agriculture", "et de la Souveraineté", "Alimentaire"]
+const store = useStore()
+const quickLinks = computed(function () {
+  if (store.state.loggedUser)
+    return [
+      {
+        label: "Se déconnecter",
+        to: "/se-deconnecter",
+        icon: "ri-account-circle-line",
+      },
+    ]
+  else return []
+})
+onMounted(() => {
+  store.dispatch("fetchLoggedUser")
+})
+</script>

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -13,8 +13,8 @@ const quickLinks = computed(function () {
     return [
       {
         label: "Se déconnecter",
-        to: "/se-deconnecter",
         icon: "ri-account-circle-line",
+        href: `${window.location.protocol}//${window.location.host}/se-deconnecter`,
       },
     ]
   else return []

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,5 +7,6 @@ import "@gouvfr/dsfr/dist/utility/icons/icons.min.css"
 
 import App from "./App.vue"
 import router from "./router"
+import store from "./store"
 
-createApp(App).use(router).use(VueDsfr).mount("#app")
+createApp(App).use(router).use(store).use(VueDsfr).mount("#app")

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,0 +1,28 @@
+import { createStore } from "vuex"
+import { verifyResponse } from "../utils"
+
+const store = createStore({
+  state() {
+    return {
+      loggedUser: null,
+    }
+  },
+  mutations: {
+    setLoggedUser(state, user) {
+      state.loggedUser = user
+    },
+  },
+  actions: {
+    fetchLoggedUser(context) {
+      return fetch("/api/v1/loggedUser/")
+        .then(verifyResponse)
+        .then((response) => {
+          context.commit("setLoggedUser", response || null)
+        })
+        .catch((e) => {
+          console.error("fetchLoggedUser", e)
+        })
+    },
+  },
+})
+export default store

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,0 +1,42 @@
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#custom_error_types
+export class AuthenticationError extends Error {
+  constructor(...params) {
+    super(...params)
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AuthenticationError)
+    }
+    this.name = "AuthenticationError"
+  }
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#custom_error_types
+export class BadRequestError extends Error {
+  constructor(jsonPromise, ...params) {
+    super(...params)
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, BadRequestError)
+    }
+    this.name = "BadRequestError"
+    this.jsonPromise = jsonPromise
+  }
+}
+
+export const verifyResponse = (response) => {
+  const contentType = response.headers.get("content-type")
+  const hasJSON = contentType && contentType.startsWith("application/json")
+
+  if (response.status < 200 || response.status >= 400) {
+    if (response.status === 403) throw new AuthenticationError()
+    else if (response.status === 400) {
+      if (hasJSON) {
+        throw new BadRequestError(response.json())
+      } else {
+        throw new BadRequestError()
+      }
+    } else throw new Error(`API responded with status of ${response.status}`)
+  }
+
+  return hasJSON ? response.json() : response.text()
+}


### PR DESCRIPTION
Cette PR permet de récupérer les données de l'utilisateur·ice identifié·e et montre un bouton de déconnexion pour fermer la session. Ceci inclut donc :

#### Endpoint
- Mise en place du `serializer`, `view`, `url` et `test` pour l'endpoint `LoggedUser`
- Appel API qui retourne un `204 No Content` lorsque personne n'est pas identifié, ou un `200 OK` avec un JSON contenant l'information dans le cas contraire

#### Frontend
- Mise en place du store `vuex`
- Créer un composant dédié pour notre entête

[Screencast from 28-11-23 16:23:41.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/f6ba89ba-0161-4b7d-974c-38a2ccf99606)
