### PR TITLE
:lady_beetle: Petit fix : bug read-only pour les nouvelles déclarations

### DIFF
--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -95,7 +95,7 @@ const hasNewElements = computed(() => {
     )
     .some((x) => x.new)
 })
-const readonly = computed(() => payload.value.status !== "DRAFT")
+const readonly = computed(() => !isNewDeclaration.value && payload.value.status !== "DRAFT")
 const currentStep = ref(null)
 const steps = computed(() => {
   if (readonly.value) return ["Résumé"]


### PR DESCRIPTION
J'ai oublié de mettre une condition dans ma PR précédente pour assurer que les nouvelles déclarations n'étaient pas en lecture seule (sinon on ne peux pas en créer).

Fix avec un petit ajout dans la condition : une déclaration est read-only pour le déclarant sauf quand elle est nouvelle, ou en état brouillon.