### PR TITLE
Page 404

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -7,6 +7,7 @@ import BlogPost from "@/views/BlogPost"
 import SearchResults from "@/views/SearchResults"
 import ElementView from "@/views/ElementView"
 import ProducerForm from "@/views/ProducerForm"
+import NotFound from "@/views/NotFound"
 
 const routes = [
   {
@@ -62,6 +63,11 @@ const routes = [
     meta: {
       authenticationRequired: true,
     },
+  },
+  {
+    path: "/:catchAll(.*)",
+    component: NotFound,
+    name: "NotFound",
   },
 ]
 

--- a/frontend/src/views/NotFound.vue
+++ b/frontend/src/views/NotFound.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="fr-container py-8">
+    <DsfrErrorPage
+      title="Page non trouvée"
+      subtitle="Erreur 404"
+      description="La page que vous cherchez n’existe pas ou l’url est erronée."
+      class="!p-0"
+    />
+    <router-link :to="{ name: 'BlogsHome' }" class="fr-btn fr-btn--md mt-0 mb-8">Page d'accueil</router-link>
+  </div>
+</template>


### PR DESCRIPTION
Cette PR met en place la route catch-all coté Vue. Une page reprend très simplement le composant 404 du DSFR pour éviter les exceptions front-end. 

Par la suite on la fera sûrement évoluer pour l'adapter plus à notre produit avec les suggestions de @JenniferStephan. (Le composant aujourd'hui est très perfectible, surtout pour les petites écrans)

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/66178c93-878d-4935-aa8d-68f897a51170)
