### PR TITLE
Informations additionnelles des éléments ajoutés manuellement (Article 15 :fr:  et 16 :eu:)

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -15,4 +15,19 @@
     .gradient-dsfr {
         @apply bg-gradient-to-r from-blue-france-925 via-blue-france-850 via-30% to-transparent
     }
+    .icon {
+        @apply bg-slate-600;
+    }
+    .icon.icon-plant {
+        @apply bg-ca-plant;
+    }
+    .icon.icon-microorganism {
+        @apply bg-ca-microorganism;
+    }
+    .icon.icon-substance {
+        @apply bg-ca-substance;
+    }
+    .icon.icon-ingredient {
+        @apply bg-ca-ingredient;
+    }
 }

--- a/frontend/src/views/ProducerFormPage/ElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/ElementCard.vue
@@ -133,21 +133,3 @@ const preparations = [
   "Teinture",
 ]
 </script>
-
-<style scoped>
-.icon {
-  @apply bg-slate-600;
-}
-.icon.icon-plant {
-  @apply bg-ca-plant;
-}
-.icon.icon-microorganism {
-  @apply bg-ca-microorganism;
-}
-.icon.icon-substance {
-  @apply bg-ca-substance;
-}
-.icon.icon-ingredient {
-  @apply bg-ca-ingredient;
-}
-</style>

--- a/frontend/src/views/ProducerFormPage/NewElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementCard.vue
@@ -140,22 +140,3 @@ const additionReasons = [
   },
 ]
 </script>
-
-<!-- TODO : factor out -->
-<style scoped>
-.icon {
-  @apply bg-slate-600;
-}
-.icon.icon-plant {
-  @apply bg-ca-plant;
-}
-.icon.icon-microorganism {
-  @apply bg-ca-microorganism;
-}
-.icon.icon-substance {
-  @apply bg-ca-substance;
-}
-.icon.icon-ingredient {
-  @apply bg-ca-ingredient;
-}
-</style>

