### PR TITLE
Alignement des breakpoints entre DSFR et Tailwind

### DIFF
--- a/frontend/src/views/LandingPage/DeclarationBlock.vue
+++ b/frontend/src/views/LandingPage/DeclarationBlock.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="grid grid-cols-12">
-    <div class="col-span-12 md:col-span-7 md:pr-10">
+    <div class="col-span-12 md:col-span-8 lg:col-span-6">
       <h3 class="mb-1">Vous êtes un•e professionnel•le du secteur et souhaitez déclarer un produit ?</h3>
       <p class="my-4">Suivez notre checklist pour vous orienter vers la bonne démarche de déclaration.</p>
       <DsfrButton label="Préparer ma télédéclaration" />
     </div>
-    <div class="hidden md:flex md:col-span-5 justify-center content-center">
+    <div class="hidden md:flex md:col-span-4 lg:col-span-6 justify-center content-center">
       <img
-        style="max-width: 350px; object-fit: contain"
+        style="max-width: 90%; max-height: 90%; object-fit: contain"
         src="/static/images/illustrations/declaration-illustration.png"
         alt="Professionnelle effectuant sa déclaration"
       />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -3,6 +3,15 @@ module.exports = {
   content: ["./src/**/*.{html,js,vue}"],
   theme: {
     extend: {},
+
+    // DSFR breakpoints taken from here:
+    // https://github.com/dnum-mi/vue-dsfr/blob/e363297144888021f3d4379c13ef0164ba80a90e/.storybook/preview.ts#L44
+    screens: {
+      sm: "576px",
+      md: "768px",
+      lg: "992px",
+      xl: "1440px",
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
Afin de déclencher les transformations de nos différents éléments dans les mêmes viewports, cette PR aligne les différents breakpoints entre DSFR et Tailwind. 

Les breakpoints utilisés sur DSFR (et donc dsfr-vue) sont ici : https://github.com/dnum-mi/vue-dsfr/blob/e363297144888021f3d4379c13ef0164ba80a90e/.storybook/preview.ts#L44

La configuration de Tailwind est spécifiée ici : https://tailwindcss.com/docs/screens#overriding-the-defaults

> [!NOTE]  
> Une fois que les autres PR soient intégrées, il faudra aussi revérifier que leurs classes responsives soient toujours OK. Ça peut se faire au moment de mettre à jour les branches. 