### PR TITLE
Autocomplete UI pour les éléments

### DIFF
--- a/frontend/src/components/ElementAutocomplete.vue
+++ b/frontend/src/components/ElementAutocomplete.vue
@@ -2,6 +2,7 @@
   <div ref="container" class="relative">
     <DsfrInput
       :model-value="modelValue"
+      @update:model-value="$emit('update:modelValue', $event)"
       v-bind="$attrs"
       :required="true"
       @focus="hasFocus = true"
@@ -47,14 +48,15 @@ const container = ref(undefined)
 const optionsList = ref(undefined)
 
 const props = defineProps({
-  modelValue: {
-    type: String,
-    default: "",
-  },
   options: {
     type: Array,
     default: () => [],
   },
+})
+
+defineModel({
+  type: String,
+  default: "",
 })
 
 const emit = defineEmits(["selected"])

--- a/frontend/src/components/ElementAutocomplete.vue
+++ b/frontend/src/components/ElementAutocomplete.vue
@@ -1,0 +1,168 @@
+<template>
+  <div ref="container" class="relative">
+    <DsfrInput
+      :model-value="modelValue"
+      v-bind="$attrs"
+      :required="true"
+      @focus="hasFocus = true"
+      @blur="hasFocus = false"
+      @keydown="checkKeyboardNav($event)"
+    />
+    <ul
+      v-show="displayOptions"
+      ref="optionsList"
+      class="list-none absolute m-0 right-0 z-1 left-0 bg-white box-shadow max-h-17 scroll pointer !p-0"
+      :class="{
+        'at-the-top': displayAtTheTop,
+        'z-10': true,
+      }"
+    >
+      <li
+        v-for="(option, i) of options"
+        :key="option"
+        class="list-item"
+        :class="{ 'active-option': activeOption === i }"
+        @mousedown="selectOption(option)"
+      >
+        <div class="p-2 pl-4 text-left flex">
+          <div class="self-center"><v-icon scale="0.85" class="mr-2" :name="getTypeIcon(option.objectType)" /></div>
+          <div>
+            <div>
+              <span class="font-bold">{{ option.autocompleteMatch }}</span>
+              <span v-if="option.autocompleteMatch !== option.name" class="ml-2">({{ option.name }})</span>
+            </div>
+            <div>{{ getType(option.objectType) }}</div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { computed, nextTick, ref, watch } from "vue"
+import { getTypeIcon } from "@/utils"
+
+const container = ref(undefined)
+const optionsList = ref(undefined)
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: "",
+  },
+  options: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+const emit = defineEmits(["selected"])
+const hasFocus = ref(false)
+const displayOptions = computed(() => hasFocus.value && !!props.options.length)
+
+function convertRemToPixels(rem) {
+  return rem * parseFloat(getComputedStyle(document.documentElement).fontSize)
+}
+
+function selectOption(option) {
+  emit("selected", option)
+}
+
+const displayAtTheTop = ref(false)
+
+watch(displayOptions, () => {
+  if (displayOptions.value) {
+    const posContainerY = container.value.offsetTop
+    const containerHeight = container.value.offsetHeight
+    const screenHeight = document.body.scrollHeight
+    const optionsHeight = convertRemToPixels(17)
+    const isTooLow = optionsHeight + posContainerY + containerHeight > screenHeight
+
+    displayAtTheTop.value = isTooLow
+  }
+})
+
+const activeOption = ref(-1)
+
+const isVisible = function (ele, container) {
+  const { bottom, height, top } = ele.getBoundingClientRect()
+  const containerRect = container.getBoundingClientRect()
+
+  return top <= containerRect.top ? containerRect.top - top <= height : bottom - containerRect.bottom <= height
+}
+
+function checkIfActiveOptionIsVisible() {
+  const activeLi = optionsList.value.querySelectorAll("li")[activeOption.value]
+  const isLiVisible = isVisible(activeLi, optionsList.value)
+  if (!isLiVisible) {
+    // Scroll to activeLi
+    activeLi.scrollIntoView({ behavior: "smooth" })
+  }
+}
+
+function moveToPreviousOption() {
+  const isFirst = activeOption.value <= 0
+  activeOption.value = isFirst ? props.options.length - 1 : activeOption.value - 1
+  nextTick().then(checkIfActiveOptionIsVisible)
+}
+
+function moveToNextOption() {
+  const isLast = activeOption.value >= props.options.length - 1
+  activeOption.value = isLast ? 0 : activeOption.value + 1
+  nextTick().then(checkIfActiveOptionIsVisible)
+}
+
+function checkKeyboardNav($event) {
+  if (["ArrowUp", "ArrowDown", "Enter"].includes($event.key)) {
+    $event.preventDefault()
+    if (!props.options.length) return
+  }
+  if ($event.key === "Enter") {
+    selectOption(props.options[activeOption.value])
+  } else if ($event.key === "ArrowUp") {
+    moveToPreviousOption()
+  } else if ($event.key === "ArrowDown") {
+    moveToNextOption()
+  }
+}
+
+const getType = (objectType) => {
+  const mapping = {
+    plant: "Plante",
+    microorganism: "Micro-organisme",
+    ingredient: "Ingredient",
+    substance: "Substance",
+  }
+  return mapping[objectType] || null
+}
+</script>
+
+<style scoped>
+.box-shadow {
+  box-shadow:
+    0px 16px 16px -16px rgba(0, 0, 0, 0.32),
+    0px 8px 16px rgba(0, 0, 0, 0.1);
+}
+
+.max-h-17 {
+  max-height: 17rem;
+}
+
+.scroll {
+  overflow: auto;
+}
+
+.at-the-top {
+  bottom: 2.8rem;
+  box-shadow:
+    0px -16px 16px -16px rgba(0, 0, 0, 0.32),
+    0px -8px 16px rgba(0, 0, 0, 0.1);
+}
+
+.list-item.active-option,
+.list-item:hover {
+  background-color: var(--blue-france-sun-113-625);
+  color: white;
+}
+</style>

