### PR TITLE
Gestion du scroll dans le router Vue

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -68,6 +68,11 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
+  scrollBehavior(to, from, savedPosition) {
+    if (to.hash) return { el: to.hash }
+    if (savedPosition) return savedPosition
+    return { top: 0 }
+  },
 })
 
 function chooseAuthorisedRoute(to, from, next, store) {


### PR DESCRIPTION
Afin de ne pas rester dans la même position scroll lors qu'on change de route, cette PR gère le positionnement de la page dans trois cas différents :

- Lors qu'on spécifie un hash dans la route (par exemple lors qu'on veut targetter un élément particulier dans la page), on retourne `{ el: to.hash }` pour indiquer au router d'aller à cet élément
- Lors qu'on fait back ou forward et on veut retourner dans la position qu'on avait précédemment (c'est le comportement natif des navigateurs). Pour ceci on utilise le `savedPosition`
- Finalement, en règle générale on scroll vers le haut lors qu'on change de route

Plus d'informations sur la gestion du scroll par ici : https://router.vuejs.org/guide/advanced/scroll-behavior