### PR TITLE
Update StatsBlock.vue

### DIFF
--- a/frontend/src/views/LandingPage/StatsBlock.vue
+++ b/frontend/src/views/LandingPage/StatsBlock.vue
@@ -21,7 +21,7 @@ const stats = [
   },
   {
     number: "50%",
-    label: "de produits circulant dans la distribution mais non déclarés",
+    label: "de produits circulant dans la distribution mais non déclarés (chiffre estimé par une enquête-mystère sur 30 produits choisis au hasard en GMS, pharmacies, internet)",
   },
 ]
 </script>


### PR DESCRIPTION
ajout d'un détail sur la source du chiffre des 50% de CAs non déclarés  contexte : retour demandé par Synadiet qui s'étonne de ce chiffre