### PR TITLE
Étape pour les pièces jointes

### DIFF
--- a/frontend/src/views/ProducerFormPage/AttachmentStep.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentStep.vue
@@ -20,6 +20,7 @@
       v-for="file in payload.files.labels"
       :key="file.file"
       @remove="removeLabelFile"
+      hideTypeSelection
     />
   </div>
 
@@ -37,14 +38,13 @@
     />
   </DsfrInputGroup>
 
-  <div class="grid grid-cols-12">
+  <div class="grid grid-cols-12 gap-3">
     <FilePreview
       class="col-span-12 sm:col-span-6 md:col-span-4"
       :file="file"
       v-for="file in payload.files.others"
       :key="file.file"
       @remove="removeOtherFile"
-      showTypeSelection
     />
   </div>
 </template>
@@ -57,18 +57,22 @@ const payload = defineModel()
 const selectedLabelFile = ref(null)
 const selectedOtherFile = ref(null)
 
-const addLabelFiles = async (files) => addFiles(files, payload.value.files.labels, selectedLabelFile)
+const addLabelFiles = async (files) =>
+  addFiles(files, payload.value.files.labels, selectedLabelFile, { type: "Étiquetage" })
 const addOtherFiles = async (files) => addFiles(files, payload.value.files.others, selectedOtherFile)
 
 const removeLabelFile = (file) => removeFile(file, payload.value.files.labels)
 const removeOtherFile = (file) => removeFile(file, payload.value.files.others)
 
-const addFiles = async (files, container, resetModel) => {
+const addFiles = async (files, container, resetModel, defaultData) => {
   for (let i = 0; i < files.length; i++) {
     const base64 = await toBase64(files[i])
     container.push({
-      file: base64,
-      name: files[i].name,
+      ...{
+        file: base64,
+        name: files[i].name,
+      },
+      ...defaultData,
     })
   }
   resetModel.value = null

--- a/frontend/src/views/ProducerFormPage/AttachmentStep.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentStep.vue
@@ -19,6 +19,7 @@
       :file="file"
       v-for="file in payload.files.labels"
       :key="file.file"
+      @remove="removeLabelFile"
     />
   </div>
 
@@ -37,7 +38,14 @@
   </DsfrInputGroup>
 
   <div class="grid grid-cols-12">
-    <FilePreview v-for="file in payload.files.others" :key="file.file" />
+    <FilePreview
+      class="col-span-12 sm:col-span-6 md:col-span-4"
+      :file="file"
+      v-for="file in payload.files.others"
+      :key="file.file"
+      @remove="removeOtherFile"
+      showTypeSelection
+    />
   </div>
 </template>
 
@@ -52,6 +60,9 @@ const selectedOtherFile = ref(null)
 const addLabelFiles = async (files) => addFiles(files, payload.value.files.labels, selectedLabelFile)
 const addOtherFiles = async (files) => addFiles(files, payload.value.files.others, selectedOtherFile)
 
+const removeLabelFile = (file) => removeFile(file, payload.value.files.labels)
+const removeOtherFile = (file) => removeFile(file, payload.value.files.others)
+
 const addFiles = async (files, container, resetModel) => {
   for (let i = 0; i < files.length; i++) {
     const base64 = await toBase64(files[i])
@@ -61,6 +72,11 @@ const addFiles = async (files, container, resetModel) => {
     })
   }
   resetModel.value = null
+}
+
+const removeFile = (file, container) => {
+  const index = container.indexOf(file)
+  container.splice(index, 1)
 }
 
 const toBase64 = (file) => {

--- a/frontend/src/views/ProducerFormPage/AttachmentStep.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentStep.vue
@@ -13,16 +13,7 @@
     />
   </DsfrInputGroup>
 
-  <div class="grid grid-cols-12 gap-3">
-    <FilePreview
-      class="col-span-12 sm:col-span-6 md:col-span-4"
-      :file="file"
-      v-for="file in payload.files.labels"
-      :key="file.file"
-      @remove="removeLabelFile"
-      hideTypeSelection
-    />
-  </div>
+  <FileGrid :files="payload.files.labels" @remove="removeLabelFile" hideTypeSelection />
 
   <h3 class="fr-h6 !mt-8">
     <v-icon class="mr-1" name="ri-attachment-2" />
@@ -38,20 +29,12 @@
     />
   </DsfrInputGroup>
 
-  <div class="grid grid-cols-12 gap-3">
-    <FilePreview
-      class="col-span-12 sm:col-span-6 md:col-span-4"
-      :file="file"
-      v-for="file in payload.files.others"
-      :key="file.file"
-      @remove="removeOtherFile"
-    />
-  </div>
+  <FileGrid :files="payload.files.others" @remove="removeOtherFile" />
 </template>
 
 <script setup>
 import { ref } from "vue"
-import FilePreview from "./FilePreview"
+import FileGrid from "./FileGrid"
 
 const payload = defineModel()
 const selectedLabelFile = ref(null)

--- a/frontend/src/views/ProducerFormPage/AttachmentStep.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentStep.vue
@@ -7,7 +7,7 @@
   <DsfrInputGroup>
     <DsfrFileUpload
       label="Merci d'ajouter au moins un fichier image ou PDF correspondant à l'étiquetage."
-      :acceptTypes="['image/jpeg, image/gif, image/png, application/pdf']"
+      :accept="['image/jpeg, image/gif, image/png, application/pdf']"
       @change="addLabelFiles"
       v-model="selectedLabelFile"
     />

--- a/frontend/src/views/ProducerFormPage/AttachmentStep.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentStep.vue
@@ -24,7 +24,7 @@
     />
   </div>
 
-  <h3 class="fr-h6 !mt-6">
+  <h3 class="fr-h6 !mt-8">
     <v-icon class="mr-1" name="ri-attachment-2" />
     Autres
   </h3>

--- a/frontend/src/views/ProducerFormPage/AttachmentStep.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentStep.vue
@@ -1,6 +1,74 @@
 <template>
-  <h2 class="fr-h6">
+  <h3 class="fr-h6">
+    <v-icon class="mr-1" name="ri-price-tag-2-fill"></v-icon>
+    Étiquetage
+  </h3>
+
+  <DsfrInputGroup>
+    <DsfrFileUpload
+      label="Merci d'ajouter au moins un fichier image ou PDF correspondant à l'étiquetage."
+      :acceptTypes="['image/jpeg, image/gif, image/png, application/pdf']"
+      @change="addLabelFiles"
+      v-model="selectedLabelFile"
+    />
+  </DsfrInputGroup>
+
+  <div class="grid grid-cols-12 gap-3">
+    <FilePreview
+      class="col-span-12 sm:col-span-6 md:col-span-4"
+      :file="file"
+      v-for="file in payload.files.labels"
+      :key="file.file"
+    />
+  </div>
+
+  <h3 class="fr-h6 !mt-6">
     <v-icon class="mr-1" name="ri-attachment-2" />
-    Pièces jointes
-  </h2>
+    Autres
+  </h3>
+
+  <DsfrInputGroup>
+    <DsfrFileUpload
+      label="Autres pièces que vous jugez nécessaires pour l'étude du dossier"
+      :acceptTypes="['image/jpeg, image/gif, image/png, application/pdf']"
+      @change="addOtherFiles"
+      v-model="selectedOtherFile"
+    />
+  </DsfrInputGroup>
+
+  <div class="grid grid-cols-12">
+    <FilePreview v-for="file in payload.files.others" :key="file.file" />
+  </div>
 </template>
+
+<script setup>
+import { ref } from "vue"
+import FilePreview from "./FilePreview"
+
+const payload = defineModel()
+const selectedLabelFile = ref(null)
+const selectedOtherFile = ref(null)
+
+const addLabelFiles = async (files) => addFiles(files, payload.value.files.labels, selectedLabelFile)
+const addOtherFiles = async (files) => addFiles(files, payload.value.files.others, selectedOtherFile)
+
+const addFiles = async (files, container, resetModel) => {
+  for (let i = 0; i < files.length; i++) {
+    const base64 = await toBase64(files[i])
+    container.push({
+      file: base64,
+      name: files[i].name,
+    })
+  }
+  resetModel.value = null
+}
+
+const toBase64 = (file) => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.readAsDataURL(file)
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = reject
+  })
+}
+</script>

