### PR TITLE
Accessibilité pour les tables déclaration

### DIFF
--- a/frontend/src/views/AllDeclarationsPage/InstructionDeclarationsTable.vue
+++ b/frontend/src/views/AllDeclarationsPage/InstructionDeclarationsTable.vue
@@ -16,14 +16,16 @@ import { timeAgo } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
-const emit = defineEmits("open")
 
 const headers = ["Nom du produit", "Entreprise", "Auteur", "État de la déclaration", "Date de modification"]
 const rows = computed(() =>
   props.data?.results?.map((x) => ({
-    rowAttrs: { class: "cursor-pointer", onClick: () => emit("open", x.id) },
     rowData: [
-      x.name,
+      {
+        component: "router-link",
+        text: x.name,
+        to: { name: "DeclarationPage", params: { id: x.id } },
+      },
       x.company.socialName,
       `${x.author.firstName} ${x.author.lastName}`,
       getStatusTagForCell(x.status),

--- a/frontend/src/views/AllDeclarationsPage/index.vue
+++ b/frontend/src/views/AllDeclarationsPage/index.vue
@@ -40,7 +40,7 @@
       <ProgressSpinner />
     </div>
     <div v-else-if="hasDeclarations">
-      <InstructionDeclarationsTable :data="data" @open="openDeclaration" />
+      <InstructionDeclarationsTable :data="data" />
     </div>
     <p v-else class="mb-8">Il n'y a pas encore de déclarations.</p>
     <DsfrPagination
@@ -72,7 +72,6 @@ const offset = computed(() => (page.value - 1) * limit)
 
 const limit = 10
 const pages = computed(() => getPagesForPagination(data.value.count, limit, route.path))
-const openDeclaration = (id) => router.push({ name: "InstructionPage", params: { declarationId: id } })
 
 const statusFilterOptions = [
   { value: "", text: "Tous les statuts" },

--- a/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
+++ b/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
@@ -36,8 +36,16 @@ const rows = computed(() => {
     }))
 
   return sorted.map((d) => ({
-    rowAttrs: { class: "cursor-pointer", onClick: () => emit("open", d.id) },
-    rowData: [d.name, d.brand || "—", getStatusTagForCell(d.status), timeAgo(d.modificationDate)],
+    rowData: [
+      {
+        component: "router-link",
+        text: d.name,
+        to: { name: "DeclarationPage", params: { id: d.id } },
+      },
+      d.brand || "—",
+      getStatusTagForCell(d.status),
+      timeAgo(d.modificationDate),
+    ],
   }))
 })
 // On prend la width de la table pour montrer/cacher les colonnes

--- a/frontend/src/views/DeclarationsHomePage/index.vue
+++ b/frontend/src/views/DeclarationsHomePage/index.vue
@@ -11,7 +11,7 @@
     <div v-if="isFetching" class="flex justify-center my-10">
       <ProgressSpinner />
     </div>
-    <DeclarationsTable :data="data" v-else-if="hasDeclarations" @open="openDeclaration" />
+    <DeclarationsTable :data="data" v-else-if="hasDeclarations" />
     <div v-else class="mb-8">
       <p>Vous n'avez pas encore créé des déclarations.</p>
       <DsfrButton icon="ri-capsule-fill" label="Créer ma première déclaration" @click="createNewDeclaration" />
@@ -39,5 +39,4 @@ const hasDeclarations = computed(() => !!data.value?.length)
 
 const router = useRouter()
 const createNewDeclaration = () => router.push({ name: "NewDeclaration" })
-const openDeclaration = (id) => router.push({ name: "DeclarationPage", params: { id } })
 </script>


### PR DESCRIPTION
Aujourd'hui en staging les tables contenant les déclarations ne sont pas accessibles : 
- On ne peut pas naviguer entre les lignes avec le clavier
- On n'a pas le lien lisible dans le navigateur

La solution la plus simple et rapide est de mettre un vrai lien dans la première colonne de la table : 

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/3b4d06c9-46b5-4b67-80bd-9d97c03e3983)

De cette façon la navigation par clavier et les lecteurs d'écran savent où mène la ligne de la table.