### PR TITLE
Les titres des éléments et leurs synonymes commencent avec majuscule

### DIFF
--- a/frontend/src/views/ElementView.vue
+++ b/frontend/src/views/ElementView.vue
@@ -8,7 +8,7 @@
     <DsfrBreadcrumb class="mb-8" :links="breadcrumbLinks" />
   </div>
   <div v-if="element" class="fr-container my-8">
-    <h1 class="fr-h4 !mb-1">{{ element.name }}</h1>
+    <h1 class="fr-h4 !mb-1 capitalize">{{ element.name }}</h1>
 
     <div class="flex flex-col flex-nowrap sm:flex-row sm:flex-wrap gap-1 sm:gap-20 mb-8">
       <div class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
@@ -21,7 +21,7 @@
 
       <div v-if="synonyms && synonyms.length" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
         <div class="fr-text--sm !font-medium !mb-1">Synonymes</div>
-        <DsfrTag small :label="synonym" v-for="synonym in synonyms" :key="synonym" class="mb-1"></DsfrTag>
+        <DsfrTag small :label="synonym" v-for="synonym in synonyms" :key="synonym" class="mb-1 capitalize"></DsfrTag>
       </div>
 
       <div v-if="family" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
@@ -46,7 +46,7 @@
 
       <div v-if="usefulParts && usefulParts.length" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
         <div class="fr-text--sm !font-medium !mb-1">Parties utiles</div>
-        <DsfrTag small :label="part" v-for="part in usefulParts" :key="part" class="mb-1"></DsfrTag>
+        <DsfrTag small :label="part" v-for="part in usefulParts" :key="part" class="mb-1 capitalize"></DsfrTag>
       </div>
 
       <div v-if="substances && substances.length" class="col-span-12 sm:col-span-4 md:col-span-3 flex flex-col mt-4">
@@ -57,7 +57,7 @@
           :label="substance.name"
           v-for="substance in substances"
           :key="`substance-${substance.id}`"
-          class="mb-1"
+          class="mb-1 capitalize"
         ></DsfrTag>
       </div>
     </div>

--- a/frontend/src/views/SearchResults/ResultCard.vue
+++ b/frontend/src/views/SearchResults/ResultCard.vue
@@ -3,7 +3,7 @@
     <div class="fr-card__body">
       <div class="fr-card__content">
         <div class="fr-card__title" style="order: unset">
-          <router-link :to="route" class="fr-card__link">{{ result.name }}</router-link>
+          <router-link :to="route" class="fr-card__link capitalize">{{ result.name }}</router-link>
         </div>
         <div class="mt-2 flex">
           <div><v-icon scale="0.85" class="mr-1" :name="icon" /></div>


### PR DESCRIPTION
Via `text-transform: capitalize;` on peut s'assurer que le texte des noms des éléments et leurs synonymes commencent toujours avec majuscule.

Closes #124 