--- a/frontend/src/views/ProducerFormPage/NewElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementCard.vue
@@ -90,7 +90,6 @@ const authorisationOptions = [
   },
 ]
 const countries = [
-  { text: "France", value: "FR" },
   { text: "Allemagne", value: "DE" },
   { text: "Autriche", value: "AT" },
   { text: "Belgique", value: "BE" },

--- a/frontend/src/views/ProducerFormPage/NewElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementCard.vue
@@ -1,0 +1,161 @@
+<template>
+  <div class="p-4 border shadow-md">
+    <div class="flex">
+      <div :class="`mr-4 self-center justify-center rounded-full icon icon-${model.element.objectType} size-8 flex`">
+        <v-icon class="self-center" fill="white" :name="getTypeIcon(model.element.objectType)" />
+      </div>
+      <div class="self-center font-bold capitalize">
+        {{ model.element.name.toLowerCase() }}
+        <span class="uppercase text-gray-400 text-sm ml-2">{{ getType(model.element.objectType) }}</span>
+      </div>
+    </div>
+    <hr class="mt-4 pb-1" />
+    <DsfrInputGroup>
+      <DsfrRadioButtonSet
+        v-model="model.element.authorisationMode"
+        name="authorisationMode"
+        legend="Modalité d'autorisation"
+        :options="authorisationOptions"
+      ></DsfrRadioButtonSet>
+    </DsfrInputGroup>
+    <div v-if="model.element.authorisationMode === 'FR'">
+      <hr class="pb-1 -mt-3" />
+      <div class="">
+        <DsfrInputGroup>
+          <DsfrRadioButtonSet
+            v-model="model.element.frReason"
+            name="frReason"
+            legend="Raison de l'ajout manuel"
+            :options="additionReasons"
+          ></DsfrRadioButtonSet>
+        </DsfrInputGroup>
+        <DsfrInputGroup v-if="model.element.frReason === 'missing'">
+          <DsfrInput
+            v-model="model.frDetails"
+            label-visible
+            label="Information additionnelle"
+            is-textarea
+            hint="Veuillez saissir des informations susceptibles de permettre à l'administration de traiter votre demande"
+          />
+        </DsfrInputGroup>
+      </div>
+    </div>
+    <div v-if="model.element.authorisationMode === 'EU'">
+      <hr class="pb-1 -mt-3" />
+      <div class="grid grid-cols-12 gap-4">
+        <DsfrInputGroup class="col-span-12 md:col-span-3">
+          <DsfrSelect
+            label="Pays de référence"
+            defaultUnselectedText=""
+            v-model="model.referenceCountry"
+            :options="countries"
+            :required="true"
+          />
+        </DsfrInputGroup>
+        <div class="col-span-12 md:col-span-9">
+          <DsfrInputGroup>
+            <DsfrInput
+              v-model="model.euLegalSource"
+              label-visible
+              label="Source réglementaire"
+              is-textarea
+              hint="Veuillez préciser la référence exacte du texte réglementaire."
+            />
+          </DsfrInputGroup>
+          <DsfrInputGroup>
+            <DsfrInput
+              v-model="model.euApplicableRestrictions"
+              label-visible
+              label="Restrictions applicables"
+              is-textarea
+              :required="true"
+              hint="Saisissez ici toutes les informations relatives aux restrictions et qui seraient susceptibles de permettre à l'administration de traiter votre demande. Eviter, si possible, toute information directement ou indirectement nominative."
+            />
+          </DsfrInputGroup>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { getTypeIcon, getType } from "@/utils/mappings"
+const model = defineModel()
+const authorisationOptions = [
+  { label: "🇫🇷 Utilisable en France", value: "FR", hint: "Cet ingrédient est autorisé ou utilisable en France" },
+  {
+    label: "🇪🇺 Autorisé dans un État membre de l'UE ",
+    value: "EU",
+    hint: "Cet ingrédient n'est pas autorisée en France mais l'est dans un autre pays de l'UE (déclaré au titre de l'article 16 du décret 2006-352)",
+  },
+]
+const countries = [
+  { text: "France", value: "FR" },
+  { text: "Allemagne", value: "DE" },
+  { text: "Autriche", value: "AT" },
+  { text: "Belgique", value: "BE" },
+  { text: "Bulgarie", value: "BG" },
+  { text: "Chypre", value: "CY" },
+  { text: "Croatie", value: "HR" },
+  { text: "Danemark", value: "DK" },
+  { text: "Espagne", value: "ES" },
+  { text: "Estonie", value: "EE" },
+  { text: "Finlande", value: "FI" },
+  { text: "Grèce", value: "GR" },
+  { text: "Hongrie", value: "HU" },
+  { text: "Irlande", value: "IE" },
+  { text: "Irlande du Nord", value: "IEN" },
+  { text: "Islande", value: "IS" },
+  { text: "Italie", value: "IT" },
+  { text: "Lettonie", value: "LV" },
+  { text: "Liechtenstein", value: "LI" },
+  { text: "Lituanie", value: "LT" },
+  { text: "Luxembourg", value: "LU" },
+  { text: "Malte", value: "MT" },
+  { text: "Norvège", value: "NO" },
+  { text: "Pays-Bas", value: "NL" },
+  { text: "Pologne", value: "PL" },
+  { text: "Portugal", value: "PT" },
+  { text: "République Tchèque", value: "CZ" },
+  { text: "Roumanie", value: "RO" },
+  { text: "Slovaquie", value: "SK" },
+  { text: "Slovénie", value: "SI" },
+  { text: "Suède", value: "SE" },
+]
+const additionReasons = [
+  {
+    label: "Usage traditionnel",
+    value: "traditional-usage",
+    hint: "Demande d’autorisation simplifiée pour un ingŕedient à usage traditionnel (directive 2004/24/CE)",
+  },
+  {
+    label: "Novel Food",
+    value: "novel-food",
+    hint: "L'ingrédient fait partie de la liste novel food",
+  },
+  {
+    label: "Ingrédient absent en base de données",
+    value: "missing",
+    hint: "L'ingrédient est autorisé en France mais ne figure pas dans la base de données",
+  },
+]
+</script>
+
+<!-- TODO : factor out -->
+<style scoped>
+.icon {
+  @apply bg-slate-600;
+}
+.icon.icon-plant {
+  @apply bg-ca-plant;
+}
+.icon.icon-microorganism {
+  @apply bg-ca-microorganism;
+}
+.icon.icon-substance {
+  @apply bg-ca-substance;
+}
+.icon.icon-ingredient {
+  @apply bg-ca-ingredient;
+}
+</style>

--- a/frontend/src/views/ProducerFormPage/NewElementStep.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementStep.vue
@@ -1,0 +1,21 @@
+<template>
+  <h2 class="fr-h6">
+    <v-icon class="mr-1" name="ri-flask-line" />
+    Nouveaux ingrédients
+  </h2>
+  <p>
+    Vous avez ajoté les nouveaux ingrédients affichés ci-dessous. Des informations supplémentaires les concernant sont
+    requises.
+  </p>
+  <div>
+    <NewElementCard :key="index" v-for="(element, index) in newElements" v-model="newElements[index]" />
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue"
+import NewElementCard from "./NewElementCard"
+const payload = defineModel()
+
+const newElements = computed(() => payload.value.elements.filter((x) => x.element.new))
+</script>

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -29,6 +29,7 @@ import ProductStep from "./ProductStep"
 import CompositionStep from "./CompositionStep"
 import SummaryStep from "./SummaryStep"
 import AttachmentStep from "./AttachmentStep"
+import NewElementStep from "./NewElementStep"
 import StepButtons from "./StepButtons"
 import { useRoute, useRouter } from "vue-router"
 
@@ -49,21 +50,32 @@ const payload = ref({
   },
 })
 
