### PR TITLE
:lady_beetle: Hot fix : Ajout de `config` dans apps

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -66,6 +66,7 @@ THIRD_PARTY_APPS = [
 ]
 
 PROJECT_APPS = [
+    "config",
     "api",
     "data",
     "tokens",


### PR DESCRIPTION
Les management commands (et autres choses qu'on pourrait mettre au niveau de config comme templates, etc) ne sont pas accessibles par Django car `config` ne fait pas partie des applications. D'où les erreurs Clevercloud qui n'arrive pas à trouver la commande `buildnpm`.

```bash
2024-03-28T11:56:16+01:00 Build failed. Please check the logs above
2024-03-28T11:56:16+01:00 Unknown command: 'buildnpm'
2024-03-28T11:56:16+01:00 Type 'manage.py help' for usage. 
```