### PR TITLE
Cache les déclarations en brouillon des personnes ayant le rôle d'instruction

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,6 +1,6 @@
 from rest_framework import permissions
 
-from data.models import InstructionRole
+from data.models import Declaration, InstructionRole
 
 
 class CanAccessUser(permissions.BasePermission):
@@ -61,7 +61,8 @@ class CanAccessIndividualDeclaration(permissions.BasePermission):
         is_author = IsDeclarationAuthor().has_object_permission(request, view, obj)
         is_instructor = IsInstructor().has_permission(request, view)
         is_declarant = IsDeclarant().has_object_permission(request, view, obj)
+        is_draft = obj.status == Declaration.DeclarationStatus.DRAFT
         if request.method == "GET":
-            return is_author or is_instructor
+            return is_author or (is_instructor and not is_draft)
 
         return is_author and is_declarant

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -863,7 +863,7 @@ class TestDeclarationApi(APITestCase):
         """
         Les déclarations brouillons ne sont pas visibles aux personnes ayant le rôle instructor
         """
-        draft_declaration = DeclarationFactory()
+        draft_declaration = DeclarationFactory(status=Declaration.DeclarationStatus.DRAFT)
         InstructionRoleFactory(user=authenticate.user)
 
         response = self.client.get(reverse("api:list_all_declarations"), format="json")

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -96,7 +96,7 @@ class AllDeclarationsListView(ListAPIView):
         CamelCaseOrderingFilter,
     ]
     filterset_class = DeclarationFilterSet
-    queryset = Declaration.objects.all()
+    queryset = Declaration.objects.exclude(status=Declaration.DeclarationStatus.DRAFT)
 
 
 class DeclarationSubmitView(DeclarationFlowView):


### PR DESCRIPTION
Petite PR pour cacher les déclarations brouillon des instructeurs e instructrices.

Lié au commentaire de David sur mon autre PR : https://github.com/betagouv/complements-alimentaires/pull/489/files#r1606797596

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/e57653cf-344d-4399-8c64-4ec65e80e407)
