### PR TITLE
Liste des déclarations front-end pour les personnes ayant `InstructionRole`

### DIFF
--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -223,3 +223,8 @@ export const RiUserLine = remixIcon(
   "ri-user-line",
   "M4 22a8 8 0 1116 0h-2a6 6 0 10-12 0H4zm8-9c-3.315 0-6-2.685-6-6s2.685-6 6-6 6 2.685 6 6-2.685 6-6 6zm0-2c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z"
 )
+
+export const RiSurveyFill = remixIcon(
+  "ri-survey-fill",
+  "M6 4v4h12V4h2.007c.548 0 .993.445.993.993v16.014a.994.994 0 01-.993.993H3.993A.994.994 0 013 21.007V4.993C3 4.445 3.445 4 3.993 4H6zm3 13H7v2h2v-2zm0-3H7v2h2v-2zm0-3H7v2h2v-2zm7-9v4H8V2h8z"
+)

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -30,4 +30,24 @@
     .icon.icon-ingredient {
         @apply bg-ca-ingredient;
     }
+    /* Je spécifier ici les couleurs pour les tags car Tailwind ne fait pas des classes dynamiques pour le bg */
+    /* https://stackoverflow.com/questions/72481680/tailwinds-background-color-is-not-being-applied-when-added-dynamically */
+    .fr-table .fr-tag.DRAFT {
+        @apply !bg-blue-france-925;
+    }
+    .fr-table .fr-tag.AWAITING_INSTRUCTION {
+        @apply !bg-gray-200;
+    }
+    .fr-table .fr-tag.AWAITING_PRODUCER {
+        @apply !bg-amber-100;
+    }
+    .fr-table .fr-tag.REJECTED {
+        @apply !bg-red-marianne-925;
+    }
+    .fr-table .fr-tag.APPROVED {
+        @apply !bg-success-950;
+    }
+    .fr-table .fr-tag .ov-icon {
+        @apply !mr-2;
+    }
 }

--- a/frontend/src/utils/components.js
+++ b/frontend/src/utils/components.js
@@ -1,0 +1,20 @@
+import { statusProps } from "@/utils/mappings"
+
+export const getStatusTagForCell = (status) => ({
+  component: "DsfrTag",
+  label: statusProps[status].label,
+  class: status,
+  icon: statusProps[status].icon,
+})
+
+export const getPagesForPagination = (count, limit, path) => {
+  const totalPages = Math.ceil(count / limit)
+  const pages = []
+  for (let i = 0; i < totalPages; i++)
+    pages.push({
+      label: i + 1,
+      href: `${path}?page=${i + 1}`,
+      title: `Page ${i + 1}`,
+    })
+  return pages
+}

--- a/frontend/src/views/AllDeclarationsPage/InstructionDeclarationsTable.vue
+++ b/frontend/src/views/AllDeclarationsPage/InstructionDeclarationsTable.vue
@@ -1,0 +1,40 @@
+<template>
+  <DsfrTable
+    ref="table"
+    class="w-full"
+    title="Mes déclarations"
+    :headers="headers"
+    :rows="rows"
+    :no-caption="true"
+    :pagination="false"
+  />
+</template>
+
+<script setup>
+import { computed } from "vue"
+import { timeAgo } from "@/utils/date"
+import { getStatusTagForCell } from "@/utils/components"
+
+const props = defineProps({ data: { type: Object, default: () => {} } })
+const emit = defineEmits("open")
+
+const headers = ["Nom du produit", "Entreprise", "Auteur", "État de la déclaration", "Date de modification"]
+const rows = computed(() =>
+  props.data?.results?.map((x) => ({
+    rowAttrs: { class: "cursor-pointer", onClick: () => emit("open", x.id) },
+    rowData: [
+      x.name,
+      x.company.socialName,
+      `${x.author.firstName} ${x.author.lastName}`,
+      getStatusTagForCell(x.status),
+      timeAgo(x.modificationDate),
+    ],
+  }))
+)
+</script>
+
+<style scoped>
+.fr-table :deep(table) {
+  @apply !table;
+}
+</style>

