### PR TITLE
Ajout du fichier robots.txt

### DIFF
--- a/web/templates/robots.txt
+++ b/web/templates/robots.txt
@@ -1,0 +1,45 @@
+User-Agent: *
+Disallow: /element/
+
+
+# Prevents AI feeding bots from scraping
+# https://neil-clarke.com/block-the-bots-that-feed-ai-models-by-scraping-your-website/
+User-agent: CCBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: Omgili
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+# PerplexityAI
+User-agent: PerplexityBot
+Disallow: /

--- a/web/tests.py
+++ b/web/tests.py
@@ -1,3 +1,17 @@
-# from django.test import TestCase
+from http import HTTPStatus
 
-# Create your tests here.
+from django.test import TestCase
+
+
+class RobotsTxtTests(TestCase):
+    def test_get(self):
+        response = self.client.get("/robots.txt")
+
+        assert response.status_code == HTTPStatus.OK
+        assert response["content-type"] == "text/plain"
+        assert response.content.startswith(b"User-Agent: *\n")
+
+    def test_post_disallowed(self):
+        response = self.client.post("/robots.txt")
+
+        assert response.status_code == HTTPStatus.METHOD_NOT_ALLOWED

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path
+from django.views.generic.base import TemplateView
 from django.contrib.auth import views as auth_views
 
 from web.views import VueAppDisplayView, RegisterUserView, FileUploadView
 
 urlpatterns = [
     path("", VueAppDisplayView.as_view(), name="app"),
+    path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain"), name="robots"),
     # https://docs.djangoproject.com/en/5.0/topics/auth/default/#django.contrib.auth.views.LoginView
     path(
         "s-identifier",


### PR DESCRIPTION
J'ai pris le parti "conservateur" :
 -> ne pas nourrir les bots pour les LLM (grandement inspirée par https://neil-clarke.com/block-the-bots-that-feed-ai-models-by-scraping-your-website/)
 -> ne pas indexer les elements

Mais c'est tout à fait modifiable. Et on peut s'en parler en commentaire sur cette PR.