### PR TITLE
Réduction de la taille de notre app.js

### DIFF
--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -1,1 +1,11 @@
-export { RiLogoutBoxRLine } from "oh-vue-icons/icons"
+// Suite à https://github.com/Renovamen/oh-vue-icons/issues/24 et en attendant un fix,
+// on import les icônes manuellement de ]frontend/node_modules/oh-vue-icons/icons/ri/index.js
+// pour réduire la taille du bundle
+export const RiLogoutBoxRLine = {
+  name: "ri-logout-box-r-line",
+  minX: 0,
+  minY: 0,
+  width: 24,
+  height: 24,
+  raw: '<path fill="none" d="M0 0h24v24H0z"/><path d="M5 22a1 1 0 01-1-1V3a1 1 0 011-1h14a1 1 0 011 1v3h-2V4H6v16h12v-2h2v3a1 1 0 01-1 1H5zm13-6v-3h-7v-2h7V8l5 4-5 4z"/>',
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,7 +4,6 @@ import * as icons from "./icons.js"
 import "@gouvfr/dsfr/dist/dsfr.min.css" // Import des styles du DSFR
 import "@gouvminint/vue-dsfr/styles" // Import des styles globaux propre à VueDSFR
 import VueDsfr from "@gouvminint/vue-dsfr" // Import (par défaut) de la bibliothèque
-import "@gouvfr/dsfr/dist/utility/icons/icons.min.css"
 
 import App from "./App.vue"
 import router from "./router"


### PR DESCRIPTION
Suite au bug https://github.com/Renovamen/oh-vue-icons/issues/24 concernant le tree-shaking, je propose d'importer les icônes directement de la libraire en attendant une réponse. 

Ceci allège la taille du app.js de plusiuers megaoctets.