### PR TITLE
:lady_beetle: Fix du crash lors qu'on n'a pas explicitement sélectionné un élément

### DIFF
--- a/frontend/src/components/ElementAutocomplete.vue
+++ b/frontend/src/components/ElementAutocomplete.vue
@@ -123,7 +123,9 @@ function checkKeyboardNav($event) {
     if (!props.options.length) return
   }
   if ($event.key === "Enter") {
-    selectOption(props.options[activeOption.value])
+    // Prendre le premier élément si on n'a pas explicitement sélectionné un autre
+    const option = activeOption.value < 0 ? 0 : activeOption.value
+    selectOption(props.options[option])
   } else if ($event.key === "ArrowUp") {
     moveToPreviousOption()
   } else if ($event.key === "ArrowDown") {


### PR DESCRIPTION
Aujourd'hui, si on appuie sur "Enter" dans le champ autocomplete sans avoir explicitement utilisé les flêches pour choisir un élément, l'appli crash.

Le comportement devrait être de choisir le premier élément dans ce cas.

### Screencast du bug

[Screencast from 06-03-24 16:17:01.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/941e0a00-6494-4c42-823c-4f03b1eba5c6)

### Screencast avec le fix

[Screencast from 06-03-24 16:17:47.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/cf924327-78bb-4303-a689-b3008abece85)
