### PR TITLE
Ajout du spinner lors de chargement de la recherche

### DIFF
--- a/frontend/src/views/SearchResults/index.vue
+++ b/frontend/src/views/SearchResults/index.vue
@@ -9,7 +9,10 @@
       class="mb-8"
       :links="[{ to: '/', text: 'Accueil' }, { text: `Recherche : « ${currentSearch} »` }]"
     />
-    <div v-if="emptyView">
+    <div class="flex justify-center my-24" v-if="loading">
+      <ProgressSpinner />
+    </div>
+    <div v-else-if="emptyView">
       <h1 class="fr-h3">Nous n'avons pas trouvé des résultats pour « {{ currentSearch }} »</h1>
     </div>
     <div class="mb-4" v-else>
@@ -39,9 +42,10 @@ import { onMounted, ref, computed, watch } from "vue"
 import { useRoute, useRouter, onBeforeRouteUpdate } from "vue-router"
 import { headers, verifyResponse } from "@/utils"
 import ResultCard from "./ResultCard"
+import ProgressSpinner from "@/components/ProgressSpinner"
 
 let mounted = false
-let currentSearch = ""
+let currentSearch = ref("")
 
 const router = useRouter()
 const route = useRoute()
@@ -78,7 +82,7 @@ const search = () => {
 
 const fetchSearchResults = () => {
   const url = "/api/v1/search/"
-  const body = JSON.stringify({ search: currentSearch, limit, offset: offset.value })
+  const body = JSON.stringify({ search: currentSearch.value, limit, offset: offset.value })
   loading.value = true
   return fetch(url, { method: "POST", headers, body })
     .then(verifyResponse)
@@ -98,7 +102,7 @@ onBeforeRouteUpdate((to) => {
 })
 
 onMounted(() => {
-  currentSearch = route.query.q
+  currentSearch.value = route.query.q
   page.value = route.query.page || 1
   fetchSearchResults().then(() => (mounted = true))
 })
@@ -107,7 +111,7 @@ watch(
   () => route.query,
   () => {
     if (mounted) {
-      currentSearch = route.query.q
+      currentSearch.value = route.query.q
       fetchSearchResults()
     }
   }


### PR DESCRIPTION
Suite à la démo, cette PR met en place un spinner basique pour indiquer que la recherche est en cours.

Au passage, j'ai du rendre la propriété `currentSearch` reactive car elle n'était pas disponible avant la fin de la recherche.

Voici une petite vidéo en mettant exprès un `sleep` de trois secondes :

[Screencast from 17-01-24 17:14:16.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/265bd14d-4054-4de7-aa6f-6955717236eb)