--- a/frontend/src/components/ElementAutocomplete.vue
+++ b/frontend/src/components/ElementAutocomplete.vue
@@ -42,7 +42,7 @@
 
 <script setup>
 import { computed, nextTick, ref, watch } from "vue"
-import { getTypeIcon } from "@/utils"
+import { getTypeIcon, getType } from "@/utils"
 
 const container = ref(undefined)
 const optionsList = ref(undefined)
@@ -127,16 +127,6 @@ function checkKeyboardNav($event) {
   } else if ($event.key === "ArrowDown") {
     moveToNextOption()
   }
-}
-
-const getType = (objectType) => {
-  const mapping = {
-    plant: "Plante",
-    microorganism: "Micro-organisme",
-    ingredient: "Ingredient",
-    substance: "Substance",
-  }
-  return mapping[objectType] || null
 }
 </script>
 

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -64,6 +64,16 @@ export const getTypeIcon = (type) => {
   return mapping[type] || null
 }
 
+export const getType = (type) => {
+  const mapping = {
+    plant: "Plante",
+    microorganism: "Micro-organisme",
+    ingredient: "Ingredient",
+    substance: "Substance",
+  }
+  return mapping[type] || null
+}
+
 export const headers = {
   "X-CSRFToken": window.CSRF_TOKEN || "",
   "Content-Type": "application/json",

--- a/frontend/src/views/ProducerForm/CompositionStep.vue
+++ b/frontend/src/views/ProducerForm/CompositionStep.vue
@@ -4,27 +4,18 @@
     Ingrédients
   </h2>
 
-  <DsfrInputGroup class="max-w-md">
-    <DsfrInput
-      @keydown="onAutocompleteChange"
-      v-model="searchTerm"
-      label="Cherchez un ingrédient"
-      hint="Tapez au moins trois caractères pour démarrer la recherche"
-      label-visible
-    />
-    <div v-if="autocompleteResults.length > 0" class="absolute left-2 min-w-80 border rounded-sm z-10">
-      <button class="min-w-full" v-for="result in autocompleteResults" :key="result.id" @click="selectOption(result)">
-        <div class="p-2 bg-white hover:bg-blue-france-975 text-left flex">
-          <div class="self-center"><v-icon scale="0.85" class="mr-2" :name="getTypeIcon(result.objectType)" /></div>
-          <div>
-            <div class="font-bold">{{ result.name }}</div>
-            <div>{{ getType(result.objectType) }}</div>
-          </div>
-        </div>
-      </button>
-    </div>
-  </DsfrInputGroup>
-  <div v-if="chosenIngredients && chosenIngredients.length">
+  <ElementAutocomplete
+    v-model="searchTerm"
+    :options="autocompleteResults"
+    autocomplete="nothing"
+    label="Cherchez un ingrédient"
+    label-visible
+    class="max-w-md"
+    hint="Tapez au moins trois caractères pour démarrer la recherche"
+    @selected="selectOption"
+  />
+
+  <div v-if="chosenIngredients && chosenIngredients.length" class="mt-4">
     <div v-for="ingredient in chosenIngredients" :key="ingredient.id" class="p-4 border">
       <v-icon scale="0.85" class="mr-2" :name="getTypeIcon(ingredient.objectType)" />
       {{ ingredient.name }}
@@ -37,11 +28,12 @@
 </template>
 
 <script setup>
-import { ref } from "vue"
-import { headers, verifyResponse, getTypeIcon } from "@/utils"
+import { ref, watch } from "vue"
+import { useFetch } from "@vueuse/core"
+import { headers, getTypeIcon } from "@/utils"
+import ElementAutocomplete from "@/components/ElementAutocomplete.vue"
 
 const autocompleteResults = ref([])
-const loading = ref(false)
 const searchTerm = ref("")
 const chosenIngredients = ref([])
 
@@ -59,28 +51,17 @@ const selectOption = (result) => {
   autocompleteResults.value = []
 }
 
-// TODO : Should use a specific API for autocomplete
-const fetchSearchResults = () => {
-  const url = "/api/v1/search/"
-  const body = JSON.stringify({ search: searchTerm.value, limit: 6, offset: 0 })
-  loading.value = true
-  return fetch(url, { method: "POST", headers, body })
-    .then(verifyResponse)
-    .then((response) => (autocompleteResults.value = response.results))
-    .catch((e) => {
-      window.alert("Une erreur est survenue veuillez réessayer plus tard")
-      console.error(e)
-    })
-    .finally(() => (loading.value = false))
+const fetchSearchResults = async () => {
+  const body = { term: searchTerm.value }
+  const { error, data } = await useFetch("/api/v1/substances/autocomplete/", { headers }).post(body).json()
+
+  if (error.value) {
+    window.alert("Une erreur est survenue veuillez réessayer plus tard")
+    console.error(error.value)
+    return
+  }
+  autocompleteResults.value = data.value
 }
 
-const getType = (objectType) => {
-  const mapping = {
-    plant: "Plante",
-    microorganism: "Micro-organisme",
-    ingredient: "Ingredient",
-    substance: "Substance",
-  }
-  return mapping[objectType] || null
-}
+watch(searchTerm, onAutocompleteChange)
 </script>

--- a/frontend/src/views/ProducerForm/CompositionStep.vue
+++ b/frontend/src/views/ProducerForm/CompositionStep.vue
@@ -32,6 +32,7 @@ import { ref, watch } from "vue"
 import { useFetch } from "@vueuse/core"
 import { headers, getTypeIcon } from "@/utils"
 import ElementAutocomplete from "@/components/ElementAutocomplete.vue"
+import useToaster from "@/composables/use-toaster"
 
 const autocompleteResults = ref([])
 const searchTerm = ref("")
@@ -56,8 +57,12 @@ const fetchSearchResults = async () => {
   const { error, data } = await useFetch("/api/v1/substances/autocomplete/", { headers }).post(body).json()
 
   if (error.value) {
-    window.alert("Une erreur est survenue veuillez réessayer plus tard")
-    console.error(error.value)
+    useToaster().addMessage({
+      type: "error",
+      title: "Error",
+      description: "Une erreur avec la recherche est survenue, veuillez réessayer plus tard.",
+      id: "autocomplete-error",
+    })
     return
   }
   autocompleteResults.value = data.value

--- a/frontend/src/views/SearchResults/ResultCard.vue
+++ b/frontend/src/views/SearchResults/ResultCard.vue
@@ -16,21 +16,13 @@
 
 <script setup>
 import { computed } from "vue"
-import { getTypeIcon } from "@/utils"
+import { getTypeIcon, getType } from "@/utils"
 
 const props = defineProps({
   result: Object,
 })
 const icon = computed(() => getTypeIcon(props.result.objectType))
-const type = computed(() => {
-  const mapping = {
-    plant: "Plante",
-    microorganism: "Micro-organisme",
-    ingredient: "Ingredient",
-    substance: "Substance",
-  }
-  return mapping[props.result.objectType] || null
-})
+const type = computed(() => getType(props.result.objectType))
 const route = computed(() => {
   const urlComponent = `${props.result?.id}--${type.value?.toLowerCase()}--${props.result?.name}`
   return { name: "ElementView", params: { urlComponent } }


### PR DESCRIPTION
Closes #232 

## Approche
J'ai repris le code draft de l'[Autocomplete du DSFR](https://github.com/dnum-mi/vue-dsfr/blob/main/demo-app/components/FdrAutoComplete.vue) (merci @ddahan) comme élément de départ en faisant quelques modifications.

Dans un premier temps, ce composant est spécifiquement créé pour les objets de notre API. À terme, si on décide de le rendre plus générique (par ex car on a d'autres types d'autocompletes) on pourra rendre les `<li>` customisables avec un template slot. J'ai décidé de ne pas le faire tout de suite car on n'a pas encore le besoin et pour rester sur quelque chose de plus simple.

## Exemple de rendu

Élément de base :
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/5a99be86-c3a0-4319-a46c-1f781047c0f4)

Élément trouvé grâce a son synonyme (nom original en parenthèse) :
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/533929a7-27e3-4970-9ef1-7c1687a3573c)

## Autres
J'en ai profité pour changer l'appel à l'API en utilisant `useFetch`

## Différences avec  l'[Autocomplete du DSFR](https://github.com/dnum-mi/vue-dsfr/blob/main/demo-app/components/FdrAutoComplete.vue)
- Le rendu de chaque élément de la liste est plus complet, non seulement un string
- Le `model` est utilisé seulement pour le texte de l'autocomplete, et un nouvel event `selected` est émit lorsqu'un élément est sélectionné
- Quelques bugs mineurs ont été adressés 
