### PR TITLE
Endpoint API : Récupérer toutes les déclarations

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -12,6 +12,12 @@ class IsLoggedUser(permissions.BasePermission):
 
 
 class CanAccessUserDeclatarions(permissions.BasePermission):
+    """
+    Un.e utilisateur.ice peut seulement avoir accès à ces propres déclarations. Cette
+    permission vérifie que le paramètre dans l'URL `user_pk` corresponde à l'objet
+    `user` de la requête.
+    """
+
     def has_permission(self, request, view):
         return view.kwargs["user_pk"] == request.user.id
 

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,5 +1,7 @@
 from rest_framework import permissions
 
+from data.models import InstructionRole
+
 
 class IsLoggedUser(permissions.BasePermission):
     message = "Vous devez être connecté et être l'utilisateur en question pour effectuer cette action"
@@ -7,6 +9,11 @@ class IsLoggedUser(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):  # obj: User
         user = request.user
         return user.is_authenticated and user == obj
+
+
+class CanAccessUserDeclatarions(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return view.kwargs["user_pk"] == request.user.id
 
 
 class IsSupervisor(permissions.BasePermission):
@@ -31,3 +38,8 @@ class IsDeclarationAuthor(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):  # obj: Declaration
         user = request.user
         return user.is_authenticated and obj.author == user
+
+
+class IsInstructor(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return InstructionRole.objects.filter(user=request.user).exists()

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -17,5 +17,5 @@ from .effect import EffectSerializer
 from .galenic_formulation import GalenicFormulationSerializer
 from .unit import SubstanceUnitSerializer
 from .autocomplete_item import AutocompleteItemSerializer
-from .declaration import DeclarationSerializer, DeclarationShortSerializer
+from .declaration import DeclarationSerializer, DeclarationShortSerializer, SimpleDeclarationSerializer
 from .company import CompanySerializer

--- a/api/serializers/blogpost.py
+++ b/api/serializers/blogpost.py
@@ -1,10 +1,12 @@
 from rest_framework import serializers
+
 from data.models import BlogPost
-from .user import BlogPostAuthor
+
+from .user import SimpleUserSerializer
 
 
 class BlogPostSerializer(serializers.ModelSerializer):
-    author = BlogPostAuthor()
+    author = SimpleUserSerializer()
     tags = serializers.SlugRelatedField(many=True, read_only=True, slug_field="name")
 
     class Meta:

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -1,29 +1,33 @@
-from rest_framework import serializers
-from api.exceptions import ProjectAPIException
 from drf_base64.fields import Base64FileField
+from rest_framework import serializers
+
+from api.exceptions import ProjectAPIException
 from data.models import (
-    Declaration,
-    DeclaredPlant,
-    DeclaredMicroorganism,
-    DeclaredIngredient,
-    DeclaredSubstance,
-    ComputedSubstance,
     Attachment,
-    Condition,
-    Effect,
-    Population,
     Company,
-    PlantPart,
-    Plant,
+    ComputedSubstance,
+    Condition,
+    Declaration,
+    DeclaredIngredient,
+    DeclaredMicroorganism,
+    DeclaredPlant,
+    DeclaredSubstance,
+    Effect,
     Ingredient,
     Microorganism,
+    Plant,
+    PlantPart,
+    Population,
     Substance,
     SubstanceUnit,
 )
-from .plant import PlantSerializer
-from .microorganism import MicroorganismSerializer
+
+from .company import SimpleCompanySerializer
 from .ingredient import IngredientSerializer
+from .microorganism import MicroorganismSerializer
+from .plant import PlantSerializer
 from .substance import SubstanceSerializer
+from .user import SimpleUserSerializer
 
 
 class IdPassthrough:
@@ -243,6 +247,26 @@ class AttachmentSerializer(IdPassthrough, serializers.ModelSerializer):
             "name",
         )
         read_only_fields = ("file",)
+
+
+class SimpleDeclarationSerializer(serializers.ModelSerializer):
+    author = SimpleUserSerializer(read_only=True)
+    company = SimpleCompanySerializer(read_only=True)
+
+    class Meta:
+        model = Declaration
+        fields = (
+            "id",
+            "status",
+            "author",
+            "company",
+            "name",
+            "brand",
+            "gamme",
+            "description",
+            "modification_date",
+        )
+        read_only_fields = fields
 
 
 class DeclarationSerializer(serializers.ModelSerializer):

--- a/api/serializers/user.py
+++ b/api/serializers/user.py
@@ -18,10 +18,10 @@ ROLE_SERIALIZER_MAPPING = {
 }
 
 
-class BlogPostAuthor(serializers.ModelSerializer):
+class SimpleUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ("first_name", "last_name")
+        fields = ("id", "first_name", "last_name")
 
 
 class CollaboratorSerializer(serializers.ModelSerializer):

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -16,6 +16,7 @@ from data.factories import (
     GalenicFormulationFactory,
     IngredientFactory,
     InstructionReadyDeclarationFactory,
+    InstructionRoleFactory,
     MicroorganismFactory,
     PlantFactory,
     PlantPartFactory,
@@ -39,7 +40,9 @@ class TestDeclarationApi(APITestCase):
             "company": CompanyFactory().id,
             "name": "name",
         }
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
@@ -50,7 +53,9 @@ class TestDeclarationApi(APITestCase):
             "company": wrong_company.id,
             "name": "name",
         }
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
@@ -95,7 +100,9 @@ class TestDeclarationApi(APITestCase):
             "warning": "Ne pas prendre plus de 20",
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -184,7 +191,9 @@ class TestDeclarationApi(APITestCase):
             ],
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         declaration = Declaration.objects.get(pk=response.json()["id"])
 
@@ -230,7 +239,9 @@ class TestDeclarationApi(APITestCase):
             ],
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         body = response.json()
@@ -277,7 +288,9 @@ class TestDeclarationApi(APITestCase):
             ],
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         declaration = Declaration.objects.get(pk=response.json()["id"])
 
@@ -324,7 +337,9 @@ class TestDeclarationApi(APITestCase):
             ],
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         body = response.json()
@@ -364,7 +379,9 @@ class TestDeclarationApi(APITestCase):
             ],
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         declaration = Declaration.objects.get(pk=response.json()["id"])
 
@@ -404,7 +421,9 @@ class TestDeclarationApi(APITestCase):
             ],
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         body = response.json()
@@ -435,7 +454,9 @@ class TestDeclarationApi(APITestCase):
             ],
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         declaration = Declaration.objects.get(pk=response.json()["id"])
 
@@ -466,7 +487,9 @@ class TestDeclarationApi(APITestCase):
             ],
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         body = response.json()
@@ -499,7 +522,9 @@ class TestDeclarationApi(APITestCase):
             ],
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         declaration = Declaration.objects.get(pk=response.json()["id"])
 
@@ -545,7 +570,9 @@ class TestDeclarationApi(APITestCase):
             ],
         }
 
-        response = self.client.post(reverse("api:list_create_declaration"), payload, format="json")
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         declaration = Declaration.objects.get(pk=response.json()["id"])
 
@@ -576,7 +603,7 @@ class TestDeclarationApi(APITestCase):
 
         other_declaration = DeclarationFactory.create()
 
-        response = self.client.get(reverse("api:list_create_declaration"))
+        response = self.client.get(reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         declarations = response.json()
 
@@ -661,3 +688,112 @@ class TestDeclarationApi(APITestCase):
         declaration = InstructionReadyDeclarationFactory(author=authenticate.user, company=wrong_company)
         response = self.client.post(reverse("api:submit_declaration", kwargs={"pk": declaration.id}), format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_get_all_declarations(self):
+        """
+        Un utilisateur ayant le rôle d'instruction peut récuperer tous les déclarations
+        """
+        InstructionRoleFactory(user=authenticate.user)
+
+        for _ in range(3):
+            DeclarationFactory()
+        response = self.client.get(reverse("api:list_all_declarations"), format="json")
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+
+    @authenticate
+    def test_get_all_declarations_non_admin(self):
+        """
+        Un utilisateur n'ayant pas le rôle d'instruction ne pourra pas obtenir toutes les
+        déclarations
+        """
+        for _ in range(3):
+            DeclarationFactory()
+        response = self.client.get(reverse("api:list_all_declarations"), format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_filter_author_all_declarations(self):
+        """
+        Les déclarations peuvent être filtrées par auteur
+        """
+        InstructionRoleFactory(user=authenticate.user)
+
+        emma = DeclarantRoleFactory()
+        edouard = DeclarantRoleFactory()
+        stephane = DeclarantRoleFactory()
+
+        [DeclarationFactory(author=edouard.user) for _ in range(4)]
+        emma_declarations = [DeclarationFactory(author=emma.user) for _ in range(3)]
+        stephane_declarations = [DeclarationFactory(author=stephane.user) for _ in range(5)]
+
+        # Filtrage pour obtenir les déclarations d'Emma
+        emma_filter_url = f"{reverse('api:list_all_declarations')}?author={emma.user.id}"
+        response = self.client.get(emma_filter_url, format="json")
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+
+        for result in results:
+            self.assertIn(result["id"], map(lambda x: x.id, emma_declarations))
+
+        # Filtrage pour obtenir les déclarations d'Emma et Edouard, mais pas Stéphane
+        emma_edouard_filter_url = f"{reverse('api:list_all_declarations')}?author={emma.user.id},{edouard.user.id}"
+        response = self.client.get(emma_edouard_filter_url, format="json")
+        results = response.json()["results"]
+        self.assertEqual(len(results), 7)
+
+        for result in results:
+            self.assertNotIn(result["id"], map(lambda x: x.id, stephane_declarations))
+
+    @authenticate
+    def test_filter_company_all_declarations(self):
+        """
+        Les déclarations peuvent être filtrées par entreprise
+        """
+        InstructionRoleFactory(user=authenticate.user)
+
+        buy_n_large = CompanyFactory()
+        acme = CompanyFactory()
+        wonka_industries = CompanyFactory()
+
+        [DeclarationFactory(company=buy_n_large) for _ in range(4)]
+        acme_declarations = [DeclarationFactory(company=acme) for _ in range(3)]
+        wonka_declarations = [DeclarationFactory(company=wonka_industries) for _ in range(5)]
+
+        # Filtrage pour obtenir les déclarations de l'entreprise Acme
+        acme_filter_url = f"{reverse('api:list_all_declarations')}?company={acme.id}"
+        response = self.client.get(acme_filter_url, format="json")
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+
+        for result in results:
+            self.assertIn(result["id"], map(lambda x: x.id, acme_declarations))
+
+        # Filtrage pour obtenir les déclarations de Acme et Buy'N'Large, mais pas Wonka Industries
+        acme_bnl_filter_url = f"{reverse('api:list_all_declarations')}?company={acme.id},{buy_n_large.id}"
+        response = self.client.get(acme_bnl_filter_url, format="json")
+        results = response.json()["results"]
+        self.assertEqual(len(results), 7)
+
+        for result in results:
+            self.assertNotIn(result["id"], map(lambda x: x.id, wonka_declarations))
+
+    @authenticate
+    def test_filter_status_all_declarations(self):
+        """
+        Les déclarations peuvent être filtrées par status
+        """
+        InstructionRoleFactory(user=authenticate.user)
+
+        [DeclarationFactory(status=Declaration.DeclarationStatus.APPROVED) for _ in range(3)]
+        [DeclarationFactory(status=Declaration.DeclarationStatus.REJECTED) for _ in range(3)]
+
+        # Filtrage pour obtenir les déclarations approuvées
+        spproved_filter_url = f"{reverse('api:list_all_declarations')}?status=APPROVED"
+        response = self.client.get(spproved_filter_url, format="json")
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+
+        for result in results:
+            self.assertEqual(result["status"], Declaration.DeclarationStatus.APPROVED.value)

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -703,7 +703,7 @@ class TestDeclarationApi(APITestCase):
         self.assertEqual(len(results), 3)
 
     @authenticate
-    def test_get_all_declarations_non_admin(self):
+    def test_get_all_declarations_non_instructor(self):
         """
         Un utilisateur n'ayant pas le rôle d'instruction ne pourra pas obtenir toutes les
         déclarations

--- a/api/urls.py
+++ b/api/urls.py
@@ -67,7 +67,12 @@ urlpatterns = {
         views.ClaimCompanyCoSupervisionView.as_view(),
         name="claim_company_co_supervision",
     ),
-    path("declarations/", views.DeclarationListCreateApiView.as_view(), name="list_create_declaration"),
+    path(
+        "users/<int:user_pk>/declarations/",
+        views.UserDeclarationsListCreateApiView.as_view(),
+        name="list_create_declaration",
+    ),
+    path("declarations/", views.AllDeclarationsListView.as_view(), name="list_all_declarations"),
     path("declarations/<int:pk>", views.DeclarationRetrieveUpdateView.as_view(), name="retrieve_update_declaration"),
     path("declarations/<int:pk>/submit/", views.DeclarationSubmitView.as_view(), name="submit_declaration"),
 }

--- a/api/utils/filters.py
+++ b/api/utils/filters.py
@@ -1,4 +1,9 @@
+import re
+
 import django_filters
+from djangorestframework_camel_case.settings import api_settings
+from djangorestframework_camel_case.util import camel_to_underscore, camelize_re, underscore_to_camel
+from rest_framework.filters import OrderingFilter
 
 
 class BaseNumberInFilter(django_filters.BaseInFilter, django_filters.NumberFilter):
@@ -11,3 +16,25 @@ class BaseNumberInFilter(django_filters.BaseInFilter, django_filters.NumberFilte
     """
 
     pass
+
+
+class CamelCaseOrderingFilter(OrderingFilter):
+    """
+    Allows filtering with camel case parameters. More info :
+    https://github.com/vbabiy/djangorestframework-camel-case/issues/87
+    """
+
+    def get_ordering(self, request, queryset, view):
+        ordering = super().get_ordering(request, queryset, view)
+
+        if ordering is None:
+            return None
+
+        return [camel_to_underscore(field, **api_settings.JSON_UNDERSCOREIZE) for field in ordering]
+
+    def get_valid_fields(self, queryset, view, context=None):
+        if context is None:
+            context = {}
+        fields = super().get_valid_fields(queryset, view, context=context)
+
+        return [(re.sub(camelize_re, underscore_to_camel, f[0]), f[1]) for f in fields]

--- a/api/utils/filters.py
+++ b/api/utils/filters.py
@@ -12,7 +12,7 @@ class BaseNumberInFilter(django_filters.BaseInFilter, django_filters.NumberFilte
     séparateur. Pratique pour le filtrage d'IDs des modèles.
 
     Par exemple, dans un URL on pourrait avoir `company=12,13,14` pour filtrer des objets ayant
-    comme compagnie une de ces trois (IDs 12, 13 ou 14).
+    comme entreprise une de ces trois (IDs 12, 13 ou 14).
     """
 
     pass

--- a/api/utils/filters.py
+++ b/api/utils/filters.py
@@ -1,0 +1,13 @@
+import django_filters
+
+
+class BaseNumberInFilter(django_filters.BaseInFilter, django_filters.NumberFilter):
+    """
+    Ce filtre permet d'effectuer des recherches par plusieurs chiffres avec la virgule comme
+    séparateur. Pratique pour le filtrage d'IDs des modèles.
+
+    Par exemple, dans un URL on pourrait avoir `company=12,13,14` pour filtrer des objets ayant
+    comme compagnie une de ces trois (IDs 12, 13 ou 14).
+    """
+
+    pass

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -2,7 +2,12 @@ from .authentication import LoginView, LogoutView
 from .autocomplete import AutocompleteView
 from .blog import BlogPostsView, BlogPostView
 from .condition import ConditionListView
-from .declaration import DeclarationListCreateApiView, DeclarationRetrieveUpdateView, DeclarationSubmitView
+from .declaration import (
+    UserDeclarationsListCreateApiView,
+    DeclarationRetrieveUpdateView,
+    DeclarationSubmitView,
+    AllDeclarationsListView,
+)
 from .effect import EffectListView
 from .galenic_formulation import GalenicFormulationListView
 from .ingredient import IngredientRetrieveView

--- a/api/views/declaration/__init__.py
+++ b/api/views/declaration/__init__.py
@@ -1,5 +1,6 @@
 from .declaration import (  # noqa: F401
-    DeclarationListCreateApiView,
+    UserDeclarationsListCreateApiView,
     DeclarationRetrieveUpdateView,
     DeclarationSubmitView,
+    AllDeclarationsListView,
 )

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -1,16 +1,19 @@
+from django_filters import rest_framework as django_filters
 from rest_framework.exceptions import NotFound, PermissionDenied
-from rest_framework.generics import GenericAPIView, ListCreateAPIView, RetrieveUpdateAPIView
+from rest_framework.generics import GenericAPIView, ListAPIView, ListCreateAPIView, RetrieveUpdateAPIView
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 
-from api.permissions import IsDeclarant, IsDeclarationAuthor
+from api.permissions import CanAccessUserDeclatarions, IsDeclarant, IsDeclarationAuthor, IsInstructor
 from api.serializers import DeclarationSerializer, DeclarationShortSerializer
+from api.utils.filters import BaseNumberInFilter
 from api.views.declaration.declaration_flow import DeclarationFlow
 from data.models import Company, Declaration
 
 
-class DeclarationListCreateApiView(ListCreateAPIView):
+class UserDeclarationsListCreateApiView(ListCreateAPIView):
     model = Declaration
-    permission_classes = [IsDeclarant]
+    permission_classes = [IsDeclarant, CanAccessUserDeclatarions]
 
     def get_queryset(self):
         return self.request.user.declarations
@@ -56,6 +59,37 @@ class DeclarationFlowView(GenericAPIView):
         declaration.save()
         serializer = self.get_serializer(declaration)
         return Response(serializer.data)
+
+
+class DeclarationFilterSet(django_filters.FilterSet):
+    author = BaseNumberInFilter(field_name="author__id")
+    company = BaseNumberInFilter(field_name="company__id")
+
+    class Meta:
+        model = Declaration
+        fields = {
+            "company",
+            "status",
+            "author",
+        }
+
+
+class DeclarationPagination(LimitOffsetPagination):
+    default_limit = 15
+    max_limit = 50
+
+
+class AllDeclarationsListView(ListAPIView):
+    model = Declaration
+    serializer_class = DeclarationSerializer
+    permission_classes = [IsInstructor]
+    ordering_fields = ["creation_date", "modification_date", "name"]
+    pagination_class = DeclarationPagination
+    filter_backends = [
+        django_filters.DjangoFilterBackend,
+    ]
+    filterset_class = DeclarationFilterSet
+    queryset = Declaration.objects.all()
 
 
 class DeclarationSubmitView(DeclarationFlowView):

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -5,7 +5,7 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 
 from api.permissions import CanAccessUserDeclatarions, IsDeclarant, IsDeclarationAuthor, IsInstructor
-from api.serializers import DeclarationSerializer, DeclarationShortSerializer
+from api.serializers import DeclarationSerializer, DeclarationShortSerializer, SimpleDeclarationSerializer
 from api.utils.filters import BaseNumberInFilter, CamelCaseOrderingFilter
 from api.views.declaration.declaration_flow import DeclarationFlow
 from data.models import Company, Declaration
@@ -81,7 +81,7 @@ class DeclarationPagination(LimitOffsetPagination):
 
 class AllDeclarationsListView(ListAPIView):
     model = Declaration
-    serializer_class = DeclarationSerializer
+    serializer_class = SimpleDeclarationSerializer
     permission_classes = [IsInstructor]
     ordering_fields = ["creation_date", "modification_date", "name"]
     pagination_class = DeclarationPagination

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 
 from api.permissions import CanAccessUserDeclatarions, IsDeclarant, IsDeclarationAuthor, IsInstructor
 from api.serializers import DeclarationSerializer, DeclarationShortSerializer
-from api.utils.filters import BaseNumberInFilter
+from api.utils.filters import BaseNumberInFilter, CamelCaseOrderingFilter
 from api.views.declaration.declaration_flow import DeclarationFlow
 from data.models import Company, Declaration
 
@@ -87,6 +87,7 @@ class AllDeclarationsListView(ListAPIView):
     pagination_class = DeclarationPagination
     filter_backends = [
         django_filters.DjangoFilterBackend,
+        CamelCaseOrderingFilter,
     ]
     filterset_class = DeclarationFilterSet
     queryset = Declaration.objects.all()

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -75,7 +75,7 @@ class DeclarationFilterSet(django_filters.FilterSet):
 
 
 class DeclarationPagination(LimitOffsetPagination):
-    default_limit = 15
+    default_limit = 10
     max_limit = 50
 
 

--- a/frontend/src/views/DeclarationsHomePage/index.vue
+++ b/frontend/src/views/DeclarationsHomePage/index.vue
@@ -26,8 +26,12 @@ import { handleError } from "@/utils/error-handling"
 import DeclarationsTable from "./DeclarationsTable"
 import { useRouter } from "vue-router"
 import { useFetch } from "@vueuse/core"
+import { useRootStore } from "@/stores/root"
+import { storeToRefs } from "pinia"
 
-const { response, data, isFetching } = useFetch("/api/v1/declarations/").get().json()
+const store = useRootStore()
+const { loggedUser } = storeToRefs(store)
+const { response, data, isFetching } = useFetch(`/api/v1/users/${loggedUser.id}/declarations/`).get().json()
 
 watch(response, () => handleError(response))
 

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -113,7 +113,9 @@ const components = computed(() => {
 
 const savePayload = async () => {
   const isNewDeclaration = !payload.value.id
-  const url = isNewDeclaration ? "/api/v1/declarations/" : `/api/v1/declarations/${payload.value.id}`
+  const url = isNewDeclaration
+    ? `/api/v1/users/${store.loggedUser.id}/declarations/`
+    : `/api/v1/declarations/${payload.value.id}`
   const httpMethod = isNewDeclaration ? "post" : "put"
   const { response, data } = await useFetch(url, { headers: headers() })[httpMethod](payload).json()
   $externalResults.value = await handleError(response)


### PR DESCRIPTION
Cette PR crée un endpoint pour obtenir la totalité des déclarations - endpoint qui sera utile aux personnes ayant le rôle d'instruction.

L'endpoint est paginé et contient des fonctionnalités de filtrage et triage. Pour l'instant on peut trier par _date de création_, _date de modification_ et _nom du produit_. Le filtrage peut se faire par _auteur_, _entreprise_ ou _status_.

À terme les propriétés utilisées pour trier ou filtrer peuvent évoluer en fonction du besoin. Il y aura certainement des petits ajustements une fois la partie front-end développée, mais je me suis dit qu'il fallait mieux ne pas trop alourdir la PR.

Pour différencier les endpoints, on a désormais les URLS :
- `/api/v1/users/<user-pk>/declarations` pour les déclarations d'un utilisateur, et
- `/api/v1/declarations` pour toutes les déclarations (accessible uniquement au rôle instruction)

À terme on aura aussi surement 
- `/api/v1/companies/<company-pk>/declarations` pour les déclarations d'une compagnie, qui sera accessible uniquement aux gestionnaires (hors scope de cette PR)

#### Note

La classe `CamelCaseOrderingFilter` permet de filtrer utilisant camelCase, comme on le fait partout dans l'appli. J'ai ajouté un commentaire qui contient l'URL de l'[issue ouvert de djangorestframework-camel-case](https://github.com/vbabiy/djangorestframework-camel-case/issues/87) concerné.

