### PR TITLE
Page individuelle pour chaque élément (plante, micro-organisme, substance et ingrédient)

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -3,3 +3,4 @@ from .user import LoggedUserSerializer  # noqa: F401
 from .webinar import WebinarSerializer  # noqa
 from .search_result import SearchResultSerializer  # noqa: F401
 from .plant import PlantSerializer  # noqa: F401
+from .ingredient import IngredientSerializer  # noqa: F401

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -5,3 +5,4 @@ from .search_result import SearchResultSerializer  # noqa: F401
 from .plant import PlantSerializer  # noqa: F401
 from .ingredient import IngredientSerializer  # noqa: F401
 from .microorganism import MicroorganismSerializer  # noqa: F401
+from .substance import SubstanceSerializer, SubstanceShortSerializer  # noqa: F401

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -2,3 +2,4 @@ from .blogpost import BlogPostSerializer  # noqa: F401
 from .user import LoggedUserSerializer  # noqa: F401
 from .webinar import WebinarSerializer  # noqa
 from .search_result import SearchResultSerializer  # noqa: F401
+from .plant import PlantSerializer  # noqa: F401

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -4,3 +4,4 @@ from .webinar import WebinarSerializer  # noqa
 from .search_result import SearchResultSerializer  # noqa: F401
 from .plant import PlantSerializer  # noqa: F401
 from .ingredient import IngredientSerializer  # noqa: F401
+from .microorganism import MicroorganismSerializer  # noqa: F401

--- a/api/serializers/ingredient.py
+++ b/api/serializers/ingredient.py
@@ -1,0 +1,28 @@
+from rest_framework import serializers
+from data.models import Ingredient, IngredientSynonym
+
+
+class IngredientSynonymSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = IngredientSynonym
+        fields = (
+            "id",
+            "name",
+        )
+        read_only_fields = fields
+
+
+class IngredientSerializer(serializers.ModelSerializer):
+    synonyms = IngredientSynonymSerializer(many=True, read_only=True, source="ingredientsynonym_set")
+
+    class Meta:
+        model = Ingredient
+        fields = (
+            "id",
+            "name",
+            "name_en",
+            "observation",
+            "description",
+            "synonyms",
+        )
+        read_only_fields = fields

--- a/api/serializers/ingredient.py
+++ b/api/serializers/ingredient.py
@@ -27,5 +27,6 @@ class IngredientSerializer(serializers.ModelSerializer):
             "description",
             "synonyms",
             "substances",
+            "public_comments",
         )
         read_only_fields = fields

--- a/api/serializers/ingredient.py
+++ b/api/serializers/ingredient.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from data.models import Ingredient, IngredientSynonym
+from .substance import SubstanceShortSerializer
 
 
 class IngredientSynonymSerializer(serializers.ModelSerializer):
@@ -14,6 +15,7 @@ class IngredientSynonymSerializer(serializers.ModelSerializer):
 
 class IngredientSerializer(serializers.ModelSerializer):
     synonyms = IngredientSynonymSerializer(many=True, read_only=True, source="ingredientsynonym_set")
+    substances = SubstanceShortSerializer(many=True, read_only=True)
 
     class Meta:
         model = Ingredient
@@ -24,5 +26,6 @@ class IngredientSerializer(serializers.ModelSerializer):
             "observation",
             "description",
             "synonyms",
+            "substances",
         )
         read_only_fields = fields

--- a/api/serializers/microorganism.py
+++ b/api/serializers/microorganism.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from data.models import Microorganism, MicroorganismSynonym
+from .substance import SubstanceShortSerializer
 
 
 class MicroorganismSynonymSerializer(serializers.ModelSerializer):
@@ -14,6 +15,7 @@ class MicroorganismSynonymSerializer(serializers.ModelSerializer):
 
 class MicroorganismSerializer(serializers.ModelSerializer):
     synonyms = MicroorganismSynonymSerializer(many=True, read_only=True, source="microorganismsynonym_set")
+    substances = SubstanceShortSerializer(many=True, read_only=True)
 
     class Meta:
         model = Microorganism
@@ -23,5 +25,6 @@ class MicroorganismSerializer(serializers.ModelSerializer):
             "name_en",
             "genre",
             "synonyms",
