### PR TITLE
Changement des model Django pour respecter le modèle de BDD de TeleIcare

### DIFF
--- a/data/models/__init__.py
+++ b/data/models/__init__.py
@@ -3,4 +3,5 @@ from .ingredient import Ingredient  # noqa: F401
 from .microorganism import Microorganism  # noqa: F401
 from .plant import Plant  # noqa: F401
 from .substance import Substance  # noqa: F401
+from .population import Population  # noqa: F401
 from .blogpost import BlogPost  # noqa: F401

--- a/data/models/approvalstate.py
+++ b/data/models/approvalstate.py
@@ -1,8 +1,0 @@
-from django.db import models
-
-
-class LegacyApprovalState(models.TextChoices):
-    TO_REGISTER = "to_register", "À inscrire"
-    AUTHORIZED = "authorized", "Autorisé"
-    REJECTED = "rejected", "Non autorisé"
-    UNKNOWN = "unknown", "Sans objet"

--- a/data/models/common_base_ingredient.py
+++ b/data/models/common_base_ingredient.py
@@ -1,0 +1,18 @@
+from django.db import models
+
+
+class CommonBaseIngredient(models.Model):
+    class Meta:
+        abstract = True
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    name = models.CharField(max_length=200)
+    name_en = models.CharField(max_length=200, blank=True)
+    public_comments = models.CharField(max_length=1000, null=True, blank=True, verbose_name="Commentaires publics")
+    private_comments = models.CharField(max_length=2000, null=True, blank=True, verbose_name="Commentaires privés")
+    is_obsolete = models.BooleanField(verbose_name="Ingrédient obsolète")
+
+    # commentaire_public_en = models.CharField(max_length=1000, blank=True)
+    # commentaire_privé_en = models.CharField(max_length=2000, blank=True)  # TODO : intégrer les quelques données ici
+    # ordre = models.IntegerField()

--- a/data/models/common_base_ingredient.py
+++ b/data/models/common_base_ingredient.py
@@ -7,10 +7,10 @@ class CommonBaseIngredient(models.Model):
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.TextField()
-    name_en = models.TextField(blank=True)
-    public_comments = models.TextField(null=True, blank=True, verbose_name="commentaires publics")
-    private_comments = models.TextField(null=True, blank=True, verbose_name="commentaires privés")
+    name = models.TextField(verbose_name="nom")
+    name_en = models.TextField(blank=True, verbose_name="nom en anglais")
+    public_comments = models.TextField(blank=True, verbose_name="commentaires publics")
+    private_comments = models.TextField(blank=True, verbose_name="commentaires privés")
     is_obsolete = models.BooleanField(verbose_name="ingrédient obsolète")
 
     # commentaire_public_en = models.TextField(blank=True)

--- a/data/models/common_base_ingredient.py
+++ b/data/models/common_base_ingredient.py
@@ -7,12 +7,12 @@ class CommonBaseIngredient(models.Model):
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
-    name_en = models.CharField(max_length=200, blank=True)
-    public_comments = models.CharField(max_length=1000, null=True, blank=True, verbose_name="Commentaires publics")
-    private_comments = models.CharField(max_length=2000, null=True, blank=True, verbose_name="Commentaires privés")
-    is_obsolete = models.BooleanField(verbose_name="Ingrédient obsolète")
+    name = models.TextField()
+    name_en = models.TextField(blank=True)
+    public_comments = models.TextField(null=True, blank=True, verbose_name="commentaires publics")
+    private_comments = models.TextField(null=True, blank=True, verbose_name="commentaires privés")
+    is_obsolete = models.BooleanField(verbose_name="ingrédient obsolète")
 
-    # commentaire_public_en = models.CharField(max_length=1000, blank=True)
-    # commentaire_privé_en = models.CharField(max_length=2000, blank=True)  # TODO : intégrer les quelques données ici
+    # commentaire_public_en = models.TextField(blank=True)
+    # commentaire_privé_en = models.TextField(blank=True)  # TODO : intégrer les quelques données ici
     # ordre = models.IntegerField()

--- a/data/models/ingredient.py
+++ b/data/models/ingredient.py
@@ -1,28 +1,22 @@
 from django.db import models
 
+from .common_base_ingredient import CommonBaseIngredient
+from .substance import Substance
 
-class Ingredient(models.Model):
+
+class Ingredient(CommonBaseIngredient):
     class Meta:
         verbose_name = "Autre ingrédient"
 
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
-    name_en = models.CharField(max_length=200, blank=True)
     observation = models.CharField(max_length=200, blank=True)
-    public_comments = models.CharField(max_length=1000, null=True, blank=True, verbose_name="Commentaires publics")
-    private_comments = models.CharField(max_length=2000, null=True, blank=True, verbose_name="Commentaires privés")
     description = models.CharField(max_length=1000, blank=True)
