### PR TITLE
Usage du POST pour fermer la session 

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -9,11 +9,26 @@
       <DsfrNavigation :nav-items="navItems" />
     </template>
   </DsfrHeader>
+  <DsfrModal title="Voulez-vous fermer votre session ?" :opened="logoutModalOpened" @close="closeModal">
+    <form action="/se-deconnecter" method="post" class="inline">
+      <input type="hidden" name="csrfmiddlewaretoken" :value="csrfToken" />
+      <DsfrButton class="mr-2">Me déconnecter</DsfrButton>
+    </form>
+    <DsfrButton tertiary @click="closeModal">Revenir en arrière</DsfrButton>
+  </DsfrModal>
 </template>
 
 <script setup>
-import { computed, onMounted } from "vue"
+import { computed, onMounted, watch, ref } from "vue"
 import { useStore } from "vuex"
+import { useRoute, useRouter } from "vue-router"
+
+const logoutModalOpened = ref(false)
+
+const route = useRoute()
+const router = useRouter()
+
+const csrfToken = window.CSRF_TOKEN
 
 const logoText = ["Ministère", "de l'Agriculture", "et de la Souveraineté", "Alimentaire"]
 const environment = window.ENVIRONMENT
@@ -38,7 +53,7 @@ const quickLinks = computed(function () {
       {
         label: "Se déconnecter",
         icon: "ri-logout-box-r-line",
-        href: `${window.location.protocol}//${window.location.host}/se-deconnecter`,
+        to: { query: { "confirmation-deconnexion": true }, replace: true },
       },
     ]
   else return []
@@ -46,4 +61,13 @@ const quickLinks = computed(function () {
 onMounted(() => {
   store.dispatch("fetchLoggedUser")
 })
+const closeModal = () => {
+  router.replace({ query: {} })
+}
+watch(
+  () => route.query["confirmation-deconnexion"],
+  (newValue) => {
+    logoutModalOpened.value = newValue
+  }
+)
 </script>


### PR DESCRIPTION
### Pourquoi

Depuis Django 5.0, on ne peut plus utiliser le `LogoutView` avec un GET. Il faut nécessairement un POST pour pouvoir fermer la session ([thread expliquant pourquoi](https://forum.djangoproject.com/t/deprecation-of-get-method-for-logoutview/25533)).

### Challenge avec vue-dsfr

On ne peut pas ajouter dans les `quicklinks` un button avec une action, ni entouré d'un `<form>` pour effectuer le POST. Vu que de toute façon c'est une bonne pratique de demander la confirmation lors de la fermeture d'une session, on peut utiliser le _quicklink_ de vue-dsfr pour modifier la route et montrer un modal à l'utilisateur. Dans le modal on est libre d'ajouter ce qu'on veut. 

### Démo

[Screencast from 30-01-24 18:00:21.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/63cb8f57-6a76-4a78-89ef-55746f5f387e)

## Autres pistes explorées

- Dynamiquement ajouter l'élément après que le composant est monté (avec la complexité que le html change dans les petits écrans, donc il faut aussi ajouter un listener de taille). Trop complexe est pas très beau.
- Mettre le bouton dans la nav en profitant du `<template #mainnav>`. Par contre ceci place le bouton à un endroit où on ne s'attend pas.
- Ne pas utiliser `DsfrHeader` et le créer nous mêmes. Trop complexe à cause des éléments qui changent en dépendant de la taille de l'écran.