### PR TITLE
Retrait des warnings sur le server front

### DIFF
--- a/frontend/src/views/BlogHomePage.vue
+++ b/frontend/src/views/BlogHomePage.vue
@@ -92,13 +92,13 @@ if (Object.keys(route.query).length > 0) fetchCurrentPage()
 
 <style scoped>
 /* Affichage des deux premières lignes du corps de l'article */
-div >>> .fr-card__desc {
+div :deep(.fr-card__desc) {
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
-div >>> .fr-card__detail {
+div :deep(.fr-card__detail) {
   margin-bottom: 6px;
 }
 </style>

--- a/frontend/src/views/BlogPostPage.vue
+++ b/frontend/src/views/BlogPostPage.vue
@@ -54,7 +54,7 @@ watch(blogPost, (post) => {
 </script>
 
 <style scoped>
-#content >>> img {
+#content :deep(img) {
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
Utilisation de la nouvelle syntaxe https://vuejs.org/api/sfc-css-features.html#deep-selectors pour retirer ces warnings : 

<img width="525" alt="Screenshot 2024-03-28 at 13 51 45" src="https://github.com/betagouv/complements-alimentaires/assets/1933516/2b8325fd-83dc-4c97-9ea6-4e9e97244355">

### TODO
- Vérifier que ça ne casse rien (je vois pas trop de diff avec ou sans ces classes)