### PR TITLE
Supprime les "parties à surveiller" de la page Ingrédient dans l'interface de recherche

### DIFF
--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -58,15 +58,6 @@
           <ElementTag :label="part" v-for="part in plantParts" :key="part" />
         </ElementColumn>
 
-        <ElementColumn title="Parties à surveiller" v-if="toWatchParts?.length">
-          <ElementTag
-            :label="part"
-            v-for="part in toWatchParts"
-            :key="part"
-            class="!bg-warning-925 !text-warning-425"
-          />
-        </ElementColumn>
-
         <ElementColumn title="Substances" v-if="substances?.length">
           <ElementTag
             :link="{
@@ -138,9 +129,6 @@ const icon = computed(() => getTypeIcon(typeMapping[type.value]))
 const family = computed(() => element.value?.family?.name)
 const genre = computed(() => element.value?.genre)
 const plantParts = computed(() => element.value?.plantParts?.map((x) => x.name).filter((x) => !!x))
-const toWatchParts = computed(() =>
-  element.value?.plantParts?.filter((x) => x.mustBeMonitored === true && !!x.name).map((x) => x.name)
-)
 const substances = computed(() => element.value?.substances)
 const synonyms = computed(() => element.value?.synonyms?.map((x) => x.name).filter((x) => !!x))
 const casNumber = computed(() => element.value?.casNumber)

--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -128,7 +128,9 @@ const icon = computed(() => getTypeIcon(typeMapping[type.value]))
 // Information affichée
 const family = computed(() => element.value?.family?.name)
 const genre = computed(() => element.value?.genre)
-const plantParts = computed(() => element.value?.plantParts?.map((x) => x.name).filter((x) => !!x))
+const plantParts = computed(() =>
+  element.value?.plantParts?.filter((x) => x.isUseful === true && !!x.name).map((x) => x.name)
+)
 const substances = computed(() => element.value?.substances)
 const synonyms = computed(() => element.value?.synonyms?.map((x) => x.name).filter((x) => !!x))
 const casNumber = computed(() => element.value?.casNumber)


### PR DESCRIPTION
Cette PR apporte une solution quick-win à l'issue #435.
Une issue d'investigation sur les parties utiles et à surveiller -> je vous incite à lire les commentaires de cette issue.

Le quick-win est de rester iso TeleIcare et cette PR permet ça.
Il faudra cependant envisager des améliorations de ces 2 catégories "utiles"/ " à surveiller" dans le cadre du nettoyage des données.


### Avant
![image](https://github.com/betagouv/complements-alimentaires/assets/1618987/b42f53ef-c450-4da2-8078-69138ce2a065)
ou
![image](https://github.com/betagouv/complements-alimentaires/assets/1618987/e6a40a4b-0a33-4759-bebf-af60ddb331bc)




### Après
![image](https://github.com/betagouv/complements-alimentaires/assets/1618987/24b2380d-4d54-4051-8e85-3221e1e930f7)
ou
![image](https://github.com/betagouv/complements-alimentaires/assets/1618987/a70256c7-d2e1-45f0-bef1-0abd96b7568c)
