### PR TITLE
Ajout d'un nouvel élément

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -2,7 +2,7 @@ from .blogpost import BlogPostSerializer  # noqa: F401
 from .user import LoggedUserSerializer  # noqa: F401
 from .webinar import WebinarSerializer  # noqa
 from .search_result import SearchResultSerializer  # noqa: F401
-from .plant import PlantSerializer  # noqa: F401
+from .plant import PlantSerializer, PlantPartSerializer  # noqa: F401
 from .ingredient import IngredientSerializer  # noqa: F401
 from .microorganism import MicroorganismSerializer  # noqa: F401
 from .substance import SubstanceSerializer, SubstanceShortSerializer  # noqa: F401

--- a/api/serializers/plant.py
+++ b/api/serializers/plant.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from data.models import Plant, PlantFamily, PlantSynonym, Part
+from data.models import Plant, PlantFamily, PlantSynonym, Part, PlantPart
 from .substance import SubstanceShortSerializer
 
 
@@ -13,6 +13,12 @@ class PlantFamilySerializer(serializers.ModelSerializer):
             "siccrf_id",
         )
         read_only_fields = fields
+
+
+class PlantPartSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PlantPart
+        fields = ("id", "name")
 
 
 class PartRelationSerializer(serializers.ModelSerializer):

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from rest_framework import status
-from data.factories import PlantFactory, IngredientFactory, MicroorganismFactory, SubstanceFactory
+from data.factories import PlantFactory, IngredientFactory, MicroorganismFactory, SubstanceFactory, PlantPartFactory
 
 
 class TestElementsApi(APITestCase):
@@ -40,3 +40,14 @@ class TestElementsApi(APITestCase):
 
         self.assertEqual(substance.name, body["name"])
         self.assertEqual(substance.id, body["id"])