+    substance = models.ManyToManyField(Substance)
 
     # champs présents dans le CSV mais inutilisés
     # stingsbs = models.IntegerField()
     # taing = models.IntegerField()
     # fctingr = models.IntegerField()
-    # commentaire_public_en = models.CharField(max_length=1000, blank=True)
-    # commentaire_privé_en = models.CharField(max_length=2000, blank=True)  # TODO : intégrer les quelques données ici
     # description_en = models.CharField(max_length=1000, blank=True)
-    # ordre = models.IntegerField()
-    # obsolet = models.BooleanField()
 
 
 class IngredientSynonym(models.Model):
@@ -32,6 +26,7 @@ class IngredientSynonym(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
     name = models.CharField(max_length=200)
+    ingredient = models.ForeignKey(Ingredient, on_delete=models.CASCADE)
 
     # champs présents dans le CSV mais inutilisés
     # ordre = models.IntegerField()

--- a/data/models/ingredient.py
+++ b/data/models/ingredient.py
@@ -9,8 +9,8 @@ class Ingredient(CommonBaseIngredient):
         verbose_name = "autre ingrédient"
         verbose_name_plural = "autres ingrédients"
 
-    observation = models.CharField(max_length=200, blank=True)
-    description = models.CharField(max_length=1000, blank=True)
+    observation = models.TextField(blank=True)
+    description = models.TextField(blank=True)
     substance = models.ManyToManyField(Substance)
 
     # champs présents dans le CSV mais inutilisés
@@ -26,7 +26,7 @@ class IngredientSynonym(models.Model):
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
+    name = models.TextField(blank=True, verbose_name="nom")
     ingredient = models.ForeignKey(Ingredient, on_delete=models.CASCADE)
 
     # champs présents dans le CSV mais inutilisés

--- a/data/models/ingredient.py
+++ b/data/models/ingredient.py
@@ -6,7 +6,8 @@ from .substance import Substance
 
 class Ingredient(CommonBaseIngredient):
     class Meta:
-        verbose_name = "Autre ingrédient"
+        verbose_name = "autre ingrédient"
+        verbose_name_plural = "autres ingrédients"
 
     observation = models.CharField(max_length=200, blank=True)
     description = models.CharField(max_length=1000, blank=True)
@@ -21,7 +22,7 @@ class Ingredient(CommonBaseIngredient):
 
 class IngredientSynonym(models.Model):
     class Meta:
-        verbose_name = "Synonymes d'ingrédient"
+        verbose_name = "synonyme d'ingrédient"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)

--- a/data/models/ingredient.py
+++ b/data/models/ingredient.py
@@ -1,71 +1,38 @@
 from django.db import models
-from simple_history.models import HistoricalRecords
-from .approvalstate import LegacyApprovalState
 
 
 class Ingredient(models.Model):
     class Meta:
-        verbose_name = "Autres ingrédients"
-
-    class LegacyIngredientType(models.TextChoices):
-        ADDITIVE = "additive", "Additif"
-        SCENT = "scent", "Arôme"
-        OTHER = "other", "Autre ingrédient"
-        OTHER_ACTIVE = "other_active", "Autre ingrédient actif"
-        NUTRIENT = "nutrient", "Nutriment"
-
-    class LegacySynonymType(models.TextChoices):
-        FRENCH = "french", "Nom français"
-        SCIENTIFIC = "scientific", "Nom scientifique"
+        verbose_name = "Autre ingrédient"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    history = HistoricalRecords()
+    name = models.CharField(max_length=200)
+    name_en = models.CharField(max_length=200, blank=True)
+    observation = models.CharField(max_length=200, blank=True)
+    public_comments = models.CharField(max_length=1000, null=True, blank=True, verbose_name="Commentaires publics")
+    private_comments = models.CharField(max_length=2000, null=True, blank=True, verbose_name="Commentaires privés")
+    description = models.CharField(max_length=1000, blank=True)
 
