### PR TITLE
Intégration Matomo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ SECURE= 'False' si on développe en local, 'True' autrement
 ENVIRONMENT= Optionnel - si cette variable est remplie un badge sera visible dans l'application et l'admin changera. Les options sont : `dev` | `staging` | `demo` | `prod`
 NEWSLETTER_BREVO_LIST_ID= L'ID de la newsletter de Brevo (précedemment Send In Blue)
 BREVO_API_KEY= La clé API de Brevo
+MATOMO_ID (optionnel)= L'ID pour le suivi avec Matomo. Compl-alim utilise l'ID 95 pour la prod, en local c'est mieux de le laisser vide
 ```
 
 ## Lancer l'application en mode développement

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "core-js": "^3.35.1",
         "oh-vue-icons": "^1.0.0-rc3",
         "vue": "^3.4.15",
+        "vue-matomo": "^4.2.0",
         "vue-router": "^4.2.5",
         "vuex": "^4.1.0",
         "webpack-bundle-tracker": "^3.0.1"
@@ -15513,6 +15514,15 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-matomo": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vue-matomo/-/vue-matomo-4.2.0.tgz",
+      "integrity": "sha512-m5hCw7LH3wPDcERaF4sp/ojR9sEx7Rl8TpOyH/4jjQxMF2DuY/q5pO+i9o5Dx+BXLSa9+IQ0qhAbWYRyESQXmA==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "core-js": "^3.35.1",
     "oh-vue-icons": "^1.0.0-rc3",
     "vue": "^3.4.15",
+    "vue-matomo": "^4.2.0",
     "vue-router": "^4.2.5",
     "vuex": "^4.1.0",
     "webpack-bundle-tracker": "^3.0.1"

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,6 +2,7 @@ import { createApp } from "vue"
 import "./styles/index.css"
 import * as icons from "./icons.js"
 import { OhVueIcon, addIcons } from "oh-vue-icons"
+import VueMatomo from "vue-matomo"
 import "@gouvfr/dsfr/dist/dsfr.min.css" // Import des styles du DSFR
 import "@gouvminint/vue-dsfr/styles" // Import des styles globaux propre à VueDSFR
 import VueDsfr from "@gouvminint/vue-dsfr" // Import (par défaut) de la bibliothèque
@@ -16,5 +17,19 @@ const app = createApp(App)
   .use(router)
   .use(store)
   .use(VueDsfr, { icons: Object.values(icons) })
+
+if (window.MATOMO_ID)
+  app.use(VueMatomo, {
+    host: "https://stats.beta.gouv.fr",
+    siteId: window.MATOMO_ID,
+    trackerFileName: "matomo",
+    router: router,
+    requireConsent: false,
+    enableLinkTracking: true,
+    trackInitialView: true,
+    debug: false,
+    userId: undefined,
+  })
+
 app.component("v-icon", OhVueIcon)
 app.mount("#app")

--- a/icare/settings.py
+++ b/icare/settings.py
@@ -281,3 +281,6 @@ CKEDITOR_CONFIGS = {
         "removePlugins": ",".join(["image"]),
     }
 }
+
+# Analytics
+MATOMO_ID = os.getenv("MATOMO_ID", "")

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load analytics %}
 <!doctype html>
 <html lang="fr">
     <head>
@@ -7,6 +8,21 @@
         <link rel="stylesheet" href="{% static 'css/auth.css' %}">
 
         <link rel="icon" type="image/png" href="{% static 'images/favicon-marianne.png' %}">
+
+        <!-- Matomo -->
+        <script>
+            var _paq = window._paq = window._paq || [];
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+            var u="https://stats.beta.gouv.fr/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', "{% matomo_id %}"]);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+            })();
+        </script>
+        <!-- End Matomo Code -->
     </head>
     <body>
         <main>

--- a/web/templates/vue-app.html
+++ b/web/templates/vue-app.html
@@ -1,6 +1,7 @@
 {% load render_bundle from webpack_loader %}
 {% load environment %}
 {% load static %}
+{% load analytics %}
 <!DOCTYPE html>
 <html lang="fr">
 
@@ -15,7 +16,8 @@
     <meta name="description" content="Compléments alimentaires">
     <script type="text/javascript">
         window.CSRF_TOKEN = "{{ csrf_token }}";
-        window.ENVIRONMENT = "{% environment %}"
+        window.ENVIRONMENT = "{% environment %}";
+        window.MATOMO_ID = "{% matomo_id %}";
     </script>
 </head>
 

--- a/web/templatetags/analytics.py
+++ b/web/templatetags/analytics.py
@@ -1,0 +1,9 @@
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+
+@register.simple_tag
+def matomo_id():
+    return getattr(settings, "MATOMO_ID", "")


### PR DESCRIPTION
## Vue

Cette PR utilise l'intégration Vue pour Matomo ([details ici](https://matomo.org/faq/new-to-piwik/how-do-i-install-the-matomo-tracking-code-on-websites-that-use-vue-js/)).

## Pages Django

Les pages hors Vue ont aussi le code Matomo via le template `base.html`, ou le code Matomo est inséré dans le `<head>`.

## Variable d'environnement

On ajoute également une variable d'environnement `MATOMO_ID` qui peut rester vide dans nos machines de developpement mais qui permettrait d'utiliser des comptes diverses pour nos environnements (par ex, un éventuel compte Matomo staging pourrait nous permettre de tester des funnels ou events spécifiques).