### PR TITLE
Intégration avec Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ SECURE= 'False' si on développe en local, 'True' autrement
 ENVIRONMENT= Optionnel - si cette variable est remplie un badge sera visible dans l'application et l'admin changera. Les options sont : `dev` | `staging` | `demo` | `prod`
 NEWSLETTER_BREVO_LIST_ID= L'ID de la newsletter de Brevo (précedemment Send In Blue)
 BREVO_API_KEY= La clé API de Brevo
+SENTRY_DSN= (optionnel) Le Data Source Name pour Sentry. Peut être vide.
 ```
 
 ## Lancer l'application en mode développement

--- a/icare/settings.py
+++ b/icare/settings.py
@@ -286,7 +286,7 @@ CKEDITOR_CONFIGS = {
 
 # Sentry
 SENTRY_DSN = os.getenv("SENTRY_DSN")
-if not SENTRY_DSN:
+if SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         integrations=[

--- a/icare/settings.py
+++ b/icare/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 from pathlib import Path
 import sys
 import os
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 import dotenv  # noqa
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -281,3 +283,16 @@ CKEDITOR_CONFIGS = {
         "removePlugins": ",".join(["image"]),
     }
 }
+
+# Sentry
+SENTRY_DSN = os.getenv("SENTRY_DSN")
+if not SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[
+            DjangoIntegration(),
+        ],
+        traces_sample_rate=1.0,
+        send_default_pii=False,
+        send_client_reports=False,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,7 @@ PyYAML==6.0.1
 requests==2.31.0
 requests-mock==1.11.0
 s3transfer==0.10.0
+sentry-sdk==1.40.2
 sib-api-v3-sdk==7.6.0
 six==1.16.0
 sqlparse==0.4.4


### PR DESCRIPTION
## Sentry SDK

On utilise le [SDK officiel avec l'intégration Django](https://docs.sentry.io/platforms/python/integrations/django/). On l'active seulement lors qu'on n'est pas en mode DEBUG.

## Test

En créant une division entre zéro pour test, on voit bien les erreurs arriver dans Sentry : 

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/aa4e179f-e81f-42f0-b03e-b90e5775beb6)