+
+    def test_get_plant_parts(self):
+        part_1 = PlantPartFactory.create()
+        part_2 = PlantPartFactory.create()
+        response = self.client.get(reverse("plant_part_list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+
+        self.assertEqual(len(body), 2)
+        self.assertIsNotNone(filter(lambda x: x["id"] == part_1.id, body))
+        self.assertIsNotNone(filter(lambda x: x["id"] == part_2.id, body))

--- a/api/urls.py
+++ b/api/urls.py
@@ -11,6 +11,7 @@ urlpatterns = {
     path("webinars/", views.WebinarView.as_view(), name="webinar_list"),
     path("search/", views.SearchView.as_view(), name="search"),
     path("plants/<int:pk>", views.PlantRetrieveView.as_view(), name="single_plant"),
+    path("plantParts/", views.PlantPartListView.as_view(), name="plant_part_list"),
     path("ingredients/<int:pk>", views.IngredientRetrieveView.as_view(), name="single_ingredient"),
     path("microorganisms/<int:pk>", views.MicroorganismRetrieveView.as_view(), name="single_microorganism"),
     path("substances/<int:pk>", views.SubstanceRetrieveView.as_view(), name="single_substance"),

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -4,7 +4,7 @@ from .report_issue import ReportIssue  # noqa: F401
 from .user import LoggedUserView  # noqa: F401
 from .webinar import WebinarView  # noqa
 from .search import SearchView  # noqa: F401
-from .plant import PlantRetrieveView  # noqa: F401
+from .plant import PlantRetrieveView, PlantPartListView  # noqa: F401
 from .ingredient import IngredientRetrieveView  # noqa: F401
 from .microorganism import MicroorganismRetrieveView  # noqa: F401
 from .substance import SubstanceRetrieveView  # noqa: F401

--- a/api/views/plant.py
+++ b/api/views/plant.py
@@ -1,9 +1,15 @@
-from rest_framework.generics import RetrieveAPIView
-from data.models import Plant
-from api.serializers import PlantSerializer
+from rest_framework.generics import RetrieveAPIView, ListAPIView
+from data.models import Plant, PlantPart
+from api.serializers import PlantSerializer, PlantPartSerializer
 
 
 class PlantRetrieveView(RetrieveAPIView):
     model = Plant
     queryset = Plant.objects.filter(missing_import_data=False)
     serializer_class = PlantSerializer
+
+
+class PlantPartListView(ListAPIView):
+    model = PlantPart
+    queryset = PlantPart.objects.all()
+    serializer_class = PlantPartSerializer

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -140,3 +140,12 @@ export const RiFileTextLine = {
   height: 24,
   raw: '<path fill="none" d="M0 0h24v24H0z"/><path d="M21 8v12.993A1 1 0 0120.007 22H3.993A.993.993 0 013 21.008V2.992C3 2.455 3.449 2 4.002 2h10.995L21 8zm-2 1h-5V4H5v16h14V9zM8 7h3v2H8V7zm0 4h8v2H8v-2zm0 4h8v2H8v-2z"/>',
 }
+
+export const RiDropLine = {
+  name: "ri-drop-line",
+  minX: 0,
+  minY: 0,
+  width: 24,
+  height: 24,
+  raw: '<path fill="none" d="M0 0h24v24H0z"/><path d="M12 3.1L7.05 8.05a7 7 0 109.9 0L12 3.1zm0-2.828l6.364 6.364a9 9 0 11-12.728 0L12 .272z"/>',
+}

--- a/frontend/src/stores/root.js
+++ b/frontend/src/stores/root.js
@@ -8,6 +8,7 @@ export const useRootStore = defineStore("root", () => {
   const initialDataLoaded = ref(false)
   const populations = ref(null)
   const conditions = ref(null)
+  const plantParts = ref(null)
 
   const fetchInitialData = () => {
     return fetchLoggedUser().then(() => (initialDataLoaded.value = true))
@@ -30,6 +31,10 @@ export const useRootStore = defineStore("root", () => {
     const { data } = await useFetch("/api/v1/conditions/").json()
     conditions.value = data.value
   }
+  const fetchPlantParts = async () => {
+    const { data } = await useFetch("/api/v1/plantParts/").json()
+    plantParts.value = data.value
+  }
   return {
     loggedUser,
     initialDataLoaded,
@@ -37,6 +42,8 @@ export const useRootStore = defineStore("root", () => {
     fetchLoggedUser,
     fetchPopulations,
     fetchConditions,
+    fetchPlantParts,
+    plantParts,
     populations,
     conditions,
   }

--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -5,7 +5,7 @@ export const getTypeIcon = (type) => {
     ingredient: "ri-flask-line",
     substance: "ri-test-tube-line",
   }
-  return mapping[type] || null
+  return mapping[type] || "ri-drop-line"
 }
 
 export const getType = (type) => {
@@ -14,6 +14,9 @@ export const getType = (type) => {
     microorganism: "Micro-organisme",
     ingredient: "Ingredient",
     substance: "Substance",
+    nutrient: "Nutriment",
+    additive: "Additif",
+    aroma: "Arôme",
   }
   return mapping[type] || null
 }

--- a/frontend/src/views/ProducerFormPage/CompositionStep.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionStep.vue
@@ -3,19 +3,25 @@
     <v-icon class="mr-1" name="ri-flask-line" />
     Ingrédients
   </h2>
-
-  <ElementAutocomplete
-    v-model="searchTerm"
-    :options="autocompleteResults"
-    autocomplete="nothing"
-    label="Cherchez un ingrédient"
-    label-visible
-    class="max-w-md"
-    hint="Tapez au moins trois caractères pour démarrer la recherche"
-    @selected="selectOption"
-  />
-
-  <TransitionGroup mode="out-in" name="list" tag="div" class="mt-4 relative">
+  <div class="sm:flex gap-10 items-center">
+    <ElementAutocomplete
+      v-model="searchTerm"
+      :options="autocompleteResults"
+      autocomplete="nothing"
+      label="Cherchez un ingrédient"
+      label-visible
+      class="max-w-md grow"
+      hint="Tapez au moins trois caractères pour démarrer la recherche"
+      @selected="selectOption"
+    />
+    <div class="hidden sm:flex flex-col items-center">
+      <div class="border-l h-6"></div>
+      <div class="my-2">Ou</div>
+      <div class="border-l h-6"></div>
+    </div>
+    <div class="mt-4 sm:mt-0"><NewElementModal v-model="payload" /></div>
+  </div>
+  <TransitionGroup mode="out-in" name="list" tag="div" class="mt-8 relative">
     <ElementCard
       v-for="(element, index) in payload.elements"
       :key="`element-${element.id}`"
@@ -46,6 +52,7 @@ import { headers } from "@/utils/data-fetching"
 import ElementAutocomplete from "@/components/ElementAutocomplete.vue"
 import ElementCard from "./ElementCard.vue"
 import SubstancesTable from "./SubstancesTable.vue"
+import NewElementModal from "./NewElementModal.vue"
 import useToaster from "@/composables/use-toaster"
 
 const payload = defineModel()

--- a/frontend/src/views/ProducerFormPage/CompositionStep.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionStep.vue
@@ -19,7 +19,7 @@
       <div class="my-2">Ou</div>
       <div class="border-l h-6"></div>
     </div>
-    <div class="mt-4 sm:mt-0"><NewElementModal v-model="payload" /></div>
+    <div class="mt-4 sm:mt-0"><NewElementModal @add="addNewElement" /></div>
   </div>
   <TransitionGroup mode="out-in" name="list" tag="div" class="mt-8 relative">
     <ElementCard
@@ -70,6 +70,8 @@ const selectOption = async (result) => {
 
 const removeElement = (index) => payload.value.elements.splice(index, 1)
 const hasActiveElements = computed(() => payload.value.elements.some((x) => x.element.active))
+
+const addNewElement = (element) => console.log(element)
 
 const fetchAutocompleteResults = useDebounceFn(async () => {
   if (searchTerm.value.length < 3) {

--- a/frontend/src/views/ProducerFormPage/CompositionStep.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionStep.vue
@@ -71,7 +71,10 @@ const selectOption = async (result) => {
 const removeElement = (index) => payload.value.elements.splice(index, 1)
 const hasActiveElements = computed(() => payload.value.elements.some((x) => x.element.active))
 
-const addNewElement = (element) => console.log(element)
+const addNewElement = (element) => {
+  const item = { element: { ...element.value, ...{ active: true, new: true } } }
+  payload.value.elements.unshift(item)
+}
 
 const fetchAutocompleteResults = useDebounceFn(async () => {
   if (searchTerm.value.length < 3) {

--- a/frontend/src/views/ProducerFormPage/ElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/ElementCard.vue
@@ -2,7 +2,7 @@
   <div class="p-4 border shadow-md">
     <div class="sm:flex">
       <div class="flex">
-        <div :class="`mr-4 self-center justify-center rounded-full icon-${model.element.objectType} h-8 w-8 flex`">
+        <div :class="`mr-4 self-center justify-center rounded-full icon icon-${model.element.objectType} h-8 w-8 flex`">
           <v-icon class="self-center" fill="white" :name="getTypeIcon(model.element.objectType)" />
         </div>
         <div class="self-center">
@@ -85,8 +85,7 @@ const plantParts = computed(() => {
 const showFields = computed(
   () =>
     model.value.element.active &&
-    model.value.element.objectType !== "substance" &&
-    model.value.element.objectType !== "ingredient"
+    (model.value.element.objectType === "plant" || model.value.element.objectType === "microorganism")
 )
 
 // TODO: s'assurer que les unités utilisées sont les mêmes partout, et possiblement les mettre dans la base de données
@@ -136,16 +135,19 @@ const preparations = [
 </script>
 
 <style scoped>
-.icon-plant {
+.icon {
+  @apply bg-slate-600;
+}
+.icon.icon-plant {
   @apply bg-ca-plant;
 }
-.icon-microorganism {
+.icon.icon-microorganism {
   @apply bg-ca-microorganism;
 }
-.icon-substance {
+.icon.icon-substance {
   @apply bg-ca-substance;
 }
-.icon-ingredient {
+.icon.icon-ingredient {
   @apply bg-ca-ingredient;
 }
 </style>

--- a/frontend/src/views/ProducerFormPage/ElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/ElementCard.vue
@@ -13,6 +13,9 @@
           <div v-if="model.element.synonyms?.length">
             {{ model.element.synonyms.map((x) => x.name).join(", ") }}
           </div>
+          <div v-if="model.element.new" class="self-center mt-1">
+            <DsfrBadge label="Nouvel ingrédient" type="info" />
+          </div>
         </div>
       </div>
       <div class="flex grow">
@@ -67,12 +70,18 @@
 </template>
 
 <script setup>
+import { useRootStore } from "@/stores/root"
 import { computed, defineModel } from "vue"
 import { getTypeIcon, getType } from "@/utils/mappings"
 
 const model = defineModel()
+const store = useRootStore()
+defineEmits(["remove"])
 
-const plantParts = computed(() => model.value.element.plantParts.map((x) => ({ text: x.name, value: x.id })))
+const plantParts = computed(() => {
+  const parts = model.value.element.plantParts || store.plantParts
+  return parts.map((x) => ({ text: x.name, value: x.id }))
+})
 const showFields = computed(
   () =>
     model.value.element.active &&

--- a/frontend/src/views/ProducerFormPage/ElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/ElementCard.vue
@@ -26,7 +26,7 @@
             :label="model.element.active ? 'Actif' : 'Non actif'"
           />
         </div>
-        <DsfrButton secondary @click="$emit('remove', element)">Enlever</DsfrButton>
+        <div><DsfrButton secondary @click="$emit('remove', element)">Enlever</DsfrButton></div>
       </div>
     </div>
     <div v-if="showFields">

--- a/frontend/src/views/ProducerFormPage/ElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/ElementCard.vue
@@ -2,7 +2,7 @@
   <div class="p-4 border shadow-md">
     <div class="sm:flex">
       <div class="flex">
-        <div :class="`mr-4 self-center justify-center rounded-full icon icon-${model.element.objectType} h-8 w-8 flex`">
+        <div :class="`mr-4 self-center justify-center rounded-full icon icon-${model.element.objectType} size-8 flex`">
           <v-icon class="self-center" fill="white" :name="getTypeIcon(model.element.objectType)" />
         </div>
         <div class="self-center">

--- a/frontend/src/views/ProducerFormPage/NewElementModal.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementModal.vue
@@ -1,0 +1,19 @@
+<template>
+  <DsfrButton label="Créer un nouvel ingrédient" secondary size="sm" @click="opened = true" ref="modalOrigin" />
+  <DsfrModal ref="modal" @close="opened = false" :opened="opened">
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas varius tortor nibh, sit amet tempor nibh finibus
+      et. Aenean eu enim justo. Vestibulum aliquam hendrerit molestie. Mauris malesuada nisi sit amet augue accumsan
+      tincidunt. Maecenas tincidunt, velit ac porttitor pulvinar, tortor eros facilisis libero, vitae commodo nunc quam
+      et ligula. Ut nec ipsum sapien. Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer id nisi nec
+      nulla luctus lacinia non eu turpis. Etiam in ex imperdiet justo tincidunt egestas. Ut porttitor urna ac augue
+      cursus tincidunt sit amet sed orci.
+    </p>
+  </DsfrModal>
+</template>
+
+<script setup>
+import { ref } from "vue"
+
+const opened = ref(false)
+</script>

--- a/frontend/src/views/ProducerFormPage/NewElementModal.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementModal.vue
@@ -1,19 +1,113 @@
 <template>
   <DsfrButton label="Créer un nouvel ingrédient" secondary size="sm" @click="opened = true" ref="modalOrigin" />
-  <DsfrModal ref="modal" @close="opened = false" :opened="opened">
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas varius tortor nibh, sit amet tempor nibh finibus
-      et. Aenean eu enim justo. Vestibulum aliquam hendrerit molestie. Mauris malesuada nisi sit amet augue accumsan
-      tincidunt. Maecenas tincidunt, velit ac porttitor pulvinar, tortor eros facilisis libero, vitae commodo nunc quam
-      et ligula. Ut nec ipsum sapien. Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer id nisi nec
-      nulla luctus lacinia non eu turpis. Etiam in ex imperdiet justo tincidunt egestas. Ut porttitor urna ac augue
-      cursus tincidunt sit amet sed orci.
-    </p>
+  <DsfrModal :actions="actions" ref="modal" @close="close" :opened="opened" title="Nouvel ingrédient">
+    <DsfrInputGroup :error-message="firstErrorMsg(v$, 'objectType')">
+      <DsfrSelect
+        label="Quel type d'ingrédient souhaitez-vous créer ?"
+        v-model="model.objectType"
+        :options="types"
+        :required="true"
+      />
+    </DsfrInputGroup>
+
+    <template v-if="model.objectType">
+      <div v-if="model.objectType === 'plant'">
+        <!-- Note: Sur téléicare on a aussi « Nom vernaculaire ». à voir si on veut l'intégrer -->
+        <DsfrInputGroup :error-message="firstErrorMsg(v$, 'name')">
+          <DsfrInput label="Nom" v-model="model.name" label-visible :required="true" />
+        </DsfrInputGroup>
+      </div>
+
+      <div v-else-if="model.objectType === 'microorganism'">
+        <!-- Note: Sur téléicare on a « Genre » et « Espèce ». Par contre je n'ai pas trouvé l'espèce dans notre modèle -->
+        <DsfrInputGroup :error-message="firstErrorMsg(v$, 'name')">
+          <DsfrInput label="Nom" v-model="model.name" label-visible :required="true" />
+        </DsfrInputGroup>
+        <DsfrInputGroup :error-message="firstErrorMsg(v$, 'name')">
+          <DsfrInput label="Genre" v-model="model.genre" label-visible :required="true" />
+        </DsfrInputGroup>
+      </div>
+
+      <div v-else>
+        <DsfrInputGroup :error-message="firstErrorMsg(v$, 'name')">
+          <DsfrInput label="Libellé" v-model="model.name" label-visible :required="true" />
+        </DsfrInputGroup>
+      </div>
+
+      <DsfrInputGroup>
+        <DsfrInput is-textarea v-model="model.description" label-visible label="Description" />
+      </DsfrInputGroup>
+    </template>
   </DsfrModal>
 </template>
 
 <script setup>
-import { ref } from "vue"
+import { ref, watch, computed } from "vue"
+import { useVuelidate } from "@vuelidate/core"
+import { required, helpers } from "@vuelidate/validators"
+import { firstErrorMsg } from "@/utils/forms"
 
 const opened = ref(false)
+const model = ref({})
+const emit = defineEmits(["add"])
+
+const addElement = () => {
+  v$.value.$validate()
+  if (v$.value.$error) return
+  emit("add", model)
+  close()
+}
+
+const actions = [
+  {
+    label: "Ajouter",
+    onClick: addElement,
+  },
+]
+
+// Note : Sur téléicare on ne peux pas ajouter des substances directement
+const types = [
+  { value: "plant", text: "Plante" },
+  { value: "microorganism", text: "Micro-organisme" },
+  { value: "ingredient", text: "Ingredient" },
+  { value: "nutrient", text: "Nutriment" },
+  { value: "additive", text: "Additif" },
+  { value: "aroma", text: "Arôme" },
+]
+
+watch(
+  () => model.value.objectType,
+  () => {
+    const keysToClear = Object.keys(model.value).filter((key) => key !== "objectType")
+    keysToClear.forEach((key) => delete model.value[key])
+    v$.value.$reset()
+  }
+)
+
+const close = () => {
+  model.value = {}
+  opened.value = false
+}
+
+// Form validation
+
+const rules = computed(() => {
+  const formRules = {
+    objectType: { required: helpers.withMessage("Veuillez remplir le type d'ingrédient", required) },
+    name: { required: helpers.withMessage("Veuillez renseigner le nom de l'ingrédient", required) },
+  }
+  if (model.value.objectType === "microorganism")
+    formRules.genre = {
+      required: helpers.withMessage("Veuillez renseigner le genre du micro-organisme à ajouter", required),
+    }
+  return formRules
+})
+
+const v$ = useVuelidate(rules, model)
 </script>
+
+<style>
+.fr-input-group {
+  @apply mt-4;
+}
+</style>

--- a/frontend/src/views/ProducerFormPage/SubstancesTable.vue
+++ b/frontend/src/views/ProducerFormPage/SubstancesTable.vue
@@ -64,7 +64,7 @@ const activeElements = computed(() => payload.value.elements.filter((x) => x.ele
 
 const sourceElements = (substance) => {
   const sources = activeElements.value.filter(
-    (x) => x.element.objectType === "substance" || x.element.substances.indexOf(substance) > -1
+    (x) => x.element.objectType === "substance" || x.element.substances?.indexOf(substance) > -1
   )
   return sources.map((x) => x.element.name).join(", ")
 }

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -35,6 +35,7 @@ import { useRoute, useRouter } from "vue-router"
 const store = useRootStore()
 store.fetchConditions()
 store.fetchPopulations()
+store.fetchPlantParts()
 
 const payload = ref({
   effects: [],


### PR DESCRIPTION
## :microscope: Ajout d'un nouvel élément dans l'étape composition

Cette PR permet d'ajouter un nouvel élément non listé dans la télédéclaration. Je me suis basé sur le comportement actuel de téléicare, y compris les champs demandés (sauf ceux indiqués en note dans le code).

Aujourd'hui téléicare ne permet pas d'ajouter une substance ou d'assigner des substances aux éléments ajoutés manuellement. Donc, même si l'élément est désigné comme étant "actif" on n'aura pas de substances liées à celui-ci.

#### Ajout d'un endpoint API

Les plantes ajoutées manuellement n'auront pas des _parties de plante_ assignées. Sur téléicare on propose la totalité des parties de plantes pour une plante n'ayant pas de partie spécifiée. J'ai du donc ajouter un endpoint pour exposer toutes les parties de plantes qu'on a pour ce cas.

#### Demo
[Screencast from 14-03-24 11:58:13.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/5e661b68-94d1-4071-b443-13020dd5ccfb)

#### Out of scope
- Champ pour spécifier si l'ajout se fait suite à un délai de la réglementation (et donc est un élément autorisé en France) ou par principe d'équivalence avec un autre pays de l'Union Européenne (pi @JenniferStephan)
- Step additionnel pour demander les documents/preuves du principe d'équivalence avec un autre pays de l'UE
- Logique particulière pour les nouveaux types d'éléments (par ex ne pas rendre actifs les arômes)