### PR TITLE
Retours et remarques webinaires et blog

### DIFF
--- a/data/factories/blogpost.py
+++ b/data/factories/blogpost.py
@@ -8,6 +8,7 @@ class BlogPostFactory(factory.django.DjangoModelFactory):
         model = BlogPost
 
     title = factory.Faker("catch_phrase")
+    tagline = factory.Faker("catch_phrase")
     body = factory.Faker("paragraph")
     published = factory.Faker("boolean")
     author = factory.SubFactory(UserFactory)

--- a/frontend/src/views/BlogsHome.vue
+++ b/frontend/src/views/BlogsHome.vue
@@ -93,7 +93,7 @@ const blogDate = (post) => {
     day: "numeric",
   })
 }
-const blogDescription = (post) => post.body?.substring(0, 100).replace(/<\/?[^>]+(>|$)/g, "")
+const blogDescription = (post) => post.tagline?.substring(0, 100) || ""
 
 // Route management
 watch(route, () => {

--- a/frontend/src/views/LandingPage/WebinarBlock.vue
+++ b/frontend/src/views/LandingPage/WebinarBlock.vue
@@ -23,9 +23,7 @@
           <v-icon scale="0.9" class="-mb-1 mr-1" name="ri-video-chat-line"></v-icon>
           Visio-conférence
         </div>
-        <a :href="webinar.link">
-          <DsfrButton label="Je m'inscris" />
-        </a>
+        <a :href="webinar.link" target="_blank" rel="noopener noreferrer" class="fr-btn fr-btn--md">Je m'inscris</a>
       </div>
     </div>
   </div>

--- a/frontend/src/views/LandingPage/WebinarBlock.vue
+++ b/frontend/src/views/LandingPage/WebinarBlock.vue
@@ -18,7 +18,7 @@
       </div>
       <div class="p-6 col-span-12 sm:col-span-4 md:col-span-3">
         <div class="font-bold capitalize">{{ formattedDate(webinar) }}</div>
-        <div class="mb-4">{{ formattedTime(webinar) }}</div>
+        <div class="mb-4">{{ formattedStartTime(webinar) }} à {{ formattedEndTime(webinar) }}</div>
         <div class="fr-text--xs text-slate-500">
           <v-icon scale="0.9" class="-mb-1 mr-1" name="ri-video-chat-line"></v-icon>
           Visio-conférence
@@ -48,12 +48,15 @@ const formattedDate = (webinar) => {
   const date = new Date(webinar.startDate)
   return date.toLocaleString("fr", options)
 }
-const formattedTime = (webinar) => {
-  const date = new Date(webinar.startDate)
+
+const formatTime = (date) => {
   const hour = date.toLocaleString("fr", { hour: "numeric" })
   const minutes = date.toLocaleString("fr", { minute: "2-digit" })
   return `${hour}${minutes}`.replace(" ", "")
 }
+
+const formattedStartTime = (webinar) => formatTime(new Date(webinar.startDate))
+const formattedEndTime = (webinar) => formatTime(new Date(webinar.endDate))
 
 onMounted(() => {
   const url = "/api/v1/webinars/"

--- a/frontend/src/views/LandingPage/WebinarBlock.vue
+++ b/frontend/src/views/LandingPage/WebinarBlock.vue
@@ -51,7 +51,7 @@ const formattedDate = (webinar) => {
 const formattedTime = (webinar) => {
   const date = new Date(webinar.startDate)
   const hour = date.toLocaleString("fr", { hour: "numeric" })
-  const minutes = date.toLocaleString("fr", { minute: "numeric" })
+  const minutes = date.toLocaleString("fr", { minute: "2-digit" })
   return `${hour}${minutes}`.replace(" ", "")
 }
 


### PR DESCRIPTION
## Retours webinaire et blog
- [x] Affichage des minutes avec deux caractères (_12h04_ et non pas _12h4_) sur la carte webinaire (https://github.com/betagouv/complements-alimentaires/pull/122/commits/48816be9e4ea1b327079d0d1e1c70a4df1f1f2fd) 
- [x] Ajout de l'heure de fin aux webinaires (https://github.com/betagouv/complements-alimentaires/pull/122/commits/48816be9e4ea1b327079d0d1e1c70a4df1f1f2fd)
- [x] Aperture des liens sur un nouvel onglet (https://github.com/betagouv/complements-alimentaires/pull/122/commits/b5b6e475792d895bf3107d95f8d67639bc90e596)
- [x] Fix du souci avec les accents dans la carte blog (https://github.com/betagouv/complements-alimentaires/pull/122/commits/9f42b5d268b4e9660e75c356b9542afdd509a4ba)

Sur ce dernier point, j'utilisais à tort le champ `body` pour le preview de la carte blog. Non seulement on a un champ dedié `tagline`, mais `body` est du html - donc on aurait pu avoir d'autres soucis si par exemple l'article commence avec une image.

Pour les autres points de l'issue, j'ai ajoute [un commentaire](https://github.com/betagouv/complements-alimentaires/issues/94#issuecomment-1893444026) pour en discuter davantage.

Closes #94 