### PR TITLE
:bug:  Cache la section des webinaires quand il n'y en a pas

### DIFF
--- a/frontend/src/views/LandingPage/WebinarBlock.vue
+++ b/frontend/src/views/LandingPage/WebinarBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="webinars">
+  <div v-if="webinars && webinars.length > 0">
     <h3>Webinaires à venir</h3>
     <p class="m-0">
       Expertes et experts du secteur partagent expériences et conseils pour développer vos produits et répondre à vos


### PR DESCRIPTION
La section des webinaires s'affichait même si la valeur `webinars` est un tableau vide. Erreur de ma part, car - contrairement à Python - un tableau vide est _truthy_ (`!![]   ->   true`)

Ce petit commit fix cette situation en vérifiant aussi le `.length` de la variable.