--- a/frontend/src/views/ProducerFormPage/FileGrid.vue
+++ b/frontend/src/views/ProducerFormPage/FileGrid.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="grid grid-cols-12 gap-3">
+    <FilePreview
+      class="col-span-12 sm:col-span-6 md:col-span-4"
+      :file="file"
+      v-for="file in props.files"
+      :key="file.file"
+      @remove="(e) => $emit('remove', e)"
+      :hideTypeSelection="props.hideTypeSelection"
+    />
+  </div>
+</template>
+
+<script setup>
+import FilePreview from "./FilePreview"
+
+const props = defineProps({ files: Array, hideTypeSelection: Boolean })
+</script>

--- a/frontend/src/views/ProducerFormPage/FilePreview.vue
+++ b/frontend/src/views/ProducerFormPage/FilePreview.vue
@@ -5,6 +5,15 @@
       <img v-else :src="file.file" class="object-contain h-32" :alt="`Image téléchargée ${props.file.name}`" />
     </div>
     <div class="fr-text--sm grow !mb-0">{{ props.file.name }}</div>
+    <DsfrInputGroup class="max-w-sm" v-if="!hideTypeSelection">
+      <DsfrSelect
+        label="Type de document"
+        defaultUnselectedText=""
+        v-model="file.type"
+        :options="documentTypes"
+        :required="true"
+      />
+    </DsfrInputGroup>
     <div>
       <DsfrButton @click="$emit('remove', file)" label="Supprimer" secondary size="sm" />
     </div>
@@ -14,6 +23,18 @@
 <script setup>
 import { computed } from "vue"
 
