### PR TITLE
Mise à jour du launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,22 +9,18 @@
             "type": "debugpy",
             "request": "launch",
             "cwd": "${workspaceFolder}",
-            "python": "${command:python.interpreterPath}",
             "program": "${workspaceFolder}/manage.py",
             "args": [
                 "runserver"
             ],
-            "redirectOutput": true,
             "django": true,
-            "justMyCode": false,
-            "stopOnEntry": false
+            "justMyCode": false
         },
         {
             "name": "Python: Tests",
             "type": "debugpy",
             "request": "launch",
             "stopOnEntry": false,
-            "python": "${command:python.interpreterPath}",
             "program": "${workspaceFolder}/manage.py",
             "args": [
                 "test",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,20 +8,23 @@
             "name": "Python: Django",
             "type": "debugpy",
             "request": "launch",
-            "python": "${workspaceFolder}/venv/bin/python",
+            "cwd": "${workspaceFolder}",
+            "python": "${command:python.interpreterPath}",
             "program": "${workspaceFolder}/manage.py",
             "args": [
                 "runserver"
             ],
+            "redirectOutput": true,
             "django": true,
-            "justMyCode": false
+            "justMyCode": false,
+            "stopOnEntry": false
         },
         {
             "name": "Python: Tests",
             "type": "debugpy",
             "request": "launch",
             "stopOnEntry": false,
-            "python": "${workspaceFolder}/venv/bin/python",
+            "python": "${command:python.interpreterPath}",
             "program": "${workspaceFolder}/manage.py",
             "args": [
                 "test",


### PR DESCRIPTION
Permet de ne plus spécifier un path hard-codé pour le bin python.
Désormais, l'interpreter choisi sur VSCode sera celui utilisé. Pour en choisir un, vous pouvez faire Ctrl+Shift+P et taper :
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/15cdc2b6-4032-4b5e-8a4e-147354af922b)

Puis sélectionner celui de Poetry
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/fef34622-259d-4507-99ec-9f3980c12257)

Les commandes debug devraient fonctionner avec le bon path.