### PR TITLE
Mise à jour precommit : ESlint à 8.55

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,7 +117,7 @@ repos:
       types:
         - vue
   repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v8.53.0
+  rev: v8.55.0
 - hooks:
     - additional_dependencies:
         - eslint@latest
@@ -136,4 +136,4 @@ repos:
       id: eslint
       name: js-eslint
   repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v8.53.0
+  rev: v8.55.0


### PR DESCRIPTION
Suite à la PR https://github.com/betagouv/complements-alimentaires/pull/44, notre version d'ESlint de precommit n'est plus à jour avec celle de npm.

> [!NOTE]  
> J'aurais du faire ce changement dans la même PR dependabot pour concentrer la mise à jour sur la même branche, je le ferai pour les prochaines :)