-    # Legacy fields
-    legacy_name = models.TextField(null=True, blank=True, verbose_name="(Legacy) Nom")
-    legacy_type = models.CharField(
-        max_length=255,
-        choices=LegacyIngredientType.choices,
-        null=True,
-        blank=True,
-        verbose_name="(Legacy) Type",
-    )
-    legacy_synonym = models.TextField(null=True, blank=True, verbose_name="(Legacy) Nom synonyme")
-    legacy_synonym_type = models.CharField(
-        max_length=255,
-        choices=LegacySynonymType.choices,
-        null=True,
-        blank=True,
-        verbose_name="(Legacy) Synonym yype",
-    )
-    legacy_substance_name = models.TextField(null=True, blank=True, verbose_name="(Legacy) Nom de la substance")
-    legacy_substance_unit_name = models.TextField(
-        null=True, blank=True, verbose_name="(Legacy) Nom de la substance avec unité"
-    )
-    legacy_approval_state = models.CharField(
-        max_length=255,
-        choices=LegacyApprovalState.choices,
-        null=True,
-        blank=True,
-        verbose_name="(Legacy) Status d'approbation",
-    )
-    legacy_intake_source = models.TextField(null=True, blank=True, verbose_name="(Legacy) Source d'apports")
-    legacy_minimum_dose = models.DecimalField(
-        blank=True,
-        null=True,
-        max_digits=10,
-        decimal_places=5,
-        verbose_name="(Legacy) Dose minimale",
-    )
-    legacy_maximum_dose = models.DecimalField(
-        blank=True,
-        null=True,
-        max_digits=10,
-        decimal_places=5,
-        verbose_name="(Legacy) Dose maximale",
-    )
-    legacy_public_comments = models.TextField(null=True, blank=True, verbose_name="(Legacy) Commentaires publics")
-    legacy_private_comments = models.TextField(null=True, blank=True, verbose_name="(Legacy) Commentaires privés")
-    legacy_observations = models.TextField(null=True, blank=True, verbose_name="(Legacy) Observations")
-    legacy_description = models.TextField(null=True, blank=True, verbose_name="(Legacy) Description")
+    # champs présents dans le CSV mais inutilisés
+    # stingsbs = models.IntegerField()
+    # taing = models.IntegerField()
+    # fctingr = models.IntegerField()
+    # commentaire_public_en = models.CharField(max_length=1000, blank=True)
+    # commentaire_privé_en = models.CharField(max_length=2000, blank=True)  # TODO : intégrer les quelques données ici
+    # description_en = models.CharField(max_length=1000, blank=True)
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()
+
+
+class IngredientSynonym(models.Model):
+    class Meta:
+        verbose_name = "Synonymes d'ingrédient"
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    name = models.CharField(max_length=200)
+
+    # champs présents dans le CSV mais inutilisés
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()

--- a/data/models/microorganism.py
+++ b/data/models/microorganism.py
@@ -1,24 +1,19 @@
 from django.db import models
 
+from .common_base_ingredient import CommonBaseIngredient
+from .substance import Substance
 
-class Microorganism(models.Model):
+
+class Microorganism(CommonBaseIngredient):
     class Meta:
         verbose_name = "Micro-organisme"
 
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200, verbose_name="Espèce de micro-organisme")
-    public_comments = models.CharField(max_length=1000, null=True, blank=True, verbose_name="Commentaires publics")
-    private_comments = models.CharField(max_length=2000, null=True, blank=True, verbose_name="Commentaires privés")
     genre = models.CharField(max_length=200, verbose_name="Genre de micro-organisme")
+    substance = models.ManyToManyField(Substance)
 
     # champs présents dans le CSV mais inutilisés
     # fctingr = models.IntegerField()
     # stingsbs = models.IntegerField()
-    # commentaire_public_en = models.CharField(max_length=1000, blank=True)
-    # commentaire_privé_en = models.CharField(max_length=2000, blank=True)
-    # ordre = models.IntegerField()
-    # obsolet = models.BooleanField()
 
 
 class MicroorganismSynonym(models.Model):
@@ -28,6 +23,7 @@ class MicroorganismSynonym(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
     name = models.CharField(max_length=200)
+    microorganism = models.ForeignKey(Microorganism, on_delete=models.CASCADE)
 
     # champs présents dans le CSV mais inutilisés
     # ordre = models.IntegerField()

--- a/data/models/microorganism.py
+++ b/data/models/microorganism.py
@@ -6,9 +6,9 @@ from .substance import Substance
 
 class Microorganism(CommonBaseIngredient):
     class Meta:
-        verbose_name = "Micro-organisme"
+        verbose_name = "micro-organisme"
 
-    genre = models.CharField(max_length=200, verbose_name="Genre de micro-organisme")
+    genre = models.CharField(max_length=200, verbose_name="genre de micro-organisme")
     substance = models.ManyToManyField(Substance)
 
     # champs présents dans le CSV mais inutilisés
@@ -18,7 +18,7 @@ class Microorganism(CommonBaseIngredient):
 
 class MicroorganismSynonym(models.Model):
     class Meta:
-        verbose_name = "Synonymes de micro-organisme"
+        verbose_name = "synonyme de micro-organisme"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)

--- a/data/models/microorganism.py
+++ b/data/models/microorganism.py
@@ -1,40 +1,34 @@
 from django.db import models
-from simple_history.models import HistoricalRecords
-from .approvalstate import LegacyApprovalState
 
 
 class Microorganism(models.Model):
     class Meta:
-        verbose_name = "micro-organisme"
-
-    class LegacyMicroorganismStatus(models.TextChoices):
-        UNKNOWN = "unknown", "Sans objet"
-        AUTHORIZED = "authorized", "Autorisé"
-
-    class LegacyMicroorganismFunction(models.TextChoices):
-        ACTIVE = "active", "Actif"
+        verbose_name = "Micro-organisme"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    history = HistoricalRecords()
+    name = models.CharField(max_length=200, verbose_name="Espèce de micro-organisme")
+    public_comments = models.CharField(max_length=1000, null=True, blank=True, verbose_name="Commentaires publics")
+    private_comments = models.CharField(max_length=2000, null=True, blank=True, verbose_name="Commentaires privés")
+    genre = models.CharField(max_length=200, verbose_name="Genre de micro-organisme")
 
-    # Legacy fields
-    legacy_species_name = models.TextField(null=True, blank=True, verbose_name="(Legacy) Nom de l'espèce")
-    legacy_genre_name = models.TextField(null=True, blank=True, verbose_name="(Legacy) Nom du genre")
-    legacy_full_name = models.TextField(null=True, blank=True, verbose_name="(Legacy) Nom complet")
-    legacy_approval_state = models.CharField(
-        max_length=255,
-        choices=LegacyApprovalState.choices,
-        null=True,
-        blank=True,
-        verbose_name="(Legacy) Status d'approbation",
-    )
-    legacy_function = models.CharField(
-        max_length=255,
-        choices=LegacyMicroorganismFunction.choices,
-        null=True,
-        blank=True,
-        verbose_name="(Legacy) Fonction",
-    )
-    legacy_public_comments = models.TextField(null=True, blank=True, verbose_name="(Legacy) Commentaires publics")
-    legacy_private_comments = models.TextField(null=True, blank=True, verbose_name="(Legacy) Commentaires privés")
+    # champs présents dans le CSV mais inutilisés
+    # fctingr = models.IntegerField()
+    # stingsbs = models.IntegerField()
+    # commentaire_public_en = models.CharField(max_length=1000, blank=True)
+    # commentaire_privé_en = models.CharField(max_length=2000, blank=True)
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()
+
+
+class MicroorganismSynonym(models.Model):
+    class Meta:
+        verbose_name = "Synonymes de micro-organisme"
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    name = models.CharField(max_length=200)
+
+    # champs présents dans le CSV mais inutilisés
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()

--- a/data/models/microorganism.py
+++ b/data/models/microorganism.py
@@ -8,7 +8,7 @@ class Microorganism(CommonBaseIngredient):
     class Meta:
         verbose_name = "micro-organisme"
 
-    genre = models.CharField(max_length=200, verbose_name="genre de micro-organisme")
+    genre = models.TextField(verbose_name="genre de micro-organisme")
     substance = models.ManyToManyField(Substance)
 
     # champs présents dans le CSV mais inutilisés
@@ -22,7 +22,7 @@ class MicroorganismSynonym(models.Model):
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
+    name = models.TextField(verbose_name="nom")
     microorganism = models.ForeignKey(Microorganism, on_delete=models.CASCADE)
 
     # champs présents dans le CSV mais inutilisés

--- a/data/models/plant.py
+++ b/data/models/plant.py
@@ -10,8 +10,8 @@ class Family(models.Model):
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.TextField()
-    name_en = models.TextField(blank=True)
+    name = models.TextField(verbose_name="nom")
+    name_en = models.TextField(blank=True, verbose_name="nom en anglais")
 
     # ordre = models.IntegerField()
     # obsolet = models.BooleanField()
@@ -23,8 +23,8 @@ class PlantPart(models.Model):
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.TextField()
-    name_en = models.TextField(blank=True)
+    name = models.TextField(verbose_name="nom")
+    name_en = models.TextField(blank=True, verbose_name="nom en anglais")
 
     # champs présents dans le CSV mais inutilisés
     # ordre = models.IntegerField()
@@ -51,8 +51,8 @@ class PlantSynonym(models.Model):
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.TextField()
-    plant = models.ForeignKey(Plant, on_delete=models.CASCADE)
+    name = models.TextField(verbose_name="nom synonyme")
+    plant = models.ForeignKey(Plant, on_delete=models.CASCADE, verbose_name="nom de référence")
 
     # champs présents dans le CSV mais inutilisés
     # ordre = models.IntegerField()

--- a/data/models/plant.py
+++ b/data/models/plant.py
@@ -1,5 +1,8 @@
 from django.db import models
 
+from .common_base_ingredient import CommonBaseIngredient
+from .substance import Substance
+
 
 class Family(models.Model):
     class Meta:
@@ -14,26 +17,32 @@ class Family(models.Model):
     # obsolet = models.BooleanField()
 
 
-class Plant(models.Model):
+class PlantPart(models.Model):
     class Meta:
-        verbose_name = "Plante"
+        verbose_name = "Partie de plante"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-
-    family = models.ForeignKey(Family, on_delete=models.SET_NULL, verbose_name="Famille de plante")
     name = models.CharField(max_length=200)
     name_en = models.CharField(max_length=200, blank=True)
-    public_comments = models.CharField(max_length=1000, null=True, blank=True, verbose_name="Commentaires publics")
-    private_comments = models.CharField(max_length=2000, blank=True, verbose_name="Commentaires privés")
+
+    # champs présents dans le CSV mais inutilisés
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()
+
+
+class Plant(CommonBaseIngredient):
+    class Meta:
+        verbose_name = "Plante"
+
+    family = models.ForeignKey(Family, null=True, on_delete=models.SET_NULL, verbose_name="Famille de plante")
+    useful_parts = models.ManyToManyField(PlantPart)
+    substance = models.ManyToManyField(Substance)
 
     # champs présents dans le CSV mais inutilisés
     # fctingr = models.IntegerField()
     # stingsbs = models.IntegerField()
-    # commentaire_public_en = models.CharField(max_length=1000, blank=True)
-    # commentaire_privé_en = models.CharField(max_length=2000, blank=True) # TODO : intégrer les quelques données ici
-    # ordre = models.IntegerField()
-    # obsolet = models.BooleanField()
+    # to_watch_part = models.ManyToManyField(PlantPart)
 
 
 class PlantSynonym(models.Model):
@@ -43,20 +52,7 @@ class PlantSynonym(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
     name = models.CharField(max_length=200)
-
-    # champs présents dans le CSV mais inutilisés
-    # ordre = models.IntegerField()
-    # obsolet = models.BooleanField()
-
-
-class PlantPart(models.Model):
-    class Meta:
-        verbose_name = "Partie de plante"
-
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
-    name_en = models.CharField(max_length=200, blank=True)
+    plant = models.ForeignKey(Plant, on_delete=models.CASCADE)
 
     # champs présents dans le CSV mais inutilisés
     # ordre = models.IntegerField()

--- a/data/models/plant.py
+++ b/data/models/plant.py
@@ -6,12 +6,12 @@ from .substance import Substance
 
 class Family(models.Model):
     class Meta:
-        verbose_name = "Famille de plante"
+        verbose_name = "famille de plantes"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)  # TODO : à vérifier une fois le CSV reçu
-    name_en = models.CharField(max_length=200, blank=True)
+    name = models.TextField()
+    name_en = models.TextField(blank=True)
 
     # ordre = models.IntegerField()
     # obsolet = models.BooleanField()
@@ -19,12 +19,12 @@ class Family(models.Model):
 
 class PlantPart(models.Model):
     class Meta:
-        verbose_name = "Partie de plante"
+        verbose_name = "partie de plante"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
-    name_en = models.CharField(max_length=200, blank=True)
+    name = models.TextField()
+    name_en = models.TextField(blank=True)
 
     # champs présents dans le CSV mais inutilisés
     # ordre = models.IntegerField()
@@ -33,9 +33,9 @@ class PlantPart(models.Model):
 
 class Plant(CommonBaseIngredient):
     class Meta:
-        verbose_name = "Plante"
+        verbose_name = "plante"
 
-    family = models.ForeignKey(Family, null=True, on_delete=models.SET_NULL, verbose_name="Famille de plante")
+    family = models.ForeignKey(Family, null=True, on_delete=models.SET_NULL, verbose_name="famille de plante")
     useful_parts = models.ManyToManyField(PlantPart)
     substance = models.ManyToManyField(Substance)
 
@@ -47,11 +47,11 @@ class Plant(CommonBaseIngredient):
 
 class PlantSynonym(models.Model):
     class Meta:
-        verbose_name = "Synonymes de plante"
+        verbose_name = "synonyme de plante"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
+    name = models.TextField()
     plant = models.ForeignKey(Plant, on_delete=models.CASCADE)
 
     # champs présents dans le CSV mais inutilisés

--- a/data/models/plant.py
+++ b/data/models/plant.py
@@ -1,32 +1,63 @@
 from django.db import models
-from simple_history.models import HistoricalRecords
-from .approvalstate import LegacyApprovalState
+
+
+class Family(models.Model):
+    class Meta:
+        verbose_name = "Famille de plante"
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    name = models.CharField(max_length=200)  # TODO : à vérifier une fois le CSV reçu
+    name_en = models.CharField(max_length=200, blank=True)
+
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()
 
 
 class Plant(models.Model):
     class Meta:
-        verbose_name = "plante"
+        verbose_name = "Plante"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    history = HistoricalRecords()
 