--- a/frontend/src/views/AllDeclarationsPage/index.vue
+++ b/frontend/src/views/AllDeclarationsPage/index.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="fr-container">
+    <DsfrBreadcrumb
+      class="mb-8"
+      :links="[{ to: '/tableau-de-bord', text: 'Tableau de bord' }, { text: 'Toutes les déclarations' }]"
+    />
+    <div v-if="isFetching" class="flex justify-center my-10">
+      <ProgressSpinner />
+    </div>
+    <InstructionDeclarationsTable v-else-if="hasDeclarations" :data="data" />
+    <p v-else class="mb-8">Il n'y a pas encore de déclarations.</p>
+    <DsfrPagination
+      v-if="showPagination"
+      @update:currentPage="updatePage"
+      :pages="pages"
+      :current-page="page - 1"
+      :truncLimit="5"
+    />
+  </div>
+</template>
+
+<script setup>
+import { useFetch } from "@vueuse/core"
+import { computed, watch } from "vue"
+import { handleError } from "@/utils/error-handling"
+import ProgressSpinner from "@/components/ProgressSpinner"
+import InstructionDeclarationsTable from "./InstructionDeclarationsTable"
+import { DsfrPagination } from "@gouvminint/vue-dsfr"
+import { useRoute, useRouter } from "vue-router"
+import { getPagesForPagination } from "@/utils/components"
+
+const router = useRouter()
+const route = useRoute()
+
+const hasDeclarations = computed(() => data.value?.count > 0)
+const showPagination = computed(() => data.value?.count > data.value?.results?.length)
+
+const updatePage = (newPage) => router.push({ query: { page: newPage + 1 } })
+
+const limit = 10
+const page = computed(() => parseInt(route.query.page))
+const pages = computed(() => getPagesForPagination(data.value.count, limit, route.path))
+
+// Obtention de la donnée via API
+const offset = computed(() => (page.value - 1) * limit)
+const url = computed(() => `/api/v1/declarations/?limit=${limit}&offset=${offset.value}`)
+const { response, data, isFetching, execute } = useFetch(url).get().json()
+const fetchSearchResults = async () => {
+  await execute()
+  await handleError(response)
+}
+watch(page, fetchSearchResults)
+</script>

--- a/frontend/src/views/BlogHomePage.vue
+++ b/frontend/src/views/BlogHomePage.vue
@@ -40,6 +40,7 @@ import ProgressSpinner from "@/components/ProgressSpinner"
 import BlogCard from "@/components/BlogCard"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
+import { getPagesForPagination } from "@/utils/components"
 
 const route = useRoute()
 const router = useRouter()
@@ -48,17 +49,8 @@ const router = useRouter()
 const limit = 6
 const page = ref(null)
 const offset = computed(() => (page.value - 1) * limit)
