### PR TITLE
Fix pour les recherches consécutives 

### DIFF
--- a/frontend/src/views/SearchResults/index.vue
+++ b/frontend/src/views/SearchResults/index.vue
@@ -1,13 +1,16 @@
 <template>
   <div class="bg-blue-france-925 py-8">
     <div class="fr-container">
-      <DsfrSearchBar v-model="searchTerm" @search="search" />
+      <DsfrSearchBar :placeholder="currentSearch" v-model="searchTerm" @search="search" />
     </div>
   </div>
   <div class="fr-container pb-6">
-    <DsfrBreadcrumb class="mb-8" :links="[{ to: '/', text: 'Accueil' }, { text: `Recherche : « ${searchTerm} »` }]" />
+    <DsfrBreadcrumb
+      class="mb-8"
+      :links="[{ to: '/', text: 'Accueil' }, { text: `Recherche : « ${currentSearch} »` }]"
+    />
     <div v-if="emptyView">
-      <h1 class="fr-h3">Nous n'avons pas trouvé des résultats pour « {{ searchTerm }} »</h1>
+      <h1 class="fr-h3">Nous n'avons pas trouvé des résultats pour « {{ currentSearch }} »</h1>
     </div>
     <div class="mb-4" v-else>
       <h1 class="fr-h3">Résultats de recherche</h1>
@@ -38,6 +41,7 @@ import { headers, verifyResponse } from "@/utils"
 import ResultCard from "./ResultCard"
 
 let mounted = false
+let currentSearch = ""
 
 const router = useRouter()
 const route = useRoute()
@@ -74,7 +78,7 @@ const search = () => {
 
 const fetchSearchResults = () => {
   const url = "/api/v1/search/"
-  const body = JSON.stringify({ search: searchTerm.value, limit, offset: offset.value })
+  const body = JSON.stringify({ search: currentSearch, limit, offset: offset.value })
   loading.value = true
   return fetch(url, { method: "POST", headers, body })
     .then(verifyResponse)
@@ -94,7 +98,7 @@ onBeforeRouteUpdate((to) => {
 })
 
 onMounted(() => {
-  searchTerm.value = route.query.q
+  currentSearch = route.query.q
   page.value = route.query.page || 1
   fetchSearchResults().then(() => (mounted = true))
 })
@@ -102,7 +106,10 @@ onMounted(() => {
 watch(
   () => route.query,
   () => {
-    if (mounted) fetchSearchResults()
+    if (mounted) {
+      currentSearch = route.query.q
+      fetchSearchResults()
+    }
   }
 )
 


### PR DESCRIPTION
Aujourd'hui, lors qu'on utilise la barre de recherche dans la page résultats, on a un comportement bizarre dans le fil d'arianne (car la même variable est utilisé pour les deux composants) :

[Screencast from 09-01-24 16:36:29.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/dc0ee924-2253-45c9-a4b1-dba3cc166ae5)


Avec une séparation de variables (`currentSearch` et `searchTerm`), on arrive à mitiger le souci :

[Screencast from 09-01-24 16:35:47.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/cc5c1a37-3dc2-4660-b437-d64346e28e4f)