+const hasNewElements = computed(() => payload.value.elements.some((x) => x.element.new))
+
 const currentStep = ref(null)
-const steps = ["Le produit", "La composition", "Pièces jointes", "Résumé"]
-const components = [ProductStep, CompositionStep, AttachmentStep, SummaryStep]
+const steps = computed(() => {
+  const baseSteps = ["Le produit", "La composition", "Pièces jointes", "Résumé"]
+  if (hasNewElements.value) baseSteps.splice(2, 0, "Nouveaux éléments")
+  return baseSteps
+})
+
+const components = computed(() => {
+  const baseComponents = [ProductStep, CompositionStep, AttachmentStep, SummaryStep]
+  if (hasNewElements.value) baseComponents.splice(2, 0, NewElementStep)
+  return baseComponents
+})
 
 const goForward = () => router.push({ query: { step: currentStep.value + 1 } })
 const goBackward = () => router.push({ query: { step: currentStep.value - 1 } })
 
 const disablePrevious = computed(() => currentStep.value === 1)
-const disableNext = computed(() => currentStep.value === steps.length)
+const disableNext = computed(() => currentStep.value === steps.value.length)
 
 const route = useRoute()
 const router = useRouter()
 
 const ensureStepInUrl = () => {
-  if (route.query.step && parseInt(route.query.step) >= 1 && parseInt(route.query.step) <= steps.length)
+  if (route.query.step && parseInt(route.query.step) >= 1 && parseInt(route.query.step) <= steps.value.length)
     currentStep.value = parseInt(route.query.step)
   else router.replace({ query: { step: 1 } })
 }


### PR DESCRIPTION
L'ajout d'un nouvel élément peut se faire dans deux cas réglementaires :

#### 1. :fr: Le cas français
C'est en "article 15", et c'est quand l'élément peut être utilisé en France. Il ne se trouve dans notre base car : 
- Notre base n'est pas à jour,
- C'est un novel food, ou
- C'est une plante dite d'usage traditionnel (exemple donnée lors du séminaire : le concombre n'était pas dans la DB)

#### 2. :eu: Le cas européen
C'est en "article 16", et c'est quand le ou la déclarant.e décide d'invoquer un principe d'équivalence avec un autre pays de l'Union Européenne. Dans ce cas, trois champs additionnels par élément ajouté doivent être renseignés.

### Fonctionnement
Cette PR ajoute une étape au parcours producteur pour isoler ces questions avec un step dedié. Pour chaque élément ajouté manuellement, on demande de quel modalité il s'agit (:fr: ou :eu:) ainsi que les champs additionnels qui en dépendent.

### Retours texte
Vu qu'il y a pas mal de texte spécifique, j'ai demandé un retour aux intras. Si pas de réponse on peut néanmoins mettre en ligne et ajouter le texte par la suite

### Démo 
[Screencast from 20-03-24 16:03:42.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/a9604a0c-295b-428c-96a8-be2886296cf1)
