### PR TITLE
:lady_beetle: Petit bug lié à l'appel des formes galéniques

### DIFF
--- a/frontend/src/views/ProducerFormPage/ProductStep.vue
+++ b/frontend/src/views/ProducerFormPage/ProductStep.vue
@@ -68,6 +68,7 @@
       <DsfrInput
         v-if="
           payload.galenicFormulation &&
+          galenicFormulation &&
           getAllIndexesOfRegex(galenicFormulation, /Autre.*(à préciser)/).includes(parseInt(payload.galenicFormulation))
         "
         v-model="payload.otherGalenicFormulation"


### PR DESCRIPTION
## Explication

Si l'appel du store pour obtenir les formes galéniques tard un peu, on a une situation où `payload.galenicFormulation` est présent, mais pas le `galenicFormulation` du store, ce qui lève une erreur _array is null_ dans cette ligne : 
```javascript
getAllIndexesOfRegex(galenicFormulation, /Autre.*(à préciser)/).includes(parseInt(payload.galenicFormulation))
```

Il suffit de s'assurer que _galenicFormulation_ soit aussi présent à ce moment là.