### PR TITLE
Ajout des pages légales : « CGU », « mentions légales » et « politique de confidentialité »

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,13 @@
 <template>
   <AppHeader />
   <router-view></router-view>
-  <DsfrFooter :logo-text="logoText" :mandatory-links="footerLinks">
+  <DsfrFooter
+    :logo-text="logoText"
+    :cookiesLink="{ name: 'CookiesInfo' }"
+    :legalLink="{ name: 'LegalNotices' }"
+    :personalDataLink="{ name: 'PrivacyPolicy' }"
+    :afterMandatoryLinks="[{ label: 'Conditions générales d\'utilisation', to: { name: 'CGU' } }]"
+  >
     <template v-slot:description>
       <p>Compléments alimentaires</p>
     </template>
@@ -14,21 +20,6 @@ import { useRoute } from "vue-router"
 import AppHeader from "@/components/AppHeader.vue"
 
 const route = useRoute()
-
-const footerLinks = [
-  {
-    label: "Mentions légales",
-    to: { name: "LegalNotices" },
-  },
-  {
-    label: "Politique de confidentialité",
-    to: { name: "PrivacyPolicy" },
-  },
-  {
-    label: "Conditions générales d'utilisation",
-    to: { name: "CGU" },
-  },
-]
 
 watch(route, (to) => {
   const suffix = "Compléments alimentaires"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <AppHeader />
   <router-view></router-view>
-  <DsfrFooter :logo-text="logoText">
+  <DsfrFooter :logo-text="logoText" :mandatory-links="footerLinks">
     <template v-slot:description>
       <p>Compléments alimentaires</p>
     </template>
@@ -14,6 +14,21 @@ import { useRoute } from "vue-router"
 import AppHeader from "@/components/AppHeader.vue"
 
 const route = useRoute()
+
+const footerLinks = [
+  {
+    label: "Mentions légales",
+    to: { name: "LegalNotices" },
+  },
+  {
+    label: "Politique de confidentialité",
+    to: { name: "PrivacyPolicy" },
+  },
+  {
+    label: "Conditions générales d'utilisation",
+    to: { name: "CGU" },
+  },
+]
 
 watch(route, (to) => {
   const suffix = "Compléments alimentaires"

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,6 +5,9 @@ import BlogsHome from "@/views/BlogsHome"
 import BlogPost from "@/views/BlogPost"
 import SearchResults from "@/views/SearchResults"
 import ElementView from "@/views/ElementView"
+import CGU from "@/views/CGU.vue"
+import PrivacyPolicy from "@/views/PrivacyPolicy.vue"
+import LegalNotices from "@/views/LegalNotices"
 
 const routes = [
   {
@@ -45,6 +48,30 @@ const routes = [
     name: "ElementView",
     component: ElementView,
     props: true,
+  },
+  {
+    path: "/mentions-legales",
+    name: "LegalNotices",
+    component: LegalNotices,
+    meta: {
+      title: "Mentions légales",
+    },
+  },
+  {
+    path: "/cgu",
+    name: "CGU",
+    component: CGU,
+    meta: {
+      title: "Conditions générales d'utilisation",
+    },
+  },
+  {
+    path: "/politique-de-confidentialite",
+    name: "PrivacyPolicy",
+    component: PrivacyPolicy,
+    meta: {
+      title: "Politique de confidentialité",
+    },
   },
 ]
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -8,6 +8,7 @@ import ElementView from "@/views/ElementView"
 import CGU from "@/views/CGU.vue"
 import PrivacyPolicy from "@/views/PrivacyPolicy.vue"
 import LegalNotices from "@/views/LegalNotices"
+import CookiesInfo from "@/views/CookiesInfo"
 
 const routes = [
   {
@@ -71,6 +72,14 @@ const routes = [
     component: PrivacyPolicy,
     meta: {
       title: "Politique de confidentialité",
+    },
+  },
+  {
+    path: "/cookies",
+    name: "CookiesInfo",
+    component: CookiesInfo,
+    meta: {
+      title: "Cookies",
     },
   },
 ]

--- a/frontend/src/views/CGU.vue
+++ b/frontend/src/views/CGU.vue
@@ -35,6 +35,10 @@
       <li>Directeur de la publication : Ministère de l’Agriculture et de la Souveraineté Alimentaire.</li>
       <li>Prestataire d'hébergement : Clevercloud, 3 rue de l'Allier, 44000 Nantes, France.</li>
     </ul>
+    <p>
+      Plus d'informations sur nos
+      <router-link :to="{ name: 'LegalNotices' }">page dédiée aux mentions légales.</router-link>
+    </p>
     <h2>Modalités d’utilisation du Service</h2>
     <p>L'utilisation du Service est facultative et gratuite.</p>
     <p>

--- a/frontend/src/views/CGU.vue
+++ b/frontend/src/views/CGU.vue
@@ -1,0 +1,157 @@
+<template>
+  <div class="fr-container pb-10">
+    <DsfrBreadcrumb :links="[{ to: '/', text: 'Accueil' }, { text: 'Conditions générales d\'utilisation' }]" />
+    <h1>Conditions générales d'utilisation</h1>
+    <p>
+      Les présentes conditions d’utilisation (CGU) sont mises en œuvre conformément à l’article L. 112-9 du code des
+      relations entre le public et l’administration. Elles s’imposent aux usagers.
+    </p>
+    <h2>Présentation</h2>
+    <p>
+      « Compl'Alim » (ci-après dénommé « le Service ») est mis en œuvre par le ministère de l’Agriculture qui s’appuie
+      sur l’expertise de la Direction interministérielle du numérique dans le cadre d’une délégation de gestion.
+    </p>
+    <p>
+      Le Service est destiné à accompagner les acteurs du secteur des compléments alimentaires (ci-après abrégé « CA »)
+      en facilitant la constitution des dossiers de déclaration.
+    </p>
+    <h2>Parcours usagers</h2>
+    <p>Le Service est une plateforme numérique permettant :</p>
+    <ul>
+      <li>la constitution d’un dossier permettant de déclarer un CA,</li>
+      <li>la modification d’un produit ou son arrêt de commercialisation</li>
+      <li>la recherche sur l’état d’un produit par le grand public</li>
+    </ul>
+    <p>Un parcours « instructeur / instructrice » est prévu pour faciliter l’analyse des déclarations.</p>
+
+    <p>
+      La création du compte peut être faite directement par l’équipe chargée du Service ou par l’usager. Le compte
+      nécessite un mot de passe et permet également l'utilisation d'un lien d’accès envoyé à l’adresse e-mail
+      renseignée.
+    </p>
+    <h2>Mentions légales</h2>
+    <ul>
+      <li>Éditeur : L'Incubateur de services numériques de la Direction Interministérielle du Numérique (DINUM).</li>
+      <li>Directeur de la publication : Ministère de l’Agriculture et de la Souveraineté Alimentaire.</li>
+      <li>Prestataire d'hébergement : Clevercloud, 3 rue de l'Allier, 44000 Nantes, France.</li>
+    </ul>
+    <h2>Modalités d’utilisation du Service</h2>
+    <p>L'utilisation du Service est facultative et gratuite.</p>
+    <p>
+      Le Service dépose des cookies de mesure d’audience (nombre de visites, pages consultées), respectant les
+      conditions d’exemption du consentement de l’internaute définies par la recommandation « Cookies » de la Commission
+      nationale informatique et libertés (CNIL); il utilise Matomo, un outil libre, paramétré pour ce faire. Cela
+      signifie, notamment, que ces cookies ne servent qu’à la production de statistiques anonymes et ne permettent pas
+      de suivre la navigation de l’internaute sur d’autres sites.
+    </p>
+    <p>Le Service dépose des cookies de navigation à des fins strictement techniques, qui ne sont pas conservés.</p>
+    <h2>Traitement des données</h2>
+    <p>
+      Le Service ne collecte que les données strictement nécessaires à sa mise en œuvre. Les données collectées incluent
+      également des données à caractère personnel.
+    </p>
+    <p>Les données traitées sont les suivantes :</p>
+    <ul>
+      <li>
+        les données obligatoires pour la création du compte : nom, prénom, nom d'utilisateur, adresse e-mail.
+        L’utilisateur doit également fournir les données de l’établissement concerné (par exemple SIRET), qui ne sont
+        pas considérées comme des données à caractère personnel.
+      </li>
+      <li>
+        les données facultatives : l’ensemble des champs décrivant la composition des CA. L’équipe chargée du Service se
+        réserve néanmoins le droit de supprimer ou de proposer une modification lorsque le contenu proposé ne répond à
+        des critères minimaux de qualité.
+      </li>
+    </ul>
+    <p>
+      Les données relatives à l’établissement ainsi que les données facultatives relatives aux diagnostics sont
+      conservées jusqu’à la fin de fonctionnement du Service, notamment pour répondre aux besoins statistiques.
+    </p>
+    <p>
+      Le ministère de l’Agriculture s'engage à prendre toutes précautions utiles pour préserver la sécurité des données
+      collectées auprès de l'usager, et notamment empêcher qu'elles soient déformées et endommagées ou que des tiers non
+      autorisés y aient accès.
+    </p>
+    <p>
+      Le ministère de l’agriculture garantit aux usagers du Service les droits d'accès, de rectification et d'opposition
+      sur leurs données à caractère personnel, prévus par la loi n° 78-17 du 6 janvier 1978 relative à l'informatique
+      aux fichiers et aux libertés.
+    </p>
+    <p>
+      Pour plus d’informations sur le traitement des données à caractère personnel l’utilisateur est invité à se référer
+      à la
+      <router-link :to="{ name: 'PrivacyPolicy' }">politique de confidentialité.</router-link>
+    </p>
+    <p>
+      La validation des CGU implique l’inscription automatique à l’infolettre Compl'Alim. Conforment à la
+      réglementation, cette inscription est révocable à tout moment, soit en vous désabonnant à réception du courriel,
+      ou en nous notifiant votre refus à l’adresse suivante :
+      <a href="mailto:compl-alim@beta.gouv.fr">compl-alim@beta.gouv.fr</a>
+    </p>
+    <h2>Statistiques</h2>
+    <p>Les données récoltées dans le cadre du téléservice servent au pilotage de la politique publique.</p>
+    <p>
+      Conformément aux dispositions des articles L. 230-5-1 et R. 230-30-4 du Code rural, les données recueillies par
+      l’intermédiaire de la plateforme permettent de réaliser un bilan de la mise en œuvre du dispositif qui est adressé
+      notamment au Parlement.
+    </p>
+    <p>
+      En outre, conformément aux dispositions du Livre III du Code des relations entre le public et l’administration, la
+      plateforme diffuse des informations publiques relatives aux données collectées et au suivi de l’usage de la
+      plateforme.
+    </p>
+    <h2>Engagements et responsabilité</h2>
+    <p>
+      Le présent Service est mis en œuvre selon les dispositions du code des relations entre le public et
+      l’administration (CRPA).
+    </p>
+    <p>
+      Le Service a été développé sous licence MIT , le code est disponible à l’adresse suivante :
+      <a href="https://github.com/betagouv/complements-alimentaires/" target="_blank" rel="noopener">
+        https://github.com/betagouv/complements-alimentaires/
+      </a>
+    </p>
+    <p>
+      Le Service est mis à disposition sans autres garanties expresses ou tacites que celles qui sont prévues par les
+      présentes.
+    </p>
+    <p>
+      Le Service est développé conformément à l’état de l’art. Toutefois, il n’est pas garanti qu’il soit exempt
+      d’anomalies ou d'erreurs. Le service est donc mis à disposition sans garantie sur sa disponibilité et ses
+      performances. A ce titre, le ministère de l’Agriculture ne peut être tenu responsable des pertes et/ou préjudices,
+      de quelque nature qu’ils soient, qui pourraient être causés à la suite d’un dysfonctionnement ou une
+      indisponibilité du service. De telles situations n'ouvriront droit à aucune compensation financière.
+    </p>
+    <p>
+      L’utilisateur s’engage à respecter les présentes CGU et la législation en vigueur. Il s’engage notamment à ne
+      fournir, dans le cadre de l'utilisation du Service, que des informations exactes, à jour et complètes.
+    </p>
+    <p>
+      Dans l'hypothèse où l'usager ne s'acquitte pas de ses engagements, le ministère de l’Agriculture se réserve le
+      droit de suspendre ou résilier le service pour cet usager sans préjudice des éventuelles actions en responsabilité
+      pénale et civile qui pourraient être engagées à son encontre.
+    </p>
+    <h2>Modification et évolution du Service</h2>
+    <p>
+      Les termes des présentes conditions d’utilisation peuvent être modifiés ou complétés à tout moment, sans préavis,
+      en fonction des modifications apportées au Service, de l’évolution de la législation ou pour tout autre motif jugé
+      nécessaire. Ces modifications et mises à jour s’imposent à l’utilisateur qui doit, en conséquence, se référer
+      régulièrement à cette rubrique pour vérifier les conditions générales en vigueur.
+    </p>
+    <h2>Nous contacter</h2>
+    <ul>
+      <li>
+        Difficultés techniques :
+        <a href="mailto:compl-alim@beta.gouv.fr">compl-alim@beta.gouv.fr</a>
+      </li>
+      <li>
+        Problèmes liés à la procédure :
+        <a href="mailto:compl-alim@beta.gouv.fr">compl-alim@beta.gouv.fr</a>
+      </li>
+      <li>
+        Droit d’accès CNIL :
+        <a href="mailto:compl-alim@beta.gouv.fr">compl-alim@beta.gouv.fr</a>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/frontend/src/views/CookiesInfo.vue
+++ b/frontend/src/views/CookiesInfo.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="fr-container pb-10">
+    <DsfrBreadcrumb :links="[{ to: '/', text: 'Accueil' }, { text: 'Cookies' }]" />
+    <h1>Cookies</h1>
+    <p>
+      Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour but de collecter des
+      informations relatives à votre navigation et de vous adresser des services adaptés à votre terminal (ordinateur,
+      mobile ou tablette).
+    </p>
+    <p>
+      Le site dépose des cookies de mesure d’audience (nombre de visites, pages consultées), respectant les conditions
+      d’exemption du consentement de l’internaute définies par la recommandation « Cookies » de la Commission nationale
+      informatique et libertés (CNIL). Cela signifie, notamment, que ces cookies ne servent qu’à la production de
+      statistiques anonymes et ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
+    </p>
+    <p>
+      Nous utilisons pour cela Matomo, un outil de mesure d’audience web libre, paramétré pour être en conformité avec
+      la recommandation « Cookies » de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant
+      d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.
+    </p>
+    <p>Il convient d’indiquer que :</p>
+    <ul>
+      <li>Les données collectées ne sont pas recoupées avec d’autres traitements</li>
+      <li>Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites</li>
+    </ul>
+    <p>
+      À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en
+      utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer
+      11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
+    </p>
+    <p>
+      Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et
+      des Libertés (CNIL) :
+    </p>
+    <ul>
+      <li>
+        <a href="https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi" target="_blank" rel="noopener">
+          Cookies & traceurs : que dit la loi ?
+        </a>
+      </li>
+      <li>
+        <a href="https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser" target="_blank" rel="noopener">
+          Cookies : les outils pour les maîtriser
+        </a>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/frontend/src/views/LegalNotices.vue
+++ b/frontend/src/views/LegalNotices.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="fr-container pb-10">
+    <DsfrBreadcrumb :links="[{ to: '/', text: 'Accueil' }, { text: 'Mentions Légales' }]" />
+    <h1>Mentions Légales</h1>
+    <h2>Éditeur de la Plateforme</h2>
+    <p>
+      La Plateforme Compl'Alim (
+      <router-link :to="{ name: 'LandingPage' }">https://compl-alim.beta.gouv.fr/</router-link>
+      ) est éditée par l'Incubateur de services numériques de la Direction Interministérielle du Numérique (DINUM).
+    </p>
+    <h2>Coordonnées</h2>
+    <p>Adresse : DINUM, 20 avenue de Ségur, 75007 Paris</p>
+    <p>Tel. accueil : 01.71.21.01.70</p>
+    <p>SIRET : 12000101100010 (secrétariat général du gouvernement)</p>
+    <p>SIREN : 120 001 011</p>
+    <h2>Directeur de la publication</h2>
+    <address>
+      <p>
+        Ministère de l’Agriculture et de la Souveraineté Alimentaire
+        <br />
+        Direction Générale de l’Alimentation
+        <br />
+        Hôtel de Villeroy, 78, rue de Varenne; Paris 7e
+      </p>
+    </address>
+    <h2>Hébergement de la Plateforme</h2>
+    <p>Ce site est hébergé en propre par:</p>
+    <address>
+      <p>Clevercloud, 3 rue de l'Allier, 44000 Nantes, France.</p>
+    </address>
+    <h2>Accessibilité</h2>
+    <p>
+      La conformité aux normes d’accessibilité numérique est un objectif ultérieur dans le développement itératif de la
+      plateforme. Nous nous efforçons de créer un maximum de composants partagés et de les rendre accessibles à toutes
+      et tous.
+    </p>
+    <p>
+      Pour en savoir plus :
+      <a href="http://references.modernisation.gouv.fr/accessibilite-numerique" target="_blank" rel="noopener">
+        http://references.modernisation.gouv.fr/accessibilite-numerique.
+      </a>
+    </p>
+    <p>
+      Pour nous signaler des problèmes ou suggestions d'amélioration concernant l'accessibilité de la plateforme, deux
+      options :
+    </p>
+    <ul>
+      <li>
+        nous signaler par email :
+        <a href="mailto:compl-alim@beta.gouv.fr">compl-alim@beta.gouv.fr</a>
+      </li>
+      <li>
+        créer une “issue” sur
+        <a href="https://github.com/betagouv/complements-alimentaires/" target="_blank" rel="noopener">
+          le dépôt de code sur GitHub.
+        </a>
+      </li>
+    </ul>
+    <p>
+      Le code source est ouvert et les contributions sont bienvenues.
+      <a href="https://github.com/betagouv/complements-alimentaires/" target="_blank" rel="noopener">
+        Voir le code source.
+      </a>
+    </p>
+    <h2>Données personnelles, suivi d’audience et gestion des cookies</h2>
+    <p>
+      Le cookie est un petit fichier texte enregistré par le navigateur de votre ordinateur, tablette ou smartphone et
+      qui permet de conserver des données utilisateur afin de faciliter la navigation et de permettre certaines
+      fonctionnalités.
+    </p>
+    <h3>A quoi nous servent-ils ?</h3>
+    <p>Cela nous permet de mesurer le nombre de visites et de comprendre quelles sont les pages les plus consultées.</p>
+    <h3>Ce site n’affiche pas de bannière de consentement aux cookies, pourquoi ?</h3>
+    <p>
+      C’est vrai, vous n’avez pas eu à cliquer sur un bloc qui recouvre la moitié de la page pour dire que vous êtes
+      d’accord avec le dépôt de cookies — même si vous ne savez pas ce que ça veut dire !
+    </p>
+    <p>
+      Rien d’exceptionnel, pas de passe-droit lié à un .gouv.fr. Nous respectons simplement la loi, qui dit que certains
+      outils de suivi d’audience, correctement configurés pour respecter la vie privée, sont exemptés d’autorisation
+      préalable.
+    </p>
+    <p>
+      Nous utilisons pour cela
+      <a href="https://matomo.org/" target="_blank" rel="noopener">Matomo</a>
+      , un outil
+      <a href="https://matomo.org/free-software/" target="_blank" rel="noopener">libre</a>
+      , paramétré pour être en conformité avec la
+      <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience" target="_blank" rel="noopener">
+        recommandation « Cookies »
+      </a>
+      de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc
+      impossible d’associer vos visites sur ce site à votre personne.
+    </p>
+    <h3>Je contribue à enrichir vos données, puis-je y accéder ?</h3>
+    <p>
+      Bien sûr ! Les statistiques d’usage de la majorité de nos produits, dont
+      <a href="https://beta.gouv.fr/" target="_blank" rel="noopener">beta.gouv.fr,</a>
+      sont disponibles en accès libre sur
+      <a
+        href="https://stats.beta.gouv.fr/index.php?module=CoreHome&action=index&idSite=95&period=day&date=yesterday#?period=day&date=yesterday&category=Dashboard_Dashboard&subcategory=1"
+      >
+        stats.beta.gouv.fr.
+      </a>
+    </p>
+  </div>
+</template>

--- a/frontend/src/views/PrivacyPolicy.vue
+++ b/frontend/src/views/PrivacyPolicy.vue
@@ -102,7 +102,8 @@
     <p>
       Les cookies de mesure d’audience, lorsque les données sont anonymisées, ne nécessitent pas de consentement. En
       l’occurrence, la plateforme utilise Matomo dans sa version anonymisée, vous pouvez néanmoins vous opposer au suivi
-      de votre navigation sur ce site web. Pour plus d’informations, voir la section « Cookies ».
+      de votre navigation sur ce site web. Pour plus d’informations, visitez
+      <router-link :to="{ name: 'CookiesInfo' }">notre page dédiée.</router-link>
     </p>
     <h2>Durée de conservation</h2>
     <DsfrTable
@@ -192,48 +193,5 @@
       no-caption
       :pagination="false"
     />
-    <h3>Cookies</h3>
-    <p>
-      Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour but de collecter des
-      informations relatives à votre navigation et de vous adresser des services adaptés à votre terminal (ordinateur,
-      mobile ou tablette).
-    </p>
-    <p>
-      Le site dépose des cookies de mesure d’audience (nombre de visites, pages consultées), respectant les conditions
-      d’exemption du consentement de l’internaute définies par la recommandation « Cookies » de la Commission nationale
-      informatique et libertés (CNIL). Cela signifie, notamment, que ces cookies ne servent qu’à la production de
-      statistiques anonymes et ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
-    </p>
-    <p>
-      Nous utilisons pour cela Matomo, un outil de mesure d’audience web libre, paramétré pour être en conformité avec
-      la recommandation « Cookies » de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant
-      d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.
-    </p>
-    <p>Il convient d’indiquer que :</p>
-    <ul>
-      <li>Les données collectées ne sont pas recoupées avec d’autres traitements</li>
-      <li>Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites</li>
-    </ul>
-    <p>
-      À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en
-      utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer
-      11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
-    </p>
-    <p>
-      Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et
-      des Libertés (CNIL) :
-    </p>
-    <ul>
-      <li>
-        <a href="https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi" target="_blank" rel="noopener">
-          Cookies & traceurs : que dit la loi ?
-        </a>
-      </li>
-      <li>
-        <a href="https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser" target="_blank" rel="noopener">
-          Cookies : les outils pour les maîtriser
-        </a>
-      </li>
-    </ul>
   </div>
 </template>

--- a/frontend/src/views/PrivacyPolicy.vue
+++ b/frontend/src/views/PrivacyPolicy.vue
@@ -1,0 +1,239 @@
+<template>
+  <div class="fr-container pb-10">
+    <DsfrBreadcrumb :links="[{ to: '/', text: 'Accueil' }, { text: 'Politique de confidentialité' }]" />
+    <h1>Politique de confidentialité</h1>
+    <h2>Traitement des données à caractère personnel</h2>
+    <p>
+      La présente plateforme Compl'Alim est à l’initiative du Ministère de l’agriculture (Direction Générale de
+      l’Alimentation), qui est responsable de traitement des données à caractère personnel collectées par la plateforme.
+    </p>
+    <h2>Finalités</h2>
+    <p>
+      La plateforme numérique Compl'Alim est destinée à accompagner les acteurs du secteur des compléments alimentaires
+      (ci-après abrégé « CA ») en facilitant la constitution des dossiers de déclaration.
+    </p>
+    <p>Elle permet ainsi d’effectuer :</p>
+    <ul>
+      <li>la constitution d’un dossier permettant de déclarer un CA,</li>
+      <li>la modification d’un produit ou son arrêt de commercialisation</li>
+      <li>la recherche sur l’état d’un produit par le grand public</li>
+    </ul>
+    <p>La recherche sur les ingrédients et les différents CA est disponible avec et sans création de compte.</p>
+    <h2>Données à caractère personnel traitées</h2>
+    <p>La plateforme peut traiter les données à caractère personnel suivantes :</p>
+    <ul>
+      <li>
+        Données relatives à la création d’un compte : Certaines données sont obligatoires pour la création du compte :
+        nom, prénom, nom d'utilisateur, adresse e-mail. L’utilisateur doit également fournir un ensemble de données
+        relatives à l’établissement concerné (par exemple SIRET), qui ne sont pas considérées comme des données à
+        caractère personnel.
+      </li>
+      <li>
+        Données de contact : Certaines données sont collectées lors de la prise de contact avec les différents acteurs
+        professionnels, notamment l’adresse-mail et de manière facultative le prénom et le nom de la personne de
+        contact.
+      </li>
+      <li>Données d’hébergeur.</li>
+      <li>Cookies : Des cookies sont utilisés dans un objectif d’amélioration de la plateforme.</li>
+    </ul>
+    <h2>Bases juridiques des traitements de données</h2>
+    <p>Les données traitées à l’occasion de ces traitements ont plusieurs fondements juridiques :</p>
+    <ul>
+      <li>
+        Le consentement de la personne concernée pour une ou plusieurs finalités spécifiques au sens de l’article 6-a du
+        RGPD et en application de l’article 5(3) de la directive 2002/58/CE modifiée ;
+      </li>
+      <li>
+        L’exécution d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le
+        responsable de traitement au sens de l’article 6-e du RPGD ;
+      </li>
+      <li>
+        Une obligation légale à laquelle le responsable de traitement est soumis au sens de l'article 6-c du RGPD.
+      </li>
+    </ul>
+    <p>Ces fondements sont précisés ci-dessous :</p>
+    <h3>a) Données relatives à la création d’un compte</h3>
+    <p>
+      Ce traitement est nécessaire à l’exécution d’une mission d’intérêt public ou relevant de l’exercice de l’autorité
+      publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du
+      Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du
+      traitement des données à caractère personnel et à la libre circulation de ces données.
+    </p>
+    <h3>b) Données de contact</h3>
+    <p>
+      Ce traitement est nécessaire à l’exécution d’une mission d’intérêt public ou relevant de l’exercice de l’autorité
+      publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du
+      Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du
+      traitement des données à caractère personnel et à la libre circulation de ces données.
+    </p>
+    <h3>c) Données d’hébergeur ou de connexion</h3>
+    <p>
+      Ce traitement est nécessaire au respect d'une obligation légale à laquelle le responsable de traitement est soumis
+      au sens de l'article 6-c du Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à
+      la protection des personnes physiques à l'égard du traitement des données à caractère personnel et à la libre
+      circulation de ces données.
+    </p>
+    <p>
+      L'obligation légale est posée par la loi LCEN n° 2004-575 du 21 juin 2004 pour la confiance dans l'économie
+      numérique et par l’article 1 du décret n° 2021-1363 du 20 octobre 2021.
+    </p>
+    <h3>d) Cookies</h3>
+    <p>
+      En application de l’article 5(3) de la directive 2002/58/CE modifiée concernant le traitement des données à
+      caractère personnel et la protection de la vie privée dans le secteur des communications électroniques, transposée
+      à l’article 83 de la loi n°78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, les
+      traceurs ou cookies suivent deux régimes distincts.
+    </p>
+    <p>
+      Les cookies strictement nécessaires au service ou n’ayant pas pour finalité exclusive de faciliter la
+      communication par voie électronique sont dispensés de consentement préalable au titre de l’article 83 de la loi
+      n°78-17 du 6 janvier 1978.
+    </p>
+    <p>
+      Les cookies n’étant pas strictement nécessaires au service ou n’ayant pas pour finalité exclusive de faciliter la
+      communication par voie électronique doivent être consenti par l’utilisateur.
+    </p>
+    <p>
+      Ce consentement de la personne concernée pour une ou plusieurs finalités spécifiques constitue une base légale au
+      sens du RGPD et doit être entendu au sens de l'article 6-a du Règlement (UE) 2016/679 du Parlement européen et du
+      Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l'égard du traitement des données à
+      caractère personnel et à la libre circulation de ces données.
+    </p>
+    <p>
+      Les cookies de mesure d’audience, lorsque les données sont anonymisées, ne nécessitent pas de consentement. En
+      l’occurrence, la plateforme utilise Matomo dans sa version anonymisée, vous pouvez néanmoins vous opposer au suivi
+      de votre navigation sur ce site web. Pour plus d’informations, voir la section « Cookies ».
+    </p>
+    <h2>Durée de conservation</h2>
+    <DsfrTable
+      title="Durée de conservation"
+      :rows="[
+        ['Données relatives à la création d’un compte', '4 ans à compter de la dernière utilisation du compte.'],
+        ['Données de contact', '4 ans à compter de la dernière prise de contact.'],
+        ['Données d’hébergeur', '1 an, conformément au le décret n° 2021-1363 du 20 octobre 2021.'],
+        [
+          'Cookies',
+          'Dès le retrait du consentement ou dans un délai de 13 mois, conformément aux recommandations de la CNIL',
+        ],
+      ]"
+      no-caption
+      :pagination="false"
+    />
+    <h2>Droit des personnes concernées</h2>
+    <p>
+      Selon la loi n° 78-17 du 6 janvier 1978 relative à l'informatique aux fichiers et aux libertés, vous disposez des
+      droits suivants concernant vos données à caractère personnel :
+    </p>
+    <ul>
+      <li>Droit d’information et droit d’accès aux données ;</li>
+      <li>Droit de rectification et le cas échéant de suppression des données ;</li>
+      <li>
+        Droit au retrait du consentement en matière de cookies uniquement s’il y a des cookies nécessitant le
+        consentement.
+      </li>
+    </ul>
+    <p>
+      Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête – ces
+      éléments sont indispensables pour nous permettre de retrouver votre recherche –à l’adresse suivante :
+    </p>
+    <p>
+      Par voie numérique :
+      <a href="mailto:compl-alim@beta.gouv.fr">compl-alim@beta.gouv.fr</a>
+    </p>
+    <p>Par voie postale :</p>
+    <address>
+      <p>
+        Ministère de l’Agriculture et de la Souveraineté Alimentaire
+        <br />
+        Direction Générale de l’Alimentation
+        <br />
+        Hôtel de Villeroy, 78, rue de Varenne; Paris 7e
+      </p>
+    </address>
+    <p>
+      En raison de l’obligation de sécurité et de confidentialité dans le traitement des données à caractère personnel
+      qui incombe au responsable de traitement, votre demande ne sera traitée que si vous apportez la preuve de votre
+      identité. Pour vous aider dans votre démarche,
+      <a href="https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces" target="_blank" rel="noopener">
+        un modèle de courrier élaboré par la Cnil
+      </a>
+      est à votre disposition.
+    </p>
+    <p>
+      Vous avez la possibilité de vous opposer à un traitement de vos données personnelles. Pour vous aider dans votre
+      démarche,
+      <a
+        href="https://www.cnil.fr/fr/modele/courrier/rectifier-des-donnees-inexactes-obsoletes-ou-perimees"
+        target="_blank"
+        rel="noopener"
+      >
+        un modèle de courrier élaboré par la Cnil
+      </a>
+      est à votre disposition.
+    </p>
+    <p>
+      Le responsable de traitement s’engage à répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à
+      compter de la réception de votre demande.
+    </p>
+
+    <h2>Destinataires des données</h2>
+    <p>
+      Le responsable de traitement s’engage à ce que les données soient traitées par les seules personnes autorisées.
+    </p>
+    <h3>Sous-traitants</h3>
+    <p>
+      Certaines des données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de
+      traitement s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de
+      conditions strictes de confidentialité, d’usage et de protection des données.
+    </p>
+    <DsfrTable
+      title="Sous-traitants"
+      :rows="[['Clever Cloud', 'France', 'Hébergement', 'https://www.clever-cloud.com/fr/privacy-policy']]"
+      no-caption
+      :pagination="false"
+    />
+    <h3>Cookies</h3>
+    <p>
+      Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour but de collecter des
+      informations relatives à votre navigation et de vous adresser des services adaptés à votre terminal (ordinateur,
+      mobile ou tablette).
+    </p>
+    <p>
+      Le site dépose des cookies de mesure d’audience (nombre de visites, pages consultées), respectant les conditions
+      d’exemption du consentement de l’internaute définies par la recommandation « Cookies » de la Commission nationale
+      informatique et libertés (CNIL). Cela signifie, notamment, que ces cookies ne servent qu’à la production de
+      statistiques anonymes et ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
+    </p>
+    <p>
+      Nous utilisons pour cela Matomo, un outil de mesure d’audience web libre, paramétré pour être en conformité avec
+      la recommandation « Cookies » de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant
+      d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.
+    </p>
+    <p>Il convient d’indiquer que :</p>
+    <ul>
+      <li>Les données collectées ne sont pas recoupées avec d’autres traitements</li>
+      <li>Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites</li>
+    </ul>
+    <p>
+      À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en
+      utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer
+      11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
+    </p>
+    <p>
+      Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et
+      des Libertés (CNIL) :
+    </p>
+    <ul>
+      <li>
+        <a href="https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi" target="_blank" rel="noopener">
+          Cookies & traceurs : que dit la loi ?
+        </a>
+      </li>
+      <li>
+        <a href="https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser" target="_blank" rel="noopener">
+          Cookies : les outils pour les maîtriser
+        </a>
+      </li>
+    </ul>
+  </div>
+</template>


### PR DESCRIPTION
## Pages Vue

Une page et une route a été créé pour chaque document. Le corps a été pris de ces [documents Notion](https://www.notion.so/betagouv-dinum/Pages-footer-CGU-mentions-l-gales-8589ecc1fd4f4894a6bd6b9253862492).

## Footer

En plus de l'ajout des pages, on trouve désormais ces liens dans le footer :

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/654994b4-29b9-48c7-abec-d81c2114ccfb)
