### PR TITLE
Gestion d'icônes dans le frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
         "@vuelidate/core": "^2.0.3",
         "@vuelidate/validators": "^2.0.4",
         "core-js": "^3.33.3",
+        "oh-vue-icons": "^1.0.0-rc3",
         "vue": "^3.3.9",
         "vue-router": "^4.2.5",
         "vuex": "^4.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",
     "core-js": "^3.33.3",
+    "oh-vue-icons": "^1.0.0-rc3",
     "vue": "^3.3.9",
     "vue-router": "^4.2.5",
     "vuex": "^4.1.0",

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -13,7 +13,7 @@ const quickLinks = computed(function () {
     return [
       {
         label: "Se déconnecter",
-        icon: "ri-account-circle-line",
+        icon: "ri-logout-box-r-line",
         href: `${window.location.protocol}//${window.location.host}/se-deconnecter`,
       },
     ]

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -1,0 +1,1 @@
+export { RiLogoutBoxRLine } from "oh-vue-icons/icons"

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,6 @@
 import { createApp } from "vue"
 import "./styles/index.css"
+import * as icons from "./icons.js"
 import "@gouvfr/dsfr/dist/dsfr.min.css" // Import des styles du DSFR
 import "@gouvminint/vue-dsfr/styles" // Import des styles globaux propre à VueDSFR
 import VueDsfr from "@gouvminint/vue-dsfr" // Import (par défaut) de la bibliothèque
@@ -9,4 +10,8 @@ import App from "./App.vue"
 import router from "./router"
 import store from "./store"
 
-createApp(App).use(router).use(store).use(VueDsfr).mount("#app")
+createApp(App)
+  .use(router)
+  .use(store)
+  .use(VueDsfr, { icons: Object.values(icons) })
+  .mount("#app")


### PR DESCRIPTION
## Icônes

Au fur et à mesure on aura besoin de mettre des icônes dans l'application. Afin de ne pas importer toute une librairie et donc d'alourdir notre bundle, cette PR met en place les fichiers nécessaires pour seulement inclure les icônes utilisées.

- Ça inclut la lib [oh-vue-icons](https://oh-vue-icons.js.org/docs) qui centralise les libs d'icônes les plus connues. À noter que nous on utilisera presque toujours remix-icons (ceux utilisés dans le DSFR), mais ça peut être utile d'en utiliser d'autres si besoin.
- Le fichier `frontend/src/icons.js` liste les différentes icônes qu'on utilise. Par exemple pour une l'icône [remix icons send-plane-fill](https://remixicon.com/icon/send-plane-fill), on peut ajouter `RiSendPlaneFill` dans ce fichier.
- Par la suite, on peut l'utiliser dans l'application avec `ri-send-plane-fill`

Je profite de ces changements pour ajouter une vraie icône déconnexion  