### PR TITLE
Rend les `loggedUser` reactives

### DIFF
--- a/frontend/src/views/ElementPage/ReportIssueBlock.vue
+++ b/frontend/src/views/ElementPage/ReportIssueBlock.vue
@@ -35,17 +35,19 @@ import { headers } from "@/utils/data-fetching"
 import { firstErrorMsg } from "@/utils/forms"
 import useToaster from "@/composables/use-toaster"
 import { useRootStore } from "@/stores/root"
+import { storeToRefs } from "pinia"
 
 // Props
 const props = defineProps({ elementName: String })
 
 // Get potential existing user from root store to pre-fill email address
-const { loggedUser } = useRootStore()
+const store = useRootStore()
+const { loggedUser } = storeToRefs(store)
 
 // Form state & rules
 const getInitialState = () => ({
   name: "",
-  email: loggedUser ? loggedUser.email : "",
+  email: loggedUser.value ? loggedUser.value.email : "",
   elementName: props.elementName, // not used by the form validation itself, but make the payload building easier
 })
 

--- a/frontend/src/views/LandingPage/NewsletterBlock.vue
+++ b/frontend/src/views/LandingPage/NewsletterBlock.vue
@@ -27,12 +27,14 @@ import { errorRequiredEmail, firstErrorMsg } from "@/utils/forms"
 import { useFetch } from "@vueuse/core"
 import useToaster from "@/composables/use-toaster"
 import { useRootStore } from "@/stores/root"
+import { storeToRefs } from "pinia"
 
 // Get potential existing user from root store to pre-fill email address
-const { loggedUser } = useRootStore()
+const store = useRootStore()
+const { loggedUser } = storeToRefs(store)
 
 // Form state & rules
-const state = ref({ email: loggedUser ? loggedUser.email : "" })
+const state = ref({ email: loggedUser.value ? loggedUser.value.email : "" })
 
 const rules = {
   email: errorRequiredEmail,


### PR DESCRIPTION
Depuis qu'on a le login directement sur Vue, ce serait mieux d'avoir les réferences à `loggedUser` de la root store en mode réactif. Comme pour les props, on ne peut pas simplement destructurer à partir de `useRootStore`.

Plus d'info sur [la doc](https://pinia.vuejs.org/core-concepts/#Destructuring-from-a-Store).