### PR TITLE
Ajout du devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,11 @@
         "ms-python.python",
         "ms-python.vscode-pylance",
         "ms-python.black-formatter",
-        "tamasfe.even-better-toml"
+        "ms-python.pylint",
+        "esbenp.prettier-vscode",
+        "tamasfe.even-better-toml",
+        "vue.volar",
+        "ban.spellright"
       ],
       "settings": {
         "workbench.colorCustomizations": {
@@ -21,14 +25,17 @@
   },
   "dockerComposeFile": "docker-compose.yml",
   "features": {
-    "ghcr.io/ddahan/feature-starter/custom_bashrc": {}
+    "ghcr.io/ddahan/feature-starter/custom_bashrc": {},
+    "ghcr.io/devcontainers/features/node": {
+      "version": "lts"
+    }
   },
   "forwardPorts": [
     8000,
     5432
   ],
   "name": "💊 compl'alim",
-  "onCreateCommand": "pip install -r requirements.txt && pip install pre-commit",
+  "onCreateCommand": "pip install -r requirements.txt && pip install pre-commit && cd frontend && npm install",
   "portsAttributes": {
     "5432": {
       "label": "PostgreSQL",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,12 +15,7 @@
         "vue.volar",
         "ban.spellright"
       ],
-      "settings": {
-        "workbench.colorCustomizations": {
-          "titleBar.activeBackground": "#000091",
-          "titleBar.activeForeground": "#ffffff"
-        }
-      }
+      "settings": {}
     }
   },
   "dockerComposeFile": "docker-compose.yml",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+    "name": "💊 compl'alim",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "srv_django",
+    "workspaceFolder": "/workspace",
+    "containerEnv": {
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONBREAKPOINT": "ipdb.set_trace"
+    },
+    "forwardPorts": [
+        8000, // django server
+        5432 // postgres
+    ],
+    "portsAttributes": {
+        "8000": {
+            "label": "Django",
+            "onAutoForward": "notify"
+        },
+        "5432": {
+            "label": "PostgreSQL",
+            "onAutoForward": "silent"
+        }
+    },
+    "onCreateCommand": "pip install -r requirements.txt",
+    "features": {
+        // TODO: feature node 20 + npm (or new image)
+        "ghcr.io/ddahan/feature-starter/custom_bashrc": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-python.black-formatter",
+                "tamasfe.even-better-toml"
+            ],
+            "settings": {} // defined at workspace level
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,40 +1,45 @@
 {
-    "name": "💊 compl'alim",
-    "dockerComposeFile": "docker-compose.yml",
-    "service": "srv_django",
-    "workspaceFolder": "/workspace",
-    "containerEnv": {
-        "PYTHONUNBUFFERED": "1",
-        "PYTHONBREAKPOINT": "ipdb.set_trace"
-    },
-    "forwardPorts": [
-        8000, // django server
-        5432 // postgres
-    ],
-    "portsAttributes": {
-        "8000": {
-            "label": "Django",
-            "onAutoForward": "notify"
-        },
-        "5432": {
-            "label": "PostgreSQL",
-            "onAutoForward": "silent"
+  "containerEnv": {
+    "PYTHONBREAKPOINT": "ipdb.set_trace",
+    "PYTHONUNBUFFERED": "1"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.black-formatter",
+        "tamasfe.even-better-toml"
+      ],
+      "settings": {
+        "workbench.colorCustomizations": {
+          "titleBar.activeBackground": "#000091",
+          "titleBar.activeForeground": "#ffffff"
         }
-    },
-    "onCreateCommand": "pip install -r requirements.txt",
-    "features": {
-        // TODO: feature node 20 + npm (or new image)
-        "ghcr.io/ddahan/feature-starter/custom_bashrc": {}
-    },
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "ms-python.python",
-                "ms-python.vscode-pylance",
-                "ms-python.black-formatter",
-                "tamasfe.even-better-toml"
-            ],
-            "settings": {} // defined at workspace level
-        }
+      }
     }
+  },
+  "dockerComposeFile": "docker-compose.yml",
+  "features": {
+    "ghcr.io/ddahan/feature-starter/custom_bashrc": {}
+  },
+  "forwardPorts": [
+    8000,
+    5432
+  ],
+  "name": "💊 compl'alim",
+  "onCreateCommand": "pip install -r requirements.txt && pip install pre-commit",
+  "portsAttributes": {
+    "5432": {
+      "label": "PostgreSQL",
+      "onAutoForward": "silent"
+    },
+    "8000": {
+      "label": "Django",
+      "onAutoForward": "notify"
+    }
+  },
+  "postCreateCommand": "pre-commit install",
+  "service": "srv_django",
+  "workspaceFolder": "/workspace"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "containerEnv": {
-    "PYTHONBREAKPOINT": "ipdb.set_trace",
+    "PYTHONBREAKPOINT": "pdb.set_trace",
     "PYTHONUNBUFFERED": "1"
   },
   "customizations": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+
