### PR TITLE
Fix du bug du logged user `null`

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -53,8 +53,8 @@ const logOut = async () => {
   const { response } = await useFetch("/api/v1/logout/", { headers: headers() }).post()
   await handleError(response)
   if (response.value.ok) {
+    await router.replace({ name: "LandingPage" })
     await store.resetInitialData()
-    router.replace({ name: "LandingPage" })
     useToaster().addMessage({
       type: "success",
       title: "Vous êtes déconnecté",


### PR DESCRIPTION
Suite à la gestion de la déconnexion, une page qui utilise le `loggedUser` (car marqué comme nécessitant d'authentification dans le router) peut se trouver avec un objet `loggedUser` null pendant le temps de la navigation.

Exemple : 
[Screencast from 26-03-24 15:13:08.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/62934b4b-403c-4043-aa30-84a3d1ebabfe)

Nous devons donc attendre la navigation avant de supprimer les données de connexion via `resetInitialData` utilisant un _await_ ([doc de vue-router](https://router.vuejs.org/guide/advanced/navigation-failures) d'où vient l'inspi)