-const props = defineProps({ file: Object, showTypeSelection: Boolean })
+const props = defineProps({ file: Object, hideTypeSelection: Boolean })
 const isPDF = computed(() => props.file.name.endsWith("pdf"))
+
+// TODO: À voir si on peut le mettre dans la base de données aussi
+const documentTypes = [
+  "Attestation d'une autorité compétente",
+  "Compléments info professionnel",
+  "Observations professionnel",
+  "Autre courrier du professionnel",
+  "Brouillon",
+  "Autre professionnel",
+  "Preuve règlementaire",
+  "Bulletin d'analyse",
+]
 </script>

--- a/frontend/src/views/ProducerFormPage/FilePreview.vue
+++ b/frontend/src/views/ProducerFormPage/FilePreview.vue
@@ -6,7 +6,7 @@
     </div>
     <div class="fr-text--sm grow !mb-0">{{ props.file.name }}</div>
     <div>
-      <DsfrButton label="Supprimer" secondary size="sm" />
+      <DsfrButton @click="$emit('remove', file)" label="Supprimer" secondary size="sm" />
     </div>
   </div>
 </template>
@@ -14,6 +14,6 @@
 <script setup>
 import { computed } from "vue"
 
-const props = defineProps({ file: Object })
+const props = defineProps({ file: Object, showTypeSelection: Boolean })
 const isPDF = computed(() => props.file.name.endsWith("pdf"))
 </script>

--- a/frontend/src/views/ProducerFormPage/FilePreview.vue
+++ b/frontend/src/views/ProducerFormPage/FilePreview.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="border p-4 flex flex-col gap-2">
-    <div class="-mx-4 -mt-4 h-32 bg-slate-200 flex justify-center items-center">
+    <div class="border-b -mx-4 -mt-4 h-32 bg-blue-france-975 flex justify-center items-center">
       <v-icon v-if="isPDF" scale="3" name="ri-file-text-line" />
       <img v-else :src="file.file" class="object-contain h-32" :alt="`Image téléchargée ${props.file.name}`" />
     </div>

--- a/frontend/src/views/ProducerFormPage/FilePreview.vue
+++ b/frontend/src/views/ProducerFormPage/FilePreview.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="border p-4 flex flex-col gap-2">
+    <div class="-mx-4 -mt-4 h-32 bg-slate-200 flex justify-center items-center">
+      <v-icon v-if="isPDF" scale="3" name="ri-file-text-line" />
+      <img v-else :src="file.file" class="object-contain h-32" :alt="`Image téléchargée ${props.file.name}`" />
+    </div>
+    <div class="fr-text--sm grow !mb-0">{{ props.file.name }}</div>
+    <div>
+      <DsfrButton label="Supprimer" secondary size="sm" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue"
+
+const props = defineProps({ file: Object })
+const isPDF = computed(() => props.file.name.endsWith("pdf"))
+</script>

--- a/frontend/src/views/ProducerFormPage/StepButtons.vue
+++ b/frontend/src/views/ProducerFormPage/StepButtons.vue
@@ -11,6 +11,7 @@
     <DsfrButton
       icon="ri-arrow-right-line"
       label="Suivant"
+      icon-right
       @click="$emit('next')"
       size="small"
       :disabled="disableNext"

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -37,6 +37,10 @@ const payload = ref({
   populations: [],
   elements: [],
   substances: [],
+  files: {
+    labels: [],
+    others: [],
+  },
 })
 
 const currentStep = ref(null)


### PR DESCRIPTION
## Pièces jointes

Aujourd'hui su téléicare un·e utilisateur·ice peut ajouter des pièces jointes dans sa demande. Une pièce jointe contenant l'étiquetage est obligatoire. Éventuellement d'autres pièces peuvent aussi être ajoutées (par exemple une preuve réglementaire, un bulletin d'analyse, etc). Ces pièces peuvent être soit images, soit documents PDF.

### Approche UX

Contrairement à téléicare, côté UI cette PR fait une différence claire entre les pièces jointes obligatoires (étiquetage) et celles facultatives en ayant deux blocs :

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/9e2c1ea0-87ea-4cc8-8711-13a4ddbddd81)

Le JSON contient cette information en _base64_ avec quelques metadata : 

```json
{
    "effects": [],
    "conditions": [],
    "populations": [],
    "elements": [],
    "substances": [],
    "files": {
        "labels": [
            {
                "file": "data:image/jpeg;base64,/9j/4W/+RX...",
                "name": "IMG_1450.JPG",
                "type": "Étiquetage"
            },
            {
                "file": "data:image/jpeg;base64,/9j/4W/+RX...",
                "name": "IMG_8980.JPG",
                "type": "Étiquetage"
            }
        ],
        "others": [
            {
                "file": "data:image/jpeg;base64,/9j/4W/+RX...",
                "name": "IMG_9098.JPG"
               "type": "Bulletin d'analyse"
            }
        ]
    }
}
```

### Comparaison avec téléicare
[Screencast from 08-03-24 08:01:45.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/a880b558-f4ab-4706-8b30-bfa4c4da1013)

 