### PR TITLE
Remplacement de python-dotenv par dj-environ

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
           HOSTNAME: localhost
           STATICFILES_STORAGE: django.contrib.staticfiles.storage.StaticFilesStorage
           DEFAULT_FILE_STORAGE: django.core.files.storage.FileSystemStorage
-          DEFAULT_FROM_EMAIL: test@test.com
+          DEFAULT_FROM_EMAIL: test@example.com
           CONTACT_EMAIL: test@test.com
           EMAIL_BACKEND: django.core.mail.backends.dummy.EmailBackend
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,10 @@ jobs:
         env:
           DEBUG: True
           SECRET: test
+          FORCE_HTTPS: False
+          SECURE: False
           ALLOWED_HOSTS: localhost
+          ENVIRONMENT: ci
           DB_USER: postgres
           DB_PASSWORD: postgres
           DB_HOST: localhost
@@ -46,5 +49,8 @@ jobs:
           HOSTNAME: localhost
           STATICFILES_STORAGE: django.contrib.staticfiles.storage.StaticFilesStorage
           DEFAULT_FILE_STORAGE: django.core.files.storage.FileSystemStorage
+          DEFAULT_FROM_EMAIL: test@test.com
+          CONTACT_EMAIL: test@test.com
+          EMAIL_BACKEND: django.core.mail.backends.dummy.EmailBackend
         run: |
           python3 manage.py test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           STATICFILES_STORAGE: django.contrib.staticfiles.storage.StaticFilesStorage
           DEFAULT_FILE_STORAGE: django.core.files.storage.FileSystemStorage
           DEFAULT_FROM_EMAIL: test@example.com
-          CONTACT_EMAIL: test@test.com
+          CONTACT_EMAIL: test@example.com
           EMAIL_BACKEND: django.core.mail.backends.dummy.EmailBackend
         run: |
           python3 manage.py test

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ postgres=# create user <DB_USER> createdb password <DB_PASSWORD>;
 
 ### Compléter les variables d'environnement
 
-L'application utilise [python-dotenv](https://pypi.org/project/python-dotenv/), vous pouvez donc créer un fichier `.env` à la racine du projet avec ces variables définies :
+L'application utilise [django-environ](https://django-environ.readthedocs.io/en/latest/), vous pouvez donc créer un fichier `.env` à la racine du projet avec ces variables définies :
 
 ```
 SECRET= Le secret pour Django (vous pouvez le [générer ici](https://djecrety.ir/))

--- a/icare/settings.py
+++ b/icare/settings.py
@@ -39,7 +39,7 @@ PROTOCOL = "https" if SECURE else "http"
 DEBUG = env("DEBUG", cast=bool)
 AUTH_USER_MODEL = "data.User"
 
-ALLOWED_HOSTS = env("ALLOWED_HOSTS", cast=list)
+ALLOWED_HOSTS = [x.strip() for x in env("ALLOWED_HOSTS", cast=list)]
 
 ENVIRONMENT = env("ENVIRONMENT")
 

--- a/icare/settings.py
+++ b/icare/settings.py
@@ -169,7 +169,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # Media and file storage
 DEFAULT_FILE_STORAGE = env("DEFAULT_FILE_STORAGE")
 
-if DEFAULT_FILE_STORAGE == "FIXME":
+if DEFAULT_FILE_STORAGE == "storages.backends.s3.S3Storage":
     AWS_ACCESS_KEY_ID = env("CELLAR_KEY")
     AWS_SECRET_ACCESS_KEY = env("CELLAR_SECRET")
     AWS_S3_ENDPOINT_URL = env("CELLAR_HOST")
@@ -200,9 +200,9 @@ if DEBUG and EMAIL_BACKEND == "django.core.mail.backends.smtp.EmailBackend":
     EMAIL_HOST = "localhost"
     EMAIL_PORT = 1025
 
-NEWSLETTER_BREVO_LIST_ID = env("NEWSLETTER_BREVO_LIST_ID")
+NEWSLETTER_BREVO_LIST_ID = env("NEWSLETTER_BREVO_LIST_ID", default=None)
 ANYMAIL = {
-    "SENDINBLUE_API_KEY": env("BREVO_API_KEY", default=""),
+    "SENDINBLUE_API_KEY": env("BREVO_API_KEY", default=None),
 }
 
 # Rest framework
@@ -292,7 +292,7 @@ CKEDITOR_CONFIGS = {
 }
 
 # Analytics
-MATOMO_ID = env("MATOMO_ID", default="")
+MATOMO_ID = env("MATOMO_ID", default=None)
 
 # Sentry
 SENTRY_DSN = env("SENTRY_DSN", default=None)

--- a/icare/settings.py
+++ b/icare/settings.py
@@ -23,7 +23,7 @@ BASE_DIR = CONFIG_DIR.parent
 
 # Environment
 env = environ.Env()
-environ.Env.read_env(os.path.join(CONFIG_DIR, ".env"))
+environ.Env.read_env(os.path.join(BASE_DIR, ".env"))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/

--- a/icare/settings.py
+++ b/icare/settings.py
@@ -15,28 +15,33 @@ import sys
 import os
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
-import dotenv  # noqa
+import environ
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+CONFIG_DIR = Path(__file__).resolve().parent
+BASE_DIR = CONFIG_DIR.parent
+
+# Environment
+env = environ.Env()
+environ.Env.read_env(os.path.join(CONFIG_DIR, ".env"))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv("SECRET")
-SECURE_SSL_REDIRECT = os.getenv("FORCE_HTTPS") == "True"
+SECRET_KEY = env("SECRET")
+SECURE_SSL_REDIRECT = env("FORCE_HTTPS", cast=bool)
 
-SECURE = os.getenv("SECURE") == "True"
+SECURE = env("SECURE", cast=bool)
 PROTOCOL = "https" if SECURE else "http"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv("DEBUG") == "True"
+DEBUG = env("DEBUG", cast=bool)
 AUTH_USER_MODEL = "data.User"
 
-ALLOWED_HOSTS = [x.strip() for x in os.getenv("ALLOWED_HOSTS").split(",")]
+ALLOWED_HOSTS = env("ALLOWED_HOSTS", cast=list)
 
-ENVIRONMENT = os.getenv("ENVIRONMENT")
+ENVIRONMENT = env("ENVIRONMENT")
 
 # Application definition
 
@@ -108,11 +113,11 @@ WEBPACK_LOADER = {
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "USER": os.getenv("DB_USER"),
-        "NAME": os.getenv("DB_NAME"),
-        "PASSWORD": os.getenv("DB_PASSWORD"),
-        "HOST": os.getenv("DB_HOST"),
-        "PORT": os.getenv("DB_PORT"),
+        "USER": env("DB_USER"),
+        "NAME": env("DB_NAME"),
+        "PASSWORD": env("DB_PASSWORD"),
+        "HOST": env("DB_HOST"),
+        "PORT": env("DB_PORT"),
         "CONN_MAX_AGE": 60,
     }
 }
@@ -162,40 +167,42 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static/")
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Media and file storage
-AWS_ACCESS_KEY_ID = os.getenv("CELLAR_KEY")
-AWS_SECRET_ACCESS_KEY = os.getenv("CELLAR_SECRET")
-AWS_S3_ENDPOINT_URL = os.getenv("CELLAR_HOST")
-AWS_STORAGE_BUCKET_NAME = os.getenv("CELLAR_BUCKET_NAME")
-AWS_LOCATION = "media"
-AWS_QUERYSTRING_AUTH = False
+DEFAULT_FILE_STORAGE = env("DEFAULT_FILE_STORAGE")
 
-DEFAULT_FILE_STORAGE = os.getenv("DEFAULT_FILE_STORAGE")
-MEDIA_ROOT = os.getenv("MEDIA_ROOT", os.path.join(BASE_DIR, "media"))
+if DEFAULT_FILE_STORAGE == "FIXME":
+    AWS_ACCESS_KEY_ID = env("CELLAR_KEY")
+    AWS_SECRET_ACCESS_KEY = env("CELLAR_SECRET")
+    AWS_S3_ENDPOINT_URL = env("CELLAR_HOST")
+    AWS_STORAGE_BUCKET_NAME = env("CELLAR_BUCKET_NAME")
+    AWS_LOCATION = "media"
+    AWS_QUERYSTRING_AUTH = False
+
+MEDIA_ROOT = env("MEDIA_ROOT", default=os.path.join(BASE_DIR, "media"))
 MEDIA_URL = "/media/"
 
-STATICFILES_STORAGE = os.getenv("STATICFILES_STORAGE")
+STATICFILES_STORAGE = env("STATICFILES_STORAGE")
 SESSION_COOKIE_AGE = 31536000
-SESSION_COOKIE_SECURE = os.getenv("SECURE") == "True"
+SESSION_COOKIE_SECURE = env("SECURE", cast=bool)
 SESSION_COOKIE_HTTPONLY = True
 
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 LOGIN_URL = "/s-identifier"
 
-HOSTNAME = os.getenv("HOSTNAME")
+HOSTNAME = env("HOSTNAME")
 
 # Email
-DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL")
-CONTACT_EMAIL = os.getenv("CONTACT_EMAIL")
-EMAIL_BACKEND = os.getenv("EMAIL_BACKEND")
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL")
+CONTACT_EMAIL = env("CONTACT_EMAIL")
+EMAIL_BACKEND = env("EMAIL_BACKEND")
 
 if DEBUG and EMAIL_BACKEND == "django.core.mail.backends.smtp.EmailBackend":
     EMAIL_HOST = "localhost"
     EMAIL_PORT = 1025
 
-NEWSLETTER_BREVO_LIST_ID = os.getenv("NEWSLETTER_BREVO_LIST_ID")
+NEWSLETTER_BREVO_LIST_ID = env("NEWSLETTER_BREVO_LIST_ID")
 ANYMAIL = {
-    "SENDINBLUE_API_KEY": os.getenv("BREVO_API_KEY", ""),
+    "SENDINBLUE_API_KEY": env("BREVO_API_KEY", default=""),
 }
 
 # Rest framework
@@ -285,10 +292,10 @@ CKEDITOR_CONFIGS = {
 }
 
 # Analytics
-MATOMO_ID = os.getenv("MATOMO_ID", "")
+MATOMO_ID = env("MATOMO_ID", default="")
 
 # Sentry
-SENTRY_DSN = os.getenv("SENTRY_DSN")
+SENTRY_DSN = env("SENTRY_DSN", default=None)
 if SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,

--- a/manage.py
+++ b/manage.py
@@ -2,12 +2,10 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
-import dotenv
 
 
 def main():
     """Run administrative tasks."""
-    dotenv.load_dotenv()
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "icare.settings")
     try:
         from django.core.management import execute_from_command_line

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,6 @@ pylint==3.0.3
 pylint-django==2.5.5
 pylint-plugin-utils==0.8.2
 python-dateutil==2.8.2
-python-dotenv==1.0.1
 pytz==2023.3.post1
 PyYAML==6.0.1
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ distlib==0.3.8
 Django==5.0.2
 django-anymail==10.2
 django-ckeditor==6.7.0
+django-environ==0.11.2
 django-filter==23.5
 django-js-asset==2.2.0
 django-simple-history==3.4.0


### PR DESCRIPTION
Ce package : 
- permet de caster automatiquement les variables d'environnement, et éviter les potentielles erreurs avec les "truthy values" en Python
- simplifie la syntaxe
- aide à définir plus clairement quelles sont les variables obligatoires et celles optionnelles (si `default=None` non écrit, alors la variable est attendue)

**Code Review** 
- Dans un soucis d'homogénéité, toutes les variables optionnelles (comme `MATOMO_ID`) ont été set par défaut à `None`, alors que certaines étaient initialement à `""`. Vérifier que ça ne pose pas de soucis.

close https://github.com/betagouv/complements-alimentaires/issues/195