-    # Legacy fields
-    legacy_latin_name = models.TextField(null=True, blank=True, verbose_name="(Legacy) Nom de la plante en latin")
-    legacy_synonym = models.TextField(null=True, blank=True, verbose_name="(Legacy) Nom synonyme")
-    legacy_useful_part = models.TextField(null=True, blank=True, verbose_name="(Legacy) Partie utile")
-    legacy_surveillance_part = models.TextField(null=True, blank=True, verbose_name="(Legacy) Partie à surveiller")
-    legacy_active_substances = models.TextField(null=True, blank=True, verbose_name="(Legacy) Substances actives")
-    legacy_approval_state = models.CharField(
-        max_length=255,
-        choices=LegacyApprovalState.choices,
-        null=True,
-        blank=True,
-        verbose_name="(Legacy) Status d'approbation",
-    )
-    legacy_family = models.TextField(null=True, blank=True, verbose_name="(Legacy) Famille de plante")
-    legacy_function = models.TextField(
-        null=True, blank=True, verbose_name="(Legacy) Fonction de la plante - ingrédient"
-    )
-    legacy_public_comments = models.TextField(null=True, blank=True, verbose_name="(Legacy) Commentaires publics")
-    legacy_private_comments = models.TextField(null=True, blank=True, verbose_name="(Legacy) Commentaires privés")
+    family = models.ForeignKey(Family, on_delete=models.SET_NULL, verbose_name="Famille de plante")
+    name = models.CharField(max_length=200)
+    name_en = models.CharField(max_length=200, blank=True)
+    public_comments = models.CharField(max_length=1000, null=True, blank=True, verbose_name="Commentaires publics")
+    private_comments = models.CharField(max_length=2000, blank=True, verbose_name="Commentaires privés")
+
+    # champs présents dans le CSV mais inutilisés
+    # fctingr = models.IntegerField()
+    # stingsbs = models.IntegerField()
+    # commentaire_public_en = models.CharField(max_length=1000, blank=True)
+    # commentaire_privé_en = models.CharField(max_length=2000, blank=True) # TODO : intégrer les quelques données ici
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()
+
+
+class PlantSynonym(models.Model):
+    class Meta:
+        verbose_name = "Synonymes de plante"
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    name = models.CharField(max_length=200)
+
+    # champs présents dans le CSV mais inutilisés
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()
+
+
+class PlantPart(models.Model):
+    class Meta:
+        verbose_name = "Partie de plante"
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    name = models.CharField(max_length=200)
+    name_en = models.CharField(max_length=200, blank=True)
+
+    # champs présents dans le CSV mais inutilisés
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()

--- a/data/models/population.py
+++ b/data/models/population.py
@@ -3,14 +3,12 @@ from django.db import models
 
 class Population(models.Model):
     class Meta:
-        verbose_name = (
-            "Groupe de population (cible d'un complément ou à risque d'un ingrédient/substance ou d'un complément)"
-        )
+        verbose_name = "Population cible / à risque"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
-    name_en = models.CharField(max_length=200, blank=True)
+    name = models.TextField()
+    name_en = models.TextField(blank=True)
 
     # ces champs semblent inutilisés
     # ordre = models.IntegerField()
@@ -19,9 +17,9 @@ class Population(models.Model):
 
 class Condition(models.Model):
     class Meta:
-        verbose_name = "Condition de santé impliquant des facteurs de risque"
+        verbose_name = "condition de santé / facteurs de risque"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
-    name_en = models.CharField(max_length=200, blank=True)
+    name = models.TextField()
+    name_en = models.TextField(blank=True)

--- a/data/models/population.py
+++ b/data/models/population.py
@@ -1,0 +1,27 @@
+from django.db import models
+
+
+class Population(models.Model):
+    class Meta:
+        verbose_name = (
+            "Groupe de population (cible d'un complément ou à risque d'un ingrédient/substance ou d'un complément)"
+        )
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    name = models.CharField(max_length=200)
+    name_en = models.CharField(max_length=200, blank=True)
+
+    # ces champs semblent inutilisés
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()
+
+
+class Condition(models.Model):
+    class Meta:
+        verbose_name = "Condition de santé impliquant des facteurs de risque"
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    name = models.CharField(max_length=200)
+    name_en = models.CharField(max_length=200, blank=True)

--- a/data/models/substance.py
+++ b/data/models/substance.py
@@ -1,16 +1,12 @@
 from django.db import models
 
+from .common_base_ingredient import CommonBaseIngredient
 
-class Substance(models.Model):
+
+class Substance(CommonBaseIngredient):
     class Meta:
         verbose_name = "substance active"
 
-    creation_date = models.DateTimeField(auto_now_add=True)
-    modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
-    name_en = models.CharField(max_length=200, blank=True)
-    public_comments = models.CharField(max_length=1000, null=True, blank=True, verbose_name="Commentaires publics")
-    private_comments = models.CharField(max_length=2000, blank=True, verbose_name="Commentaires privés")
     cas_number = models.CharField(
         max_length=10, blank=True, verbose_name="Numéro CAS (Chemical Abstracts Service) - Standard mondial"
     )
@@ -21,22 +17,16 @@ class Substance(models.Model):
     )
     source = models.CharField(max_length=1000, blank=True)
     qty_to_fill = models.BooleanField()
-    min_qty = models.CharField(
-        max_length=2000, blank=True, verbose_name="Quantité minimale autorisée"
-    )  # jamais remplie
-    max_qty = models.CharField(max_length=2000, blank=True, verbose_name="Quantité maximale autorisée")
-    nutritional_reference = models.CharField(
-        max_length=2000, blank=True, verbose_name="Apport nutritionnel conseillé"
+    min_qty = models.FloatField(blank=True, verbose_name="Quantité minimale autorisée")  # jamais remplie
+    max_qty = models.FloatField(blank=True, verbose_name="Quantité maximale autorisée")
+    nutritional_reference = models.FloatField(
+        blank=True, verbose_name="Apport nutritionnel conseillé"
     )  # cette colonne devrat être associée à une unité
 
     # champs présents dans le CSV mais inutilisés
     # fctingr = models.IntegerField()
     # stingsbs = models.IntegerField()
-    # commentaire_public_en = models.CharField(max_length=1000, blank=True)
-    # commentaire_privé_en = models.CharField(max_length=2000, blank=True) # TODO : intégrer les quelques données ici
     # source_en = models.CharField(max_length=1000, blank=True)
-    # ordre = models.IntegerField()
-    # obsolet = models.BooleanField()
 
 
 class SubstanceSynonym(models.Model):
@@ -46,7 +36,9 @@ class SubstanceSynonym(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
     name = models.CharField(max_length=200)
+    substance = models.ForeignKey(Substance, on_delete=models.CASCADE)
 
     # champs présents dans le CSV mais inutilisés
     # ordre = models.IntegerField()
     # obsolet = models.BooleanField()
+    # TSYN -> est-ce que ça donne l'ordre d'affichage des synonymes ?

--- a/data/models/substance.py
+++ b/data/models/substance.py
@@ -1,6 +1,4 @@
 from django.db import models
-from simple_history.models import HistoricalRecords
-from .approvalstate import LegacyApprovalState
 
 
 class Substance(models.Model):
@@ -9,19 +7,46 @@ class Substance(models.Model):
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    history = HistoricalRecords()
-
-    # Legacy fields
-    legacy_sbsact_name = models.TextField(null=True, blank=True, verbose_name="(Legacy) Nom SBSACT")
-    legacy_synonym = models.TextField(null=True, blank=True, verbose_name="(Legacy) Nom synonyme")
-    legacy_type = models.TextField(null=True, blank=True, verbose_name="(Legacy) Type")
-    legacy_approval_state = models.CharField(
-        max_length=255,
-        choices=LegacyApprovalState.choices,
-        null=True,
-        blank=True,
-        verbose_name="(Legacy) Status d'approbation",
+    name = models.CharField(max_length=200)
+    name_en = models.CharField(max_length=200, blank=True)
+    public_comments = models.CharField(max_length=1000, null=True, blank=True, verbose_name="Commentaires publics")
+    private_comments = models.CharField(max_length=2000, blank=True, verbose_name="Commentaires privés")
+    cas_number = models.CharField(
+        max_length=10, blank=True, verbose_name="Numéro CAS (Chemical Abstracts Service) - Standard mondial"
     )
-    legacy_public_comments = models.TextField(null=True, blank=True, verbose_name="(Legacy) Commentaires publics")
-    legacy_private_comments = models.TextField(null=True, blank=True, verbose_name="(Legacy) Commentaires privés")
-    legacy_source = models.TextField(null=True, blank=True, verbose_name="(Legacy) Substance source")
+    einec_number = models.CharField(
+        max_length=7,
+        blank=True,
+        verbose_name="Numéro EINECS (Inventaire européen des substances chimiques commerciales existantes)",
+    )
+    source = models.CharField(max_length=1000, blank=True)
+    qty_to_fill = models.BooleanField()
+    min_qty = models.CharField(
+        max_length=2000, blank=True, verbose_name="Quantité minimale autorisée"
+    )  # jamais remplie
+    max_qty = models.CharField(max_length=2000, blank=True, verbose_name="Quantité maximale autorisée")
+    nutritional_reference = models.CharField(
+        max_length=2000, blank=True, verbose_name="Apport nutritionnel conseillé"
+    )  # cette colonne devrat être associée à une unité
+
+    # champs présents dans le CSV mais inutilisés
+    # fctingr = models.IntegerField()
+    # stingsbs = models.IntegerField()
+    # commentaire_public_en = models.CharField(max_length=1000, blank=True)
+    # commentaire_privé_en = models.CharField(max_length=2000, blank=True) # TODO : intégrer les quelques données ici
+    # source_en = models.CharField(max_length=1000, blank=True)
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()
+
+
+class SubstanceSynonym(models.Model):
+    class Meta:
+        verbose_name = "Synonymes substance active"
+
+    creation_date = models.DateTimeField(auto_now_add=True)
+    modification_date = models.DateTimeField(auto_now=True)
+    name = models.CharField(max_length=200)
+
+    # champs présents dans le CSV mais inutilisés
+    # ordre = models.IntegerField()
+    # obsolet = models.BooleanField()

--- a/data/models/substance.py
+++ b/data/models/substance.py
@@ -6,36 +6,35 @@ from .common_base_ingredient import CommonBaseIngredient
 class Substance(CommonBaseIngredient):
     class Meta:
         verbose_name = "substance active"
+        verbose_name_plural = "substances actives"
 
-    cas_number = models.CharField(
-        max_length=10, blank=True, verbose_name="Numéro CAS (Chemical Abstracts Service) - Standard mondial"
-    )
+    cas_number = models.CharField(max_length=10, blank=True, verbose_name="numéro CAS")
     einec_number = models.CharField(
         max_length=7,
         blank=True,
-        verbose_name="Numéro EINECS (Inventaire européen des substances chimiques commerciales existantes)",
+        verbose_name="numéro EINECS",
     )
-    source = models.CharField(max_length=1000, blank=True)
-    qty_to_fill = models.BooleanField()
-    min_qty = models.FloatField(blank=True, verbose_name="Quantité minimale autorisée")  # jamais remplie
-    max_qty = models.FloatField(blank=True, verbose_name="Quantité maximale autorisée")
+    source = models.TextField(blank=True)
+    must_specify_quantity = models.BooleanField()
+    min_quantity = models.FloatField(blank=True, verbose_name="quantité minimale autorisée")  # jamais remplie
+    max_quantity = models.FloatField(blank=True, verbose_name="quantité maximale autorisée")
     nutritional_reference = models.FloatField(
-        blank=True, verbose_name="Apport nutritionnel conseillé"
+        blank=True, verbose_name="apport nutritionnel conseillé"
     )  # cette colonne devrat être associée à une unité
 
     # champs présents dans le CSV mais inutilisés
     # fctingr = models.IntegerField()
     # stingsbs = models.IntegerField()
-    # source_en = models.CharField(max_length=1000, blank=True)
+    # source_en = models.TextField(blank=True)
 
 
 class SubstanceSynonym(models.Model):
     class Meta:
-        verbose_name = "Synonymes substance active"
+        verbose_name = "synonyme substance active"
 
     creation_date = models.DateTimeField(auto_now_add=True)
     modification_date = models.DateTimeField(auto_now=True)
-    name = models.CharField(max_length=200)
+    name = models.TextField()
     substance = models.ForeignKey(Substance, on_delete=models.CASCADE)
 
     # champs présents dans le CSV mais inutilisés


### PR DESCRIPTION
## Done :
* Création (ou MAJ) des modèles dont nous avons déjà les données (Plantes, MicroOrganismes, IngrédientsAutres, Substances, tous les Synonymes, Parties Utiles de Plantes). 
* ajout des fichiers de données brutes

## Still todo dans une prochaine PR :

- [ ] Intégrer toutes les autres tables (notamment de déclaration) voire les penser autrement
- [ ] Faire la commande pour l'import des csv dans les modèles
- [ ] Créer un bouton d'import de données csv depuis le backoffice
- [ ] Intégrer (itérativement) les données de World Flora, etc


## Les possibilités de changement de modèle :
- On pourrait faire une seule table de Synonymes qui aurait en plus un champ `Ingregient_type` à choisir parmi Plante, MicroOrganisme, AutreIngredient
  - Mais ce n'est pas vraiment possible de faire une seule table Ingrédient (de la même manière) car les Plantes ont des spécificités : famille, partie de plante
- les champs `name_en` (aka libelle_en dans l'ancienne base) pourraient être supprimés pour être seulements considérés comme "synonymes"
- dans les substances, on pourrait afficher les reférences selon l'[anses](https://www.anses.fr/fr/content/les-r%C3%A9f%C3%A9rences-nutritionnelles-en-vitamines-et-min%C3%A9raux) : 
  - Besoin Nutritionnel Moyen (BNM)
  - Référence Nutritionnelle pour la population (RNP)
  - Apport satisfaisant (AS)
  - Limite supérieure de sécurité (LSS)


- Peut-on trouver une CAS Registry database ? ou une EINEC database ?
- Ajouter les champs `age` et `genre` à la table population
- séparer Population de Facteurs de risque (=pathologies). Déjà fait.