+services:
+
+  srv_django:
+    container_name: "complalim_ctn_django"
+    # vars are injected at runtime, so no need to specify env_var value here.
+    image: 'python:3.11.0-bookworm'
+    volumes:
+      - ..:/workspaces:delegated
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+    expose:
+      - 8000
+
+  srv_postgres:
+    container_name: "complalim_ctn_postgres"
+    environment:
+      - POSTGRES_DB=icare
+      - POSTGRES_USER=myuser
+      - POSTGRES_PASSWORD=mypassword
+    image: 'postgres:15-bookworm'
+    restart: unless-stopped
+    volumes:
+      - postgres-data-complalim:/var/lib/postgresql/data
+    expose:
+      - 5432
+
+volumes:
+  postgres-data-complalim:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   srv_django:
     container_name: "complalim_ctn_django"
     # vars are injected at runtime, so no need to specify env_var value here.
-    image: "3.11-bookworm"
+    image: "python:3.11-bookworm"
     volumes:
       - ..:/workspaces:delegated
     # Overrides default command so things don't shut down after the process ends.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   srv_django:
     container_name: "complalim_ctn_django"
     # vars are injected at runtime, so no need to specify env_var value here.
-    image: 'python:3.11.0-bookworm'
+    image: "3.11-bookworm"
     volumes:
       - ..:/workspaces:delegated
     # Overrides default command so things don't shut down after the process ends.
@@ -19,7 +19,7 @@ services:
       - POSTGRES_DB=icare
       - POSTGRES_USER=myuser
       - POSTGRES_PASSWORD=mypassword
-    image: 'postgres:15-bookworm'
+    image: "postgres:15-bookworm"
     restart: unless-stopped
     volumes:
       - postgres-data-complalim:/var/lib/postgresql/data

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,17 @@
 {
   "files.exclude": {
-    "**/__pycache__": true
-},
-  "spellright.language": ["fr_FR (modern)"],
-  "spellright.documentTypes": ["latex", "plaintext", "markdown"],
+    "**/__pycache__": true,
+    "**/node_modules": true
+  },
+  "editor.formatOnSave": true,
+  "spellright.language": [
+    "fr_FR (modern)"
+  ],
+  "spellright.documentTypes": [
+    "latex",
+    "plaintext",
+    "markdown"
+  ],
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.wrappingIndent": "indent",
@@ -20,6 +28,7 @@
   "[markdown]": {
     "editor.formatOnSave": false
   },
+  "css.lint.unknownAtRules": "ignore",
   "prettier.enable": true,
   "prettier.prettierPath": "",
   "prettier.configPath": "./frontend/.prettierrc",
@@ -27,7 +36,12 @@
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
   },
-  "pylint.args": ["--load-plugins=pylint_django", "--rcfile", "${workspaceRoot}/.pylintrc"],
-  "black-formatter.args": ["--line-length=119"],
-  "black-formatter.path": ["${workspaceRoot}/venv/bin/black"]
+  "pylint.args": [
+    "--load-plugins=pylint_django",
+    "--rcfile",
+    "${workspaceFolder}/.pylintrc"
+  ],
+  "black-formatter.args": [
+    "--line-length=119"
+  ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,15 @@
 {
+  "files.insertFinalNewline": true,
+  "files.eol": "\n",
   "files.exclude": {
     "**/__pycache__": true,
     "**/node_modules": true
   },
   "editor.formatOnSave": true,
+  "workbench.colorCustomizations": {
+    "titleBar.activeBackground": "#000091",
+    "titleBar.activeForeground": "#ffffff"
+  },
   "spellright.language": [
     "fr_FR (modern)"
   ],
@@ -32,7 +38,6 @@
   "prettier.enable": true,
   "prettier.prettierPath": "",
   "prettier.configPath": "./frontend/.prettierrc",
-  "files.eol": "\n",
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "files.exclude": {
+    "**/__pycache__": true
+},
   "spellright.language": ["fr_FR (modern)"],
   "spellright.documentTypes": ["latex", "plaintext", "markdown"],
   "[javascript]": {

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Il existe 2 méthodes distinctes d'installation pour ce projet :
 
 #### À installer localement
 
-- [Python3](https://www.python.org/downloads/) (de préference 3.8)
+- [Python3](https://www.python.org/downloads/) (version 3.11)
 - [pip](https://pip.pypa.io/en/stable/installing/) (souvent installé avec Python)
 - [vitrualenv](https://virtualenv.pypa.io/en/stable/installation.html)
-- [Node et npm](https://nodejs.org/en/download/)
-- [Postgres](https://www.postgresql.org/download/)
+- [Node et npm](https://nodejs.org/en/download/) (version 20 LTS)
+- [Postgres](https://www.postgresql.org/download/) (version 15)
 - [pre-commit](https://pypi.org/project/pre-commit/)
 
 #### Création d'un environnement Python3 virtualenv
@@ -39,8 +39,6 @@ pip install -r requirements.txt
 ```
 
 #### Installer les dépendances du frontend
-
-On utilise les dernires versions LTS de `node` et `npm`.
 
 L'application frontend se trouve sous `/frontend`. Pour installer les dépendances :
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Compléments Alimentaires
 
-Projet en construction
+_Projet en construction_
 
-### À installer localement
+## Installation du projet
+
+Il existe 2 méthodes distinctes d'installation pour ce projet :
+1) l'installation manuelle classique
+2) l'installation automatique via un [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) (nécessite Docker et VS Code)
+
+
+### Installation manuelle classique (_méthode 1_)
+
+
+#### À installer localement
 
 - [Python3](https://www.python.org/downloads/) (de préference 3.8)
 - [pip](https://pip.pypa.io/en/stable/installing/) (souvent installé avec Python)
@@ -11,7 +21,7 @@ Projet en construction
 - [Postgres](https://www.postgresql.org/download/)
 - [pre-commit](https://pypi.org/project/pre-commit/)
 
-### Création d'un environnement Python3 virtualenv
+#### Création d'un environnement Python3 virtualenv
 
 Pour commencer, c'est recommandé de créer un environnement virtuel avec Python3.
 
@@ -20,7 +30,7 @@ virtualenv -p python3 venv
 source ./venv/bin/activate
 ```
 
-### Installer les dépendances du backend
+#### Installer les dépendances du backend
 
 Les dépendances du backend se trouvent dans `requirements.txt`. Pour les installer :
 
@@ -28,7 +38,7 @@ Les dépendances du backend se trouvent dans `requirements.txt`. Pour les instal
 pip install -r requirements.txt
 ```
 
-### Installer les dépendances du frontend
+#### Installer les dépendances du frontend
 
 On utilise les dernires versions LTS de `node` et `npm`.
 
@@ -39,7 +49,7 @@ cd frontend
 npm install
 ```
 
-### Créer la base de données
+#### Créer la base de données
 
 Par exemple, pour utiliser une base de données nommée _icare_ :
 
@@ -53,13 +63,34 @@ sudo su postgres
 postgres=# create user <DB_USER> createdb password <DB_PASSWORD>;
 ```
 
-Ensuite, pour créer les différents modèles Django dans la base de données :
+#### Pre-commit
 
-```
-python manage.py migrate
-```
+On utilise l'outil [`pre-commit`](https://pre-commit.com/) pour effectuer des vérifications automatiques
+avant chaque commit. Cela permet par exemple de linter les code Python, Javascript et HTML.
 
-### Compléter les variables d'environnement
+Pour pouvoir l'utiliser, il faut installer `pre-commit` (en général plutôt de manière globable que dans
+l'environnement virtuel) : `pip install pre-commit`.
+
+Puis l'activer : `pre-commit install`.
+
+Les vérifications seront ensuite effectuées avant chaque commit. Attention, lorsqu'une vérification `fail`,
+le commit est annulé. Il faut donc que toutes les vérifications passent pour que le commit soit pris en
+compte. Si exceptionnellement vous voulez commiter malgré qu'une vérification ne passe pas, c'est possible
+avec `git commit -m 'my message' --no-verify`.
+
+
+### Installation automatique via un devcontainer (_méthode 2_)
+
+- Installer [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- Installer l'extension [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) dans VS Code
+- Dans VS Code, lancer la commande `Clone Repository in Container Volume` et suivre les instructions. Le container va alors être créé.
+- Une fois le container créé, si une icône de chargement reste présente sur l'icône des extensions dans le menu gauche (bug VS Code), lancer la commande `Reload Window` pour régler le soucis.
+
+## Configuration du projet
+
+_À suivre peu importe la méthode d'installation choisie_
+
+#### Compléter les variables d'environnement
 
 L'application utilise [python-dotenv](https://pypi.org/project/python-dotenv/), vous pouvez donc créer un fichier `.env` à la racine du projet avec ces variables définies :
 
@@ -86,7 +117,13 @@ BREVO_API_KEY= La clé API de Brevo
 MATOMO_ID (optionnel)= L'ID pour le suivi avec Matomo. Compl-alim utilise l'ID 95 pour la prod, en local c'est mieux de le laisser vide
 ```
 
-## Lancer l'application en mode développement
+#### Créer les différents modèles Django dans la base de données
+
+```
+python manage.py migrate
+```
+
+## Lancement de l'application en mode développement
 
 Pour le développement il faudra avoir deux terminales ouvertes : une pour l'application Django, et une autre pour l'application VueJS.
 
@@ -109,22 +146,9 @@ npm run serve
 
 Une fois la compilation finie des deux côtés, l'application se trouvera sous [127.0.0.1:8000](127.0.0.1:8000) (le port Django, non pas celui de npm).
 
-### Pre-commit
+## Lancement des tests
 
-On utilise l'outil [`pre-commit`](https://pre-commit.com/) pour effectuer des vérifications automatiques
-avant chaque commit. Cela permet par exemple de linter les code Python, Javascript et HTML.
-
-Pour pouvoir l'utiliser, il faut installer `pre-commit` (en général plutôt de manière globable que dans
-l'environnement virtuel) : `pip install pre-commit`.
-
-Puis l'activer : `pre-commit install`.
-
-Les vérifications seront ensuite effectuées avant chaque commit. Attention, lorsqu'une vérification `fail`,
-le commit est annulé. Il faut donc que toutes les vérifications passent pour que le commit soit pris en
-compte. Si exceptionnellement vous voulez commiter malgré qu'une vérification ne passe pas, c'est possible
-avec `git commit -m 'my message' --no-verify`.
-
-## Lancer les tests pour l'application Django
+### Lancer les tests Django
 
 La commande pour lancer les tests Django est :
 
@@ -134,7 +158,7 @@ python manage.py test
 
 Sur VSCode, ces tests peuvent être debuggés avec la configuration "Python: Tests", présente sur le menu "Run".
 
-## Lancer les tests pour l'application VueJS
+### Lancer les tests VueJS
 
 Il faut d'abord se placer sur "/frontend", ensuite la commande pour lancer les tests VueJS est :
 
@@ -143,7 +167,9 @@ cd frontend
 npm run test
 ```
 
-## Creation d'un superuser
+## Création / import de données initiales
+
+#### Creation d'un superuser
 
 Afin de pouvoir s'identifier dans le backoffice (sous /admin), il est nécessaire de créer un utilisateur admin avec tous les droits. Pour ce faire, vous pouvez en console lancer :
 
@@ -151,7 +177,7 @@ Afin de pouvoir s'identifier dans le backoffice (sous /admin), il est nécessair
 python manage.py createsuperuser
 ```
 
-## Import de données dans les tables ingrédient
+#### Import de données dans les tables ingrédient
 
 Pour pouvoir tester l'application et le backoffice avec des données réelles, il est nécessaire d'importer des données. Pour cela :
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ sudo su postgres
 postgres=# create user <DB_USER> createdb password <DB_PASSWORD>;
 ```
 
+Ensuite, pour créer les différents modèles Django dans la base de données :
+
+```
+python manage.py migrate
+```
+
 ### Compléter les variables d'environnement
 
 L'application utilise [python-dotenv](https://pypi.org/project/python-dotenv/), vous pouvez donc créer un fichier `.env` à la racine du projet avec ces variables définies :


### PR DESCRIPTION
Cette PR introduit un 2e moyen d'installer le projet (l'utilisation des devcontainers) ayant pour avantages :
- D'automatiser les différentes étapes de l'installation et donc d'installer le projet plus vite
- De fournir une installation uniforme entre les différents développeurs (dev/dev parity), même s'ils sont sur différents OS.
- D'aider à la dev/prod parity en ayant les versions de dev déclarées dans le projet (plutôt qu'au cas par cas sur les machines des différents développeurs)


**A vérifier dans la review**
- Quelques settings ont du être modifiés pour l'occasion. Attention notamment à vérifier que Black fonctionne toujours. Si ce n'est plus le cas, installer [l'extension VS Code](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter) devrait régler le soucis.

Closes #183 