+            "substances",
         )
         read_only_fields = fields

--- a/api/serializers/microorganism.py
+++ b/api/serializers/microorganism.py
@@ -26,5 +26,6 @@ class MicroorganismSerializer(serializers.ModelSerializer):
             "genre",
             "synonyms",
             "substances",
+            "public_comments",
         )
         read_only_fields = fields

--- a/api/serializers/microorganism.py
+++ b/api/serializers/microorganism.py
@@ -1,0 +1,27 @@
+from rest_framework import serializers
+from data.models import Microorganism, MicroorganismSynonym
+
+
+class MicroorganismSynonymSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MicroorganismSynonym
+        fields = (
+            "id",
+            "name",
+        )
+        read_only_fields = fields
+
+
+class MicroorganismSerializer(serializers.ModelSerializer):
+    synonyms = MicroorganismSynonymSerializer(many=True, read_only=True, source="microorganismsynonym_set")
+
+    class Meta:
+        model = Microorganism
+        fields = (
+            "id",
+            "name",
+            "name_en",
+            "genre",
+            "synonyms",
+        )
+        read_only_fields = fields

--- a/api/serializers/plant.py
+++ b/api/serializers/plant.py
@@ -1,0 +1,54 @@
+from rest_framework import serializers
+from data.models import Plant, PlantFamily, PlantPart, PlantSynonym
+
+
+class PlantFamilySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PlantFamily
+        fields = (
+            "name",
+            "is_obsolete",
+            "name_en",
+            "siccrf_id",
+        )
+        read_only_fields = fields
+
+
+class PlantPartSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PlantPart
+        fields = (
+            "name",
+            "is_obsolete",
+            "name_en",
+            "siccrf_id",
+        )
+        read_only_fields = fields
+
+
+class PlantSynonymSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PlantSynonym
+        fields = (
+            "name",
+            "is_obsolete",
+            "standard_name",
+        )
+        read_only_fields = fields
+
+
+class PlantSerializer(serializers.ModelSerializer):
+    family = PlantFamilySerializer(read_only=True)
+    useful_parts = PlantPartSerializer(many=True, read_only=True)
+    synonyms = PlantSynonymSerializer(many=True, read_only=True, source="plantsynonym_set")
+
+    class Meta:
+        model = Plant
+        fields = (
+            "id",
+            "name",
+            "family",
+            "useful_parts",
+            "synonyms",
+        )
+        read_only_fields = fields

--- a/api/serializers/plant.py
+++ b/api/serializers/plant.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from data.models import Plant, PlantFamily, PlantPart, PlantSynonym
+from .substance import SubstanceShortSerializer
 
 
 class PlantFamilySerializer(serializers.ModelSerializer):
@@ -41,6 +42,7 @@ class PlantSerializer(serializers.ModelSerializer):
     family = PlantFamilySerializer(read_only=True)
     useful_parts = PlantPartSerializer(many=True, read_only=True)
     synonyms = PlantSynonymSerializer(many=True, read_only=True, source="plantsynonym_set")
+    substances = SubstanceShortSerializer(many=True, read_only=True)
 
     class Meta:
         model = Plant
@@ -50,5 +52,6 @@ class PlantSerializer(serializers.ModelSerializer):
             "family",
             "useful_parts",
             "synonyms",
+            "substances",
         )
         read_only_fields = fields

--- a/api/serializers/plant.py
+++ b/api/serializers/plant.py
@@ -53,5 +53,6 @@ class PlantSerializer(serializers.ModelSerializer):
             "useful_parts",
             "synonyms",
             "substances",
+            "public_comments",
         )
         read_only_fields = fields

--- a/api/serializers/substance.py
+++ b/api/serializers/substance.py
@@ -29,6 +29,7 @@ class SubstanceSerializer(serializers.ModelSerializer):
             "max_quantity",
             "nutritional_reference",
             "synonyms",
+            "public_comments",
         )
         read_only_fields = fields
 

--- a/api/serializers/substance.py
+++ b/api/serializers/substance.py
@@ -1,0 +1,46 @@
+from rest_framework import serializers
+from data.models import Substance, SubstanceSynonym
+
+
+class SubstanceSynonymSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SubstanceSynonym
+        fields = (
+            "id",
+            "name",
+        )
+        read_only_fields = fields
+
+
+class SubstanceSerializer(serializers.ModelSerializer):
+    synonyms = SubstanceSynonymSerializer(many=True, read_only=True, source="substancesynonym_set")
+
+    class Meta:
+        model = Substance
+        fields = (
+            "id",
+            "name",
+            "name_en",
+            "cas_number",
+            "einec_number",
+            "source",
+            "must_specify_quantity",
+            "min_quantity",
+            "max_quantity",
+            "nutritional_reference",
+            "synonyms",
+        )
+        read_only_fields = fields
+
+
+class SubstanceShortSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Substance
+        fields = (
+            "id",
+            "name",
+            "name_en",
+            "cas_number",
+            "einec_number",
+        )
+        read_only_fields = fields

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from rest_framework import status
-from data.factories import PlantFactory
+from data.factories import PlantFactory, IngredientFactory
 
 
 class TestElementsApi(APITestCase):
@@ -13,3 +13,12 @@ class TestElementsApi(APITestCase):
 
         self.assertEqual(plant.name, body["name"])
         self.assertEqual(plant.id, body["id"])
+
+    def test_get_single_ingredient(self):
+        ingredient = IngredientFactory.create()
+        response = self.client.get(reverse("single_ingredient", kwargs={"pk": ingredient.id}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+
+        self.assertEqual(ingredient.name, body["name"])
+        self.assertEqual(ingredient.id, body["id"])

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -1,0 +1,15 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from data.factories import PlantFactory
+
+
+class TestElementsApi(APITestCase):
+    def test_get_single_plant(self):
+        plant = PlantFactory.create()
+        response = self.client.get(reverse("single_plant", kwargs={"pk": plant.id}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+
+        self.assertEqual(plant.name, body["name"])
+        self.assertEqual(plant.id, body["id"])

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from rest_framework import status
-from data.factories import PlantFactory, IngredientFactory
+from data.factories import PlantFactory, IngredientFactory, MicroorganismFactory
 
 
 class TestElementsApi(APITestCase):
@@ -22,3 +22,12 @@ class TestElementsApi(APITestCase):
 
         self.assertEqual(ingredient.name, body["name"])
         self.assertEqual(ingredient.id, body["id"])
+
+    def test_get_single_microorganism(self):
+        microorganism = MicroorganismFactory.create()
+        response = self.client.get(reverse("single_microorganism", kwargs={"pk": microorganism.id}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+
+        self.assertEqual(microorganism.name, body["name"])
+        self.assertEqual(microorganism.id, body["id"])

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from rest_framework import status
-from data.factories import PlantFactory, IngredientFactory, MicroorganismFactory
+from data.factories import PlantFactory, IngredientFactory, MicroorganismFactory, SubstanceFactory
 
 
 class TestElementsApi(APITestCase):
@@ -31,3 +31,12 @@ class TestElementsApi(APITestCase):
 
         self.assertEqual(microorganism.name, body["name"])
         self.assertEqual(microorganism.id, body["id"])
+
+    def test_get_single_substance(self):
+        substance = SubstanceFactory.create()
+        response = self.client.get(reverse("single_substance", kwargs={"pk": substance.id}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+
+        self.assertEqual(substance.name, body["name"])
+        self.assertEqual(substance.id, body["id"])

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,14 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api.views import BlogPostsView, BlogPostView, SubscribeNewsletter, LoggedUserView, WebinarView, SearchView
+from api.views import (
+    BlogPostsView,
+    BlogPostView,
+    SubscribeNewsletter,
+    LoggedUserView,
+    WebinarView,
+    SearchView,
+    PlantRetrieveView,
+)
 
 urlpatterns = {
     path("blogPosts/", BlogPostsView.as_view(), name="blog_posts_list"),
@@ -9,6 +17,7 @@ urlpatterns = {
     path("loggedUser/", LoggedUserView.as_view(), name="logged_user"),
     path("webinars/", WebinarView.as_view(), name="webinar_list"),
     path("search/", SearchView.as_view(), name="search"),
+    path("plants/<int:pk>", PlantRetrieveView.as_view(), name="single_plant"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/urls.py
+++ b/api/urls.py
@@ -11,6 +11,7 @@ urlpatterns = {
     path("search/", views.SearchView.as_view(), name="search"),
     path("plants/<int:pk>", views.PlantRetrieveView.as_view(), name="single_plant"),
     path("ingredients/<int:pk>", views.IngredientRetrieveView.as_view(), name="single_ingredient"),
+    path("microorganism/<int:pk>", views.MicroorganismRetrieveView.as_view(), name="single_microorganism"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/urls.py
+++ b/api/urls.py
@@ -12,6 +12,7 @@ urlpatterns = {
     path("plants/<int:pk>", views.PlantRetrieveView.as_view(), name="single_plant"),
     path("ingredients/<int:pk>", views.IngredientRetrieveView.as_view(), name="single_ingredient"),
     path("microorganism/<int:pk>", views.MicroorganismRetrieveView.as_view(), name="single_microorganism"),
+    path("substance/<int:pk>", views.SubstanceRetrieveView.as_view(), name="single_substance"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,23 +1,16 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api.views import (
-    BlogPostsView,
-    BlogPostView,
-    SubscribeNewsletter,
-    LoggedUserView,
-    WebinarView,
-    SearchView,
-    PlantRetrieveView,
-)
+import api.views as views
 
 urlpatterns = {
-    path("blogPosts/", BlogPostsView.as_view(), name="blog_posts_list"),
-    path("blogPosts/<int:pk>", BlogPostView.as_view(), name="single_blog_post"),
-    path("subscribeNewsletter/", SubscribeNewsletter.as_view(), name="subscribe_newsletter"),
-    path("loggedUser/", LoggedUserView.as_view(), name="logged_user"),
-    path("webinars/", WebinarView.as_view(), name="webinar_list"),
-    path("search/", SearchView.as_view(), name="search"),
-    path("plants/<int:pk>", PlantRetrieveView.as_view(), name="single_plant"),
+    path("blogPosts/", views.BlogPostsView.as_view(), name="blog_posts_list"),
+    path("blogPosts/<int:pk>", views.BlogPostView.as_view(), name="single_blog_post"),
+    path("subscribeNewsletter/", views.SubscribeNewsletter.as_view(), name="subscribe_newsletter"),
+    path("loggedUser/", views.LoggedUserView.as_view(), name="logged_user"),
+    path("webinars/", views.WebinarView.as_view(), name="webinar_list"),
+    path("search/", views.SearchView.as_view(), name="search"),
+    path("plants/<int:pk>", views.PlantRetrieveView.as_view(), name="single_plant"),
+    path("ingredients/<int:pk>", views.IngredientRetrieveView.as_view(), name="single_ingredient"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/urls.py
+++ b/api/urls.py
@@ -11,8 +11,8 @@ urlpatterns = {
     path("search/", views.SearchView.as_view(), name="search"),
     path("plants/<int:pk>", views.PlantRetrieveView.as_view(), name="single_plant"),
     path("ingredients/<int:pk>", views.IngredientRetrieveView.as_view(), name="single_ingredient"),
-    path("microorganism/<int:pk>", views.MicroorganismRetrieveView.as_view(), name="single_microorganism"),
-    path("substance/<int:pk>", views.SubstanceRetrieveView.as_view(), name="single_substance"),
+    path("microorganisms/<int:pk>", views.MicroorganismRetrieveView.as_view(), name="single_microorganism"),
+    path("substances/<int:pk>", views.SubstanceRetrieveView.as_view(), name="single_substance"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -6,3 +6,4 @@ from .search import SearchView  # noqa: F401
 from .plant import PlantRetrieveView  # noqa: F401
 from .ingredient import IngredientRetrieveView  # noqa: F401
 from .microorganism import MicroorganismRetrieveView  # noqa: F401
+from .substance import SubstanceRetrieveView  # noqa: F401

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -5,3 +5,4 @@ from .webinar import WebinarView  # noqa
 from .search import SearchView  # noqa: F401
 from .plant import PlantRetrieveView  # noqa: F401
 from .ingredient import IngredientRetrieveView  # noqa: F401
+from .microorganism import MicroorganismRetrieveView  # noqa: F401

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -3,3 +3,4 @@ from .newsletter import SubscribeNewsletter  # noqa: F401
 from .user import LoggedUserView  # noqa: F401
 from .webinar import WebinarView  # noqa
 from .search import SearchView  # noqa: F401
+from .plant import PlantRetrieveView  # noqa: F401

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -4,3 +4,4 @@ from .user import LoggedUserView  # noqa: F401
 from .webinar import WebinarView  # noqa
 from .search import SearchView  # noqa: F401
 from .plant import PlantRetrieveView  # noqa: F401
+from .ingredient import IngredientRetrieveView  # noqa: F401

--- a/api/views/ingredient.py
+++ b/api/views/ingredient.py
@@ -1,0 +1,9 @@
+from rest_framework.generics import RetrieveAPIView
+from data.models import Ingredient
+from api.serializers import IngredientSerializer
+
+
+class IngredientRetrieveView(RetrieveAPIView):
+    model = Ingredient
+    queryset = Ingredient.objects.all()
+    serializer_class = IngredientSerializer

--- a/api/views/microorganism.py
+++ b/api/views/microorganism.py
@@ -1,0 +1,9 @@
+from rest_framework.generics import RetrieveAPIView
+from data.models import Microorganism
+from api.serializers import MicroorganismSerializer
+
+
+class MicroorganismRetrieveView(RetrieveAPIView):
+    model = Microorganism
+    queryset = Microorganism.objects.all()
+    serializer_class = MicroorganismSerializer

--- a/api/views/plant.py
+++ b/api/views/plant.py
@@ -1,0 +1,9 @@
+from rest_framework.generics import RetrieveAPIView
+from data.models import Plant
+from api.serializers import PlantSerializer
+
+
+class PlantRetrieveView(RetrieveAPIView):
+    model = Plant
+    queryset = Plant.objects.all()
+    serializer_class = PlantSerializer

--- a/api/views/substance.py
+++ b/api/views/substance.py
@@ -1,0 +1,9 @@
+from rest_framework.generics import RetrieveAPIView
+from data.models import Substance
+from api.serializers import SubstanceSerializer
+
+
+class SubstanceRetrieveView(RetrieveAPIView):
+    model = Substance
+    queryset = Substance.objects.all()
+    serializer_class = SubstanceSerializer

--- a/data/models/__init__.py
+++ b/data/models/__init__.py
@@ -2,7 +2,7 @@ from .user import User  # noqa: F401
 from .ingredient import Ingredient, IngredientSynonym  # noqa: F401
 from .microorganism import Microorganism, MicroorganismSynonym  # noqa: F401
 from .plant import Plant, PlantSynonym, PlantPart, PlantFamily  # noqa: F401
-from .substance import Substance  # noqa: F401
+from .substance import Substance, SubstanceSynonym  # noqa: F401
 from .population import Population  # noqa: F401
 from .blogpost import BlogPost  # noqa: F401
 from .webinar import Webinar  # noqa: F401

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,6 +3,7 @@ import LandingPage from "@/views/LandingPage"
 import BlogsHome from "@/views/BlogsHome"
 import BlogPost from "@/views/BlogPost"
 import SearchResults from "@/views/SearchResults"
+import ElementView from "@/views/ElementView"
 
 const routes = [
   {
@@ -32,6 +33,12 @@ const routes = [
     beforeEnter(to) {
       if (!to.query?.q) return { to: "LandingPage" }
     },
+  },
+  {
+    path: "/element/:urlComponent",
+    name: "ElementView",
+    component: ElementView,
+    props: true,
   },
 ]
 

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -54,6 +54,16 @@ export const verifyResponse = (response) => {
   return hasJSON ? response.json() : response.text()
 }
 
+export const getTypeIcon = (type) => {
+  const mapping = {
+    plant: "ri-plant-line",
+    microorganism: "ri-microscope-line",
+    ingredient: "ri-flask-line",
+    substance: "ri-test-tube-line",
+  }
+  return mapping[type] || null
+}
+
 export const headers = {
   "X-CSRFToken": window.CSRF_TOKEN || "",
   "Content-Type": "application/json",

--- a/frontend/src/views/ElementView.vue
+++ b/frontend/src/views/ElementView.vue
@@ -10,12 +10,12 @@
   <div v-if="element" class="fr-container my-8">
     <h1 class="fr-h4 !mb-1">{{ element.name }}</h1>
 
-    <div class="flex flex-col flex-nowrap sm:flex-row sm:flex-wrap gap-20 mb-8">
+    <div class="flex flex-col flex-nowrap sm:flex-row sm:flex-wrap gap-1 sm:gap-20 mb-8">
       <div class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
         <div class="fr-text--sm !font-medium !mb-1">Type</div>
         <div class="flex">
           <div><v-icon scale="0.75" class="mr-1" :name="icon" /></div>
-          <div class="fr-text--sm !mb-0 capitalize">{{ type }}</div>
+          <div class="fr-text--sm !mb-0 capitalize">{{ type === "ingredient" ? "ingrédient" : type }}</div>
         </div>
       </div>
 

--- a/frontend/src/views/ElementView.vue
+++ b/frontend/src/views/ElementView.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="fr-container">
+    <DsfrBreadcrumb class="mb-8" :links="[{ to: '/', text: 'Accueil' }, { text: element?.name || '' }]" />
+  </div>
+  <div v-if="element" class="fr-container my-8">
+    <h1 class="fr-h4 !mb-1">{{ element.name }}</h1>
+
+    <div class="flex flex-col flex-nowrap sm:flex-row sm:flex-wrap gap-20">
+      <div class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
+        <div class="fr-text--sm !font-medium !mb-1">Type</div>
+        <div class="flex">
+          <div><v-icon scale="0.75" class="mr-1" :name="icon" /></div>
+          <div class="fr-text--sm !mb-0 capitalize">{{ type }}</div>
+        </div>
+      </div>
+
+      <div v-if="synonyms && synonyms.length" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
+        <div class="fr-text--sm !font-medium !mb-1">Synonymes</div>
+        <DsfrTag small :label="synonym" v-for="synonym in synonyms" :key="synonym" class="mb-1"></DsfrTag>
+      </div>
+
+      <div v-if="family" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
+        <div class="fr-text--sm !font-medium !mb-1">Famille</div>
+        <div class="fr-text--sm !mb-0 capitalize">{{ family }}</div>
+      </div>
+
+      <div v-if="genre" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
+        <div class="fr-text--sm !font-medium !mb-1">Genre</div>
+        <div class="fr-text--sm !mb-0 capitalize">{{ genre }}</div>
+      </div>
+
+      <div v-if="casNumber" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
+        <div class="fr-text--sm !font-medium !mb-1">Numéro CAS</div>
+        <div class="fr-text--sm !mb-0 capitalize">{{ casNumber }}</div>
+      </div>
+
+      <div v-if="einecNumber" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
+        <div class="fr-text--sm !font-medium !mb-1">Numéro EINEC</div>
+        <div class="fr-text--sm !mb-0 capitalize">{{ einecNumber }}</div>
+      </div>
+
+      <div v-if="usefulParts && usefulParts.length" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
+        <div class="fr-text--sm !font-medium !mb-1">Parties utiles</div>
+        <DsfrTag small :label="part" v-for="part in usefulParts" :key="part" class="mb-1"></DsfrTag>
+      </div>
+
+      <div v-if="substances && substances.length" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
+        <div class="fr-text--sm !font-medium !mb-1">Substances</div>
+        <DsfrTag
+          :link="{ name: 'ElementView', params: { urlComponent: `${substance.id}--substance--${substance.name}` } }"
+          small
+          :label="substance.name"
+          v-for="substance in substances"
+          :key="`substance-${substance.id}`"
+          class="mb-1"
+        ></DsfrTag>
+      </div>
+    </div>
+
+    <h2 class="fr-h6 !mb-1" v-if="description">Description</h2>
+    <p>{{ description }}</p>
+
+    <h2 class="fr-h6 !mb-1" v-if="publicComments">Commentaires</h2>
+    <p>{{ publicComments }}</p>
+  </div>
+  <DsfrErrorPage v-else-if="notFound" class="my-8" title="Article non trouvé" />
+</template>
+
+<script setup>
+import { onMounted, ref, computed, watch } from "vue"
+import { verifyResponse, NotFoundError, getTypeIcon } from "@/utils"
+import { useRoute } from "vue-router"
+
+const route = useRoute()
+const notFound = ref(false)
+const typeMapping = {
+  plante: "plant",
+  "micro-organisme": "microorganism",
+  ingredient: "ingredient",
+  substance: "substance",
+}
+
+// Afin d'améliorer le SEO, l'urlComponent prend la forme id--type--name
+const props = defineProps({ urlComponent: String })
+const elementId = computed(() => props.urlComponent.split("--")[0])
+const type = computed(() => props.urlComponent.split("--")[1])
+
+const icon = computed(() => getTypeIcon(typeMapping[type.value]))
+const element = ref(null)
+
+// Information affichée
+
+const family = computed(() => element.value?.family?.name)
+const genre = computed(() => element.value?.genre)
+const usefulParts = computed(() => element.value?.usefulParts?.map((x) => x.name).filter((x) => !!x))
+const substances = computed(() => element.value?.substances)
+const synonyms = computed(() => element.value?.synonyms?.map((x) => x.name).filter((x) => !!x))
+const casNumber = computed(() => element.value?.casNumber)
+const einecNumber = computed(() => element.value?.einecNumber)
+const description = computed(() => element.value?.description)
+const publicComments = computed(() => element.value?.publicComments)
+
+const getElementFromApi = () => {
+  if (!type.value || !elementId.value) {
+    notFound.value = true
+    return
+  }
+  return fetch(`/api/v1/${typeMapping[type.value]}s/${elementId.value}`)
+    .then(verifyResponse)
+    .then((response) => (element.value = response))
+    .catch((error) => {
+      if (error instanceof NotFoundError) notFound.value = true
+      else window.alert("Une erreur est survenue veuillez réessayer plus tard")
+    })
+}
+
+onMounted(getElementFromApi)
+
+watch(element, (newElement) => {
+  if (newElement) document.title = `${newElement.name} - Compléments alimentaires`
+})
+
+watch(route, getElementFromApi)
+</script>

--- a/frontend/src/views/ElementView.vue
+++ b/frontend/src/views/ElementView.vue
@@ -1,11 +1,16 @@
 <template>
+  <div class="bg-blue-france-925 py-8">
+    <div class="fr-container">
+      <DsfrSearchBar :placeholder="currentSearch" v-model="searchTerm" @search="search" />
+    </div>
+  </div>
   <div class="fr-container">
-    <DsfrBreadcrumb class="mb-8" :links="[{ to: '/', text: 'Accueil' }, { text: element?.name || '' }]" />
+    <DsfrBreadcrumb class="mb-8" :links="breadcrumbLinks" />
   </div>
   <div v-if="element" class="fr-container my-8">
     <h1 class="fr-h4 !mb-1">{{ element.name }}</h1>
 
-    <div class="flex flex-col flex-nowrap sm:flex-row sm:flex-wrap gap-20">
+    <div class="flex flex-col flex-nowrap sm:flex-row sm:flex-wrap gap-20 mb-8">
       <div class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
         <div class="fr-text--sm !font-medium !mb-1">Type</div>
         <div class="flex">
@@ -69,9 +74,11 @@
 <script setup>
 import { onMounted, ref, computed, watch } from "vue"
 import { verifyResponse, NotFoundError, getTypeIcon } from "@/utils"
-import { useRoute } from "vue-router"
+import { useRoute, useRouter } from "vue-router"
 
 const route = useRoute()
+const router = useRouter()
+
 const notFound = ref(false)
 const typeMapping = {
   plante: "plant",
@@ -114,7 +121,20 @@ const getElementFromApi = () => {
     })
 }
 
-onMounted(getElementFromApi)
+const searchPageSource = ref(null)
+
+const breadcrumbLinks = computed(() => {
+  const links = [{ to: "/", text: "Accueil" }]
+  if (searchPageSource.value) links.push({ to: searchPageSource, text: "Résultats de recherche" })
+  links.push({ text: element.value?.name || "" })
+  return links
+})
+
+onMounted(() => {
+  if (router.options.history.state.back && router.options.history.state.back.indexOf("resultats") > -1)
+    searchPageSource.value = router.options.history.state.back
+  getElementFromApi()
+})
 
 watch(element, (newElement) => {
   if (newElement) document.title = `${newElement.name} - Compléments alimentaires`

--- a/frontend/src/views/SearchResults/ResultCard.vue
+++ b/frontend/src/views/SearchResults/ResultCard.vue
@@ -3,7 +3,7 @@
     <div class="fr-card__body">
       <div class="fr-card__content">
         <div class="fr-card__title" style="order: unset">
-          <a :href="url" class="fr-card__link">{{ result.name }}</a>
+          <router-link :to="route" class="fr-card__link">{{ result.name }}</router-link>
         </div>
         <div class="mt-2 flex">
           <div><v-icon scale="0.85" class="mr-1" :name="icon" /></div>
@@ -16,10 +16,7 @@
 
 <script setup>
 import { computed } from "vue"
-import { useRouter } from "vue-router"
 import { getTypeIcon } from "@/utils"
-
-const router = useRouter()
 
 const props = defineProps({
   result: Object,
@@ -34,8 +31,8 @@ const type = computed(() => {
   }
   return mapping[props.result.objectType] || null
 })
-const url = computed(() => {
+const route = computed(() => {
   const urlComponent = `${props.result?.id}--${type.value?.toLowerCase()}--${props.result?.name}`
-  return router.resolve({ name: "ElementView", params: { urlComponent } }).path
+  return { name: "ElementView", params: { urlComponent } }
 })
 </script>

--- a/frontend/src/views/SearchResults/ResultCard.vue
+++ b/frontend/src/views/SearchResults/ResultCard.vue
@@ -3,7 +3,7 @@
     <div class="fr-card__body">
       <div class="fr-card__content">
         <div class="fr-card__title" style="order: unset">
-          <a href="#" class="fr-card__link">{{ result.name }}</a>
+          <a :href="url" class="fr-card__link">{{ result.name }}</a>
         </div>
         <div class="mt-2 flex">
           <div><v-icon scale="0.85" class="mr-1" :name="icon" /></div>
@@ -16,19 +16,15 @@
 
 <script setup>
 import { computed } from "vue"
+import { useRouter } from "vue-router"
+import { getTypeIcon } from "@/utils"
+
+const router = useRouter()
 
 const props = defineProps({
   result: Object,
 })
-const icon = computed(() => {
-  const mapping = {
-    plant: "ri-plant-line",
-    microorganism: "ri-microscope-line",
-    ingredient: "ri-flask-line",
-    substance: "ri-test-tube-line",
-  }
-  return mapping[props.result.objectType] || null
-})
+const icon = computed(() => getTypeIcon(props.result.objectType))
 const type = computed(() => {
   const mapping = {
     plant: "Plante",
@@ -37,5 +33,9 @@ const type = computed(() => {
     substance: "Substance",
   }
   return mapping[props.result.objectType] || null
+})
+const url = computed(() => {
+  const urlComponent = `${props.result?.id}--${type.value?.toLowerCase()}--${props.result?.name}`
+  return router.resolve({ name: "ElementView", params: { urlComponent } }).path
 })
 </script>


### PR DESCRIPTION
Cette PR expose des points API pour chaque élément (sous `/plants/<id>`, `/substances/<id>`, `/ingredients/<id>` et `/microorganisms/<id>`. Pour chaque type d'élément on a donc un serializer, view, url, et test API.

Elle inclut aussi la page Vue où l'on montre ces éléments.

Questions pour d'éventuelles améliorations : 
- C'est quoi le nombre maximum et moyen de substances par élément ? Un trop grand nombre de substances risque de créer une colonne trop grande et trop d'espace blanc. Potentiellement cette info on peut la bouger à un display en ligne.
- Combien d'éléments n'ont ni commentaires publics, ni description ? L'affichage est assez vide quand c'est le cas. À enrichir par la suite avec d'autres composants une fois qu'on aura la liaison avec les personas, etc.

**Affichage desktop**
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/7955bc67-02de-49a8-8cee-db694b63cbd7)

**Affichage mobile**
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/0a21032a-a0b2-40bc-b832-9f58cc6735d4)

L'affichage diffère en dépendant du type d'élément et des informations disponibles. Par exemple pour un type ingrédient : 
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/03180f3e-2b6d-47b7-a6dd-7a741cddae77)

