### PR TITLE
[FIX] sur l'édition de l'utilisateur

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -1,8 +1,7 @@
 from .blogpost import BlogPostSerializer  # noqa: F401
 from .user import (  # noqa: F401
-    LoggedUserSerializer,
+    UserSerializer,
     CreateUserSerializer,
-    EditUserSerializer,
     ChangePasswordSerializer,
 )
 from .webinar import WebinarSerializer  # noqa

--- a/api/serializers/user.py
+++ b/api/serializers/user.py
@@ -16,21 +16,13 @@ class BlogPostAuthor(serializers.ModelSerializer):
         )
 
 
-class BaseUserSerializer(serializers.ModelSerializer):
-    class Meta:
-        fields = ("username", "email", "last_name", "first_name")
-
-
-class LoggedUserSerializer(BaseUserSerializer):
-    roles = serializers.SerializerMethodField()
-
+class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = BaseUserSerializer.Meta.fields + (
-            "id",
-            "roles",
-        )
-        read_only_fields = fields
+        fields = ("id", "username", "email", "last_name", "first_name", "roles")
+
+    id = serializers.IntegerField(read_only=True)
+    roles = serializers.SerializerMethodField(read_only=True)
 
     def get_roles(self, obj):
         roles_data = []
@@ -54,15 +46,11 @@ class LoggedUserSerializer(BaseUserSerializer):
         return roles_data
 
 
-class CreateUserSerializer(BaseUserSerializer):
+class CreateUserSerializer(UserSerializer):
     class Meta:
         model = User
-        fields = BaseUserSerializer.Meta.fields + (
-            "id",
-            "password",
-        )
+        fields = UserSerializer.Meta.fields + ("password",)
 
-    id = serializers.IntegerField(read_only=True)
     password = serializers.CharField(
         write_only=True, required=True
     )  # empêche le retour du hash du mdp dans la réponse
@@ -75,12 +63,6 @@ class CreateUserSerializer(BaseUserSerializer):
     def create(self, validated_data):
         user = User.objects.create_user(**validated_data)
         return user
-
-
-class EditUserSerializer(BaseUserSerializer):
-    class Meta:
-        model = User
-        fields = BaseUserSerializer.Meta.fields
 
 
 class ChangePasswordSerializer(serializers.Serializer):

--- a/api/views/user.py
+++ b/api/views/user.py
@@ -16,10 +16,9 @@ from api.permissions import IsLoggedUser
 
 from api.exception_handling import ProjectAPIException
 from api.serializers import (
+    UserSerializer,
     ChangePasswordSerializer,
     CreateUserSerializer,
-    EditUserSerializer,
-    LoggedUserSerializer,
 )
 from tokens.models import MagicLinkToken, MagicLinkUsage
 
@@ -45,7 +44,7 @@ class LoggedUserView(APIView):
 
         user = request.user
         if user.is_active:
-            return Response(LoggedUserSerializer(user).data)
+            return Response(UserSerializer(user).data)
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
 
@@ -68,7 +67,7 @@ class UserUpdateDestroyView(RetrieveUpdateDestroyAPIView):
     """
 
     permission_classes = [IsLoggedUser]
-    serializer_class = EditUserSerializer
+    serializer_class = UserSerializer
     queryset = get_user_model().objects.active()
 
     @transaction.atomic


### PR DESCRIPTION
Suite au passage aux vues génériques dans la PR de modif des utilisateurs, la view `edit-user` utilisait un output serializer ne contenant plus les rôles de l'utilisateur. Or, cette response était utilisée pour l'injection dans le state du loggedUser côté front.

Afin de régler ça, cette PR utilise le même serializer pour toutes les views, avec 2 avantages :
- résoud le bug
- simplifie encore le code