-const pages = computed(() => {
-  const totalPages = Math.ceil(data?.value.count / limit)
-  const pages = []
-  for (let i = 0; i < totalPages; i++)
-    pages.push({
-      label: i + 1,
-      href: `${route.path}?page=${i + 1}`,
-      title: `Page ${i + 1}`,
-    })
-  return pages
-})
+const pages = computed(() => getPagesForPagination(data.value.count, limit, route.path))
+
 const updatePage = (newPage) => (page.value = newPage + 1)
 const updateRoute = () => {
   const query = { page: page.value }

--- a/frontend/src/views/DashboardPage/index.vue
+++ b/frontend/src/views/DashboardPage/index.vue
@@ -8,6 +8,7 @@
       icon="ri-home-4-line"
     />
     <ActionGrid v-if="isDeclarant" :actions="declarantActions" title="Mes déclarations" icon="ri-capsule-fill" />
+    <ActionGrid v-if="isInstructor" :actions="instructionActions" title="Instruction" icon="ri-survey-fill" />
     <ActionGrid v-if="emptyRoles" :actions="onboardingActions" title="Démarrez chez Compl-Alim !" />
     <ActionGrid :actions="userActions" title="Mon compte" icon="ri-account-circle-line" />
   </div>
@@ -26,6 +27,7 @@ const { loggedUser, company } = storeToRefs(store)
 const emptyRoles = computed(() => !company.value || !company.value.roles || company.value.roles.length === 0)
 const isSupervisor = computed(() => company.value?.roles.some((x) => x.name === "SupervisorRole"))
 const isDeclarant = computed(() => company.value?.roles.some((x) => x.name === "DeclarantRole"))
+const isInstructor = computed(() => loggedUser.value?.globalRoles.some((x) => x.name === "InstructionRole"))
 
 const supervisorActions = [
   {
@@ -58,6 +60,14 @@ const declarantActions = [
     title: "Toutes mes déclarations",
     description: "Consultez, modifiez ou dupliquez une déclaration que vous avez effectuée",
     link: { name: "DeclarationsHomePage" },
+  },
+]
+
+const instructionActions = [
+  {
+    title: "Liste des déclarations",
+    description: "Accédez à la liste des déclarations Compl'Alim",
+    link: { name: "AllDeclarations" },
   },
 ]
 

--- a/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
+++ b/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
@@ -13,7 +13,7 @@
 <script setup>
 import { computed, ref } from "vue"
 import { timeAgo } from "@/utils/date"
-import { statusProps } from "@/utils/mappings"
+import { getStatusTagForCell } from "@/utils/components"
 import { useResizeObserver, useDebounceFn } from "@vueuse/core"
 
 const props = defineProps({ data: { type: Array, default: () => [] } })
@@ -32,20 +32,13 @@ const rows = computed(() => {
   if (useShortTable.value)
     return sorted.map((d) => ({
       rowAttrs: { class: "cursor-pointer", onClick: () => emit("open", d.id) },
-      rowData: [d.name, getTagForCell(d.status)],
+      rowData: [d.name, getStatusTagForCell(d.status)],
     }))
 
   return sorted.map((d) => ({
     rowAttrs: { class: "cursor-pointer", onClick: () => emit("open", d.id) },
-    rowData: [d.name, d.brand || "—", getTagForCell(d.status), timeAgo(d.modificationDate)],
+    rowData: [d.name, d.brand || "—", getStatusTagForCell(d.status), timeAgo(d.modificationDate)],
   }))
-})
-
-const getTagForCell = (status) => ({
-  component: "DsfrTag",
-  label: statusProps[status].label,
-  class: status,
-  icon: statusProps[status].icon,
 })
 // On prend la width de la table pour montrer/cacher les colonnes
 const table = ref(null)
@@ -58,25 +51,5 @@ useResizeObserver(
 <style scoped>
 .fr-table :deep(table) {
   @apply !table;
-}
-.fr-table :deep(.fr-tag .ov-icon) {
-  @apply !mr-2;
-}
-/* Je dois les spécifier ici car Tailwind ne fait pas des classes dynamiques pour le bg */
-/* https://stackoverflow.com/questions/72481680/tailwinds-background-color-is-not-being-applied-when-added-dynamically */
-.fr-table :deep(.fr-tag.DRAFT) {
-  @apply !bg-blue-france-925;
-}
-.fr-table :deep(.fr-tag.AWAITING_INSTRUCTION) {
-  @apply !bg-gray-200;
-}
-.fr-table :deep(.fr-tag.AWAITING_PRODUCER) {
-  @apply !bg-amber-100;
-}
-.fr-table :deep(.fr-tag.REJECTED) {
-  @apply !bg-red-marianne-925;
-}
-.fr-table :deep(.fr-tag.APPROVED) {
-  @apply !bg-success-950;
 }
 </style>

--- a/frontend/src/views/DeclarationsHomePage/index.vue
+++ b/frontend/src/views/DeclarationsHomePage/index.vue
@@ -31,7 +31,7 @@ import { storeToRefs } from "pinia"
 
 const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
-const { response, data, isFetching } = useFetch(`/api/v1/users/${loggedUser.id}/declarations/`).get().json()
+const { response, data, isFetching } = useFetch(`/api/v1/users/${loggedUser.value.id}/declarations/`).get().json()
 
 watch(response, () => handleError(response))
 

--- a/frontend/src/views/ElementSearchResultsPage/index.vue
+++ b/frontend/src/views/ElementSearchResultsPage/index.vue
@@ -52,6 +52,7 @@ import { headers } from "@/utils/data-fetching"
 import ResultCard from "./ResultCard"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import { handleError } from "@/utils/error-handling"
+import { getPagesForPagination } from "@/utils/components"
 
 const router = useRouter()
 const route = useRoute()
@@ -73,17 +74,7 @@ const limit = 6
 const page = ref(parseInt(route.query.page) || 1)
 const offset = computed(() => (page.value - 1) * limit)
 const showPagination = computed(() => data.value.count > limit)
-const pages = computed(() => {
-  const totalPages = Math.ceil(data.value.count / limit)
-  const pages = []
-  for (let i = 0; i < totalPages; i++)
-    pages.push({
-      label: i + 1,
-      href: `${route.path}?page=${i + 1}`,
-      title: `Page ${i + 1}`,
-    })
-  return pages
-})
+const pages = computed(() => getPagesForPagination(data.value.count, limit, route.path))
 const updatePage = (newPage) => (page.value = newPage + 1)
 
 // Search request

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -95,7 +95,7 @@ const hasNewElements = computed(() => {
     )
     .some((x) => x.new)
 })
-const readonly = computed(() => payload.value.status !== "DRAFT")
+const readonly = computed(() => !isNewDeclaration.value && payload.value.status !== "DRAFT")
 const currentStep = ref(null)
 const steps = computed(() => {
   if (readonly.value) return ["Résumé"]


### PR DESCRIPTION
### :eyes: Cette PR se base sur _declarations-list-view_ (PR #485), non pas sur _staging_

## Liste des déclarations pour l'instruction

Cette PR est une vue très basique des déclarations pour les instructeurs et instructrices.

[Screencast from 08-05-24 17:48:30.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/5d752d1e-5d2e-4aa5-9048-45c9c0a1792e)

#### Scope de la PR
- [x] Ajout du segment _Instruction_ dans le tableau de bord
- [x] Permet de visualiser les déclarations avec le nom de l'auteur et la compagnie concernée
- [x] La pagination est active et fontionne

#### Pour après
- Filtrer
- Enlever les déclarations _brouillon_
- Triage
- Aller dans la page _instruction_ après avoir cliqué sur une déclaration

#### Notes

##### Query params par défaut
Dans le router j'ai ajouté une nouvelle fonctionnalité pour déclarer les query-params par défault qu'une view doit avoir (optionnel bien sur). Ceci simplifie énormément les vues où l'affichage se base dans les params de l'URL (pagination, filtrage, triage), car la vue peut être sur d'avoir ces valeurs dès le début. 

Après cette PR je ferais pareil pour les autres vues contenant la pagination (_résultats de recherche_ et _blog_) mais en prio basse.

##### Création de l'utils `components.js`

Certaines fonctions utilisées lors de l'usage des composants ont été placées dans ce nouvel fichier, notamment la génération de l'objet `pages` pour les paginations et la création des tags pour les tables. 

