### PR TITLE
Ajout du favicon

### DIFF
--- a/web/templates/vue-app.html
+++ b/web/templates/vue-app.html
@@ -1,5 +1,6 @@
 {% load render_bundle from webpack_loader %}
 {% load environment %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="fr">
 
@@ -8,7 +9,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
 
-
+    <link rel="icon" type="image/png" href="{% static 'images/favicon-marianne.png' %}">
 
     <title>Compléments alimentaires</title>
     <meta name="description" content="Compléments alimentaires">


### PR DESCRIPTION
Avec cette PR on met en place le favicon du dsfr :

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/e02f3465-f69a-4692-a0dc-6219b00ac1f5)
