### PR TITLE
Enlève la requête inutile vers le logged user depuis le header

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, watch } from "vue"
+import { computed, watch } from "vue"
 import { useRootStore } from "@/stores/root"
 import { useRoute } from "vue-router"
 
@@ -45,9 +45,6 @@ const quickLinks = computed(function () {
       },
     ]
   else return []
-})
-onMounted(() => {
-  store.fetchLoggedUser()
 })
 watch(
   () => route.query["confirmation-deconnexion"],


### PR DESCRIPTION
Merci @pletelli de l'avoir vu :)

En effet le router maintenant s'assure que les données de l'utilisateur soient téléchargées avant de rendre possible l'accès à la route.