### PR TITLE
:lady_beetle:  Fix des warnings vue-router concernant les steps

### DIFF
--- a/frontend/src/views/ProducerFormPage/AttachmentStep.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentStep.vue
@@ -1,28 +1,30 @@
 <template>
-  <SectionTitle title="Étiquetage" sizeTag="h6" icon="ri-price-tag-2-fill" />
-  <DsfrInputGroup>
-    <DsfrFileUpload
-      label="Merci d'ajouter au moins un fichier image ou PDF correspondant à l'étiquetage."
-      :accept="['image/jpeg, image/gif, image/png, application/pdf']"
-      @change="addLabelFiles"
-      v-model="selectedLabelFile"
-    />
-  </DsfrInputGroup>
+  <div>
+    <SectionTitle title="Étiquetage" sizeTag="h6" icon="ri-price-tag-2-fill" />
+    <DsfrInputGroup>
+      <DsfrFileUpload
+        label="Merci d'ajouter au moins un fichier image ou PDF correspondant à l'étiquetage."
+        :accept="['image/jpeg, image/gif, image/png, application/pdf']"
+        @change="addLabelFiles"
+        v-model="selectedLabelFile"
+      />
+    </DsfrInputGroup>
 
-  <FileGrid :files="labelFiles" @remove="removeFile" hideTypeSelection />
+    <FileGrid :files="labelFiles" @remove="removeFile" hideTypeSelection />
 
-  <SectionTitle title="Autres" class="!mt-10" sizeTag="h6" icon="ri-attachment-2" />
+    <SectionTitle title="Autres" class="!mt-10" sizeTag="h6" icon="ri-attachment-2" />
 
-  <DsfrInputGroup>
-    <DsfrFileUpload
-      label="Autres pièces que vous jugez nécessaires pour l'étude du dossier"
-      :acceptTypes="['image/jpeg, image/gif, image/png, application/pdf']"
-      @change="addOtherFiles"
-      v-model="selectedOtherFile"
-    />
-  </DsfrInputGroup>
+    <DsfrInputGroup>
+      <DsfrFileUpload
+        label="Autres pièces que vous jugez nécessaires pour l'étude du dossier"
+        :acceptTypes="['image/jpeg, image/gif, image/png, application/pdf']"
+        @change="addOtherFiles"
+        v-model="selectedOtherFile"
+      />
+    </DsfrInputGroup>
 
-  <FileGrid :files="otherFiles" @remove="removeFile" />
+    <FileGrid :files="otherFiles" @remove="removeFile" />
+  </div>
 </template>
 
 <script setup>

--- a/frontend/src/views/ProducerFormPage/CompositionStep.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionStep.vue
@@ -1,38 +1,40 @@
 <template>
-  <SectionTitle title="Ma composition" sizeTag="h6" icon="ri-flask-line" />
-  <div class="sm:flex gap-10 items-center">
-    <ElementAutocomplete
-      autocomplete="nothing"
-      label="Cherchez un ingrédient"
-      label-visible
-      class="max-w-md grow"
-      hint="Tapez au moins trois caractères pour démarrer la recherche"
-      @selected="selectOption"
-    />
-    <div class="hidden sm:flex flex-col items-center">
-      <div class="border-l h-6"></div>
-      <div class="my-2">Ou</div>
-      <div class="border-l h-6"></div>
+  <div>
+    <SectionTitle title="Ma composition" sizeTag="h6" icon="ri-flask-line" />
+    <div class="sm:flex gap-10 items-center">
+      <ElementAutocomplete
+        autocomplete="nothing"
+        label="Cherchez un ingrédient"
+        label-visible
+        class="max-w-md grow"
+        hint="Tapez au moins trois caractères pour démarrer la recherche"
+        @selected="selectOption"
+      />
+      <div class="hidden sm:flex flex-col items-center">
+        <div class="border-l h-6"></div>
+        <div class="my-2">Ou</div>
+        <div class="border-l h-6"></div>
+      </div>
+      <div class="mt-4 sm:mt-0"><NewElementModal @add="addElement" /></div>
     </div>
-    <div class="mt-4 sm:mt-0"><NewElementModal @add="addElement" /></div>
-  </div>
 
-  <ElementList @remove="removeElement" objectType="plant" :elements="payload.declaredPlants" />
-  <ElementList @remove="removeElement" objectType="microorganism" :elements="payload.declaredMicroorganisms" />
-  <ElementList @remove="removeElement" objectType="ingredient" :elements="payload.declaredIngredients" />
-  <ElementList @remove="removeElement" objectType="substance" :elements="payload.declaredSubstances" />
-  <div v-if="allElements.length === 0" class="my-12">
-    <v-icon name="ri-information-line" class="mr-1"></v-icon>
-    Vous n'avez pas encore saisi d'ingrédients pour votre complément alimentaire
-  </div>
+    <ElementList @remove="removeElement" objectType="plant" :elements="payload.declaredPlants" />
+    <ElementList @remove="removeElement" objectType="microorganism" :elements="payload.declaredMicroorganisms" />
+    <ElementList @remove="removeElement" objectType="ingredient" :elements="payload.declaredIngredients" />
+    <ElementList @remove="removeElement" objectType="substance" :elements="payload.declaredSubstances" />
+    <div v-if="allElements.length === 0" class="my-12">
+      <v-icon name="ri-information-line" class="mr-1"></v-icon>
+      Vous n'avez pas encore saisi d'ingrédients pour votre complément alimentaire
+    </div>
 
-  <div v-show="hasActiveSubstances">
-    <h3 class="fr-h6 !mb-4 !mt-6">Substances</h3>
-    <p>
-      Les substances contenues dans les ingrédients actifs renseignés sont affichées ci-dessous. Veuillez compléter leur
-      dosage total.
-    </p>
-    <SubstancesTable v-model="payload" />
+    <div v-show="hasActiveSubstances">
+      <h3 class="fr-h6 !mb-4 !mt-6">Substances</h3>
+      <p>
+        Les substances contenues dans les ingrédients actifs renseignés sont affichées ci-dessous. Veuillez compléter
+        leur dosage total.
+      </p>
+      <SubstancesTable v-model="payload" />
+    </div>
   </div>
 </template>
 

--- a/frontend/src/views/ProducerFormPage/NewElementStep.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementStep.vue
@@ -1,12 +1,14 @@
 <template>
-  <SectionTitle title="Nouveaux ingrédients" sizeTag="h6" icon="ri-flask-line" />
-  <p>
-    Vous avez ajouté les nouveaux ingrédients affichés ci-dessous. Des informations supplémentaires les concernant sont
-    requises.
-  </p>
-  <NewElementList objectType="plant" :elements="newPlants" />
-  <NewElementList objectType="microorganism" :elements="newMicroorganisms" />
-  <NewElementList objectType="ingredient" :elements="newIngredients" />
+  <div>
+    <SectionTitle title="Nouveaux ingrédients" sizeTag="h6" icon="ri-flask-line" />
+    <p>
+      Vous avez ajouté les nouveaux ingrédients affichés ci-dessous. Des informations supplémentaires les concernant
+      sont requises.
+    </p>
+    <NewElementList objectType="plant" :elements="newPlants" />
+    <NewElementList objectType="microorganism" :elements="newMicroorganisms" />
+    <NewElementList objectType="ingredient" :elements="newIngredients" />
+  </div>
 </template>
 
 <script setup>

--- a/frontend/src/views/ProducerFormPage/ProductStep.vue
+++ b/frontend/src/views/ProducerFormPage/ProductStep.vue
@@ -1,215 +1,219 @@
 <template>
-  <!-- Si on a une seule entreprise, pas besoin d'afficher ce champ -->
-  <template v-if="!companies || companies.length !== 1">
-    <SectionTitle title="Entreprise" sizeTag="h6" icon="ri-home-2-fill" />
-    <DsfrAlert type="warning" v-if="!companies || companies.length === 0">
-      <p>
-        Vous n'avez pas d'entreprise assignée. Contacter l'administrateur de votre entreprise ou
-        <router-link :to="{ name: 'Root' }">ajoutez une entreprise</router-link>
-        .
-      </p>
-    </DsfrAlert>
-    <DsfrInputGroup class="max-w-md" :error-message="firstErrorMsg(v$, 'company')" v-else>
-      <DsfrSelect
-        label="Entreprise qui produit le complément"
-        v-model.number="payload.company"
-        :options="companies.map((x) => ({ text: x.socialName, value: x.id }))"
-        :required="true"
-      />
-    </DsfrInputGroup>
-  </template>
+  <div>
+    <!-- Si on a une seule entreprise, pas besoin d'afficher ce champ -->
+    <template v-if="!companies || companies.length !== 1">
+      <SectionTitle title="Entreprise" sizeTag="h6" icon="ri-home-2-fill" />
+      <DsfrAlert type="warning" v-if="!companies || companies.length === 0">
+        <p>
+          Vous n'avez pas d'entreprise assignée. Contacter l'administrateur de votre entreprise ou
+          <router-link :to="{ name: 'Root' }">ajoutez une entreprise</router-link>
+          .
+        </p>
+      </DsfrAlert>
+      <DsfrInputGroup class="max-w-md" :error-message="firstErrorMsg(v$, 'company')" v-else>
+        <DsfrSelect
+          label="Entreprise qui produit le complément"
+          v-model.number="payload.company"
+          :options="companies.map((x) => ({ text: x.socialName, value: x.id }))"
+          :required="true"
+        />
+      </DsfrInputGroup>
+    </template>
 
-  <SectionTitle title="Dénomination commerciale" class="!mt-10" sizeTag="h6" icon="ri-price-tag-2-fill" />
-  <div class="grid grid-cols-2 gap-4">
-    <div class="col-span-2 md:col-span-1 max-w-md">
-      <DsfrInputGroup :error-message="firstErrorMsg(v$, 'name')">
-        <DsfrInput v-model="payload.name" label-visible label="Nom du produit" :required="true" />
-      </DsfrInputGroup>
-      <DsfrInputGroup>
-        <DsfrInput v-model="payload.brand" label-visible label="Marque" />
-      </DsfrInputGroup>
-    </div>
-    <div class="col-span-2 md:col-span-1 max-w-md">
-      <!-- Useless? -->
-      <DsfrInputGroup>
-        <DsfrInput v-model="payload.gamme" label-visible label="Gamme" />
-      </DsfrInputGroup>
-
-      <!-- Useless? -->
-      <DsfrInputGroup>
-        <DsfrInput v-model="payload.flavor" label-visible label="Arôme" />
-      </DsfrInputGroup>
-    </div>
-    <DsfrInputGroup class="max-w-2xl mt-6">
-      <DsfrInput is-textarea v-model="payload.description" label-visible label="Description" :required="true" />
-    </DsfrInputGroup>
-  </div>
-  <SectionTitle title="Format" class="!mt-10" sizeTag="h6" icon="ri-capsule-fill" />
-  <div class="grid grid-cols-2 gap-4">
-    <DsfrFieldset legend="Forme galénique" legendClass="fr-label !font-normal !pb-0">
-      <div class="flex">
-        <div class="max-w-32">
-          <DsfrSelect :options="formulationStates" v-model="galenicFormulationState" defaultUnselectedText="État" />
-        </div>
-        <div class="max-w-md ml-4">
-          <DsfrSelect
-            v-model="payload.galenicFormulation"
-            :options="
-              galenicFormulationList?.map((formulation) => ({
-                text: formulation.name,
-                value: formulation.id,
-              }))
-            "
-          />
-        </div>
+    <SectionTitle title="Dénomination commerciale" class="!mt-10" sizeTag="h6" icon="ri-price-tag-2-fill" />
+    <div class="grid grid-cols-2 gap-4">
+      <div class="col-span-2 md:col-span-1 max-w-md">
+        <DsfrInputGroup :error-message="firstErrorMsg(v$, 'name')">
+          <DsfrInput v-model="payload.name" label-visible label="Nom du produit" :required="true" />
+        </DsfrInputGroup>
+        <DsfrInputGroup>
+          <DsfrInput v-model="payload.brand" label-visible label="Marque" />
+        </DsfrInputGroup>
       </div>
-    </DsfrFieldset>
-    <div class="max-w-2xl">
-      <DsfrInput
-        v-if="
-          payload.galenicFormulation &&
-          galenicFormulation &&
-          getAllIndexesOfRegex(galenicFormulation, /Autre.*(à préciser)/).includes(parseInt(payload.galenicFormulation))
-        "
-        v-model="payload.otherGalenicFormulation"
-        label-visible
-        label="Merci de préciser la forme galénique"
-      />
-    </div>
-  </div>
+      <div class="col-span-2 md:col-span-1 max-w-md">
+        <!-- Useless? -->
+        <DsfrInputGroup>
+          <DsfrInput v-model="payload.gamme" label-visible label="Gamme" />
+        </DsfrInputGroup>
 
-  <div class="grid grid-cols-2 gap-4">
-    <div class="col-span-2 md:col-span-1 max-w-md mt-6">
-      <DsfrFieldset legend="Poids ou volume d'une unité de consommation" legendClass="fr-label !font-normal !pb-0">
+        <!-- Useless? -->
+        <DsfrInputGroup>
+          <DsfrInput v-model="payload.flavor" label-visible label="Arôme" />
+        </DsfrInputGroup>
+      </div>
+      <DsfrInputGroup class="max-w-2xl mt-6">
+        <DsfrInput is-textarea v-model="payload.description" label-visible label="Description" :required="true" />
+      </DsfrInputGroup>
+    </div>
+    <SectionTitle title="Format" class="!mt-10" sizeTag="h6" icon="ri-capsule-fill" />
+    <div class="grid grid-cols-2 gap-4">
+      <DsfrFieldset legend="Forme galénique" legendClass="fr-label !font-normal !pb-0">
         <div class="flex">
-          <div class="max-w-64">
-            <DsfrInput v-model="payload.unitQuantity" class="max-w-64" :required="true" />
+          <div class="max-w-32">
+            <DsfrSelect :options="formulationStates" v-model="galenicFormulationState" defaultUnselectedText="État" />
           </div>
-          <div class="max-w-32 ml-4">
+          <div class="max-w-md ml-4">
             <DsfrSelect
-              :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
-              v-model="payload.unitMeasurement"
-              defaultUnselectedText="Unité"
+              v-model="payload.galenicFormulation"
+              :options="
+                galenicFormulationList?.map((formulation) => ({
+                  text: formulation.name,
+                  value: formulation.id,
+                }))
+              "
             />
           </div>
         </div>
       </DsfrFieldset>
-    </div>
-    <div class="col-span-2 md:col-span-1 max-w-md">
-      <DsfrInputGroup>
-        <DsfrInput v-model="payload.conditioning" label-visible label="Conditionnements" />
-      </DsfrInputGroup>
-    </div>
-  </div>
-  <div class="grid grid-cols-2 gap-4">
-    <div class="col-span-2 md:col-span-1 max-w-md">
-      <DsfrInputGroup>
+      <div class="max-w-2xl">
         <DsfrInput
-          v-model="payload.dailyRecommendedDose"
+          v-if="
+            payload.galenicFormulation &&
+            galenicFormulation &&
+            getAllIndexesOfRegex(galenicFormulation, /Autre.*(à préciser)/).includes(
+              parseInt(payload.galenicFormulation)
+            )
+          "
+          v-model="payload.otherGalenicFormulation"
           label-visible
-          label="Dose journalière recommandée"
-          :required="true"
+          label="Merci de préciser la forme galénique"
         />
-      </DsfrInputGroup>
-    </div>
-    <div class="col-span-2 md:col-span-1 max-w-md">
-      <DsfrInputGroup>
-        <DsfrInput
-          :required="true"
-          v-model="payload.minimumDuration"
-          label-visible
-          label="Durabilité minimale / DLUO (en mois)"
-        />
-      </DsfrInputGroup>
-    </div>
-  </div>
-  <DsfrInputGroup class="max-w-2xl mt-6">
-    <DsfrInput v-model="payload.instructions" label-visible label="Mode d'emploi" />
-  </DsfrInputGroup>
-  <DsfrInputGroup class="max-w-2xl mt-6">
-    <DsfrInput is-textarea v-model="payload.warning" label-visible label="Mise en garde et avertissement" />
-  </DsfrInputGroup>
-  <SectionTitle title="Populations cible" class="!mt-10" sizeTag="h6" icon="ri-file-user-fill" />
-  <DsfrFieldset legend="Population cible" legendClass="fr-label">
-    <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
-      <div
-        v-for="population in populations"
-        :key="`effect-${population.id}`"
-        class="flex col-span-6 sm:col-span-3 lg:col-span-2"
-      >
-        <input
-          :id="`population-${population.id}`"
-          type="checkbox"
-          v-model="payload.populations"
-          :value="population.id"
-        />
-        <label :for="`population-${population.id}`" class="fr-label ml-2">{{ population.name }}</label>
       </div>
     </div>
-  </DsfrFieldset>
 
-  <DsfrFieldset legend="Consommation déconseillée" legendClass="fr-label">
-    <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
-      <div
-        v-for="condition in conditions"
-        :key="`condition-${condition.id}`"
-        class="flex col-span-6 sm:col-span-3 lg:col-span-2"
-      >
-        <input
-          :id="`condition-${condition.id}`"
-          type="checkbox"
-          v-model="payload.conditionsNotRecommended"
-          :value="condition.id"
-        />
-        <label :for="`condition-${condition.id}`" class="fr-label ml-2">{{ condition.name }}</label>
+    <div class="grid grid-cols-2 gap-4">
+      <div class="col-span-2 md:col-span-1 max-w-md mt-6">
+        <DsfrFieldset legend="Poids ou volume d'une unité de consommation" legendClass="fr-label !font-normal !pb-0">
+          <div class="flex">
+            <div class="max-w-64">
+              <DsfrInput v-model="payload.unitQuantity" class="max-w-64" :required="true" />
+            </div>
+            <div class="max-w-32 ml-4">
+              <DsfrSelect
+                :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
+                v-model="payload.unitMeasurement"
+                defaultUnselectedText="Unité"
+              />
+            </div>
+          </div>
+        </DsfrFieldset>
+      </div>
+      <div class="col-span-2 md:col-span-1 max-w-md">
+        <DsfrInputGroup>
+          <DsfrInput v-model="payload.conditioning" label-visible label="Conditionnements" />
+        </DsfrInputGroup>
       </div>
     </div>
-  </DsfrFieldset>
-  <SectionTitle title="Objectifs / effets" class="!mt-10" sizeTag="h6" icon="ri-focus-2-fill" />
-  <DsfrFieldset>
-    <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
-      <div v-for="effect in effects" :key="`effect-${effect.id}`" class="flex col-span-6 sm:col-span-3 lg:col-span-2">
-        <input :id="`effect-${effect.id}`" type="checkbox" v-model="payload.effects" :value="effect.id" />
-        <label :for="`effect-${effect.id}`" class="fr-label ml-2">{{ effect.name }}</label>
+    <div class="grid grid-cols-2 gap-4">
+      <div class="col-span-2 md:col-span-1 max-w-md">
+        <DsfrInputGroup>
+          <DsfrInput
+            v-model="payload.dailyRecommendedDose"
+            label-visible
+            label="Dose journalière recommandée"
+            :required="true"
+          />
+        </DsfrInputGroup>
+      </div>
+      <div class="col-span-2 md:col-span-1 max-w-md">
+        <DsfrInputGroup>
+          <DsfrInput
+            :required="true"
+            v-model="payload.minimumDuration"
+            label-visible
+            label="Durabilité minimale / DLUO (en mois)"
+          />
+        </DsfrInputGroup>
       </div>
     </div>
-  </DsfrFieldset>
-
-  <DsfrInputGroup class="max-w-2xl mt-6" v-if="payload.effects && payload.effects.indexOf(otherEffectsId) > -1">
-    <DsfrInput
-      v-model="payload.otherEffects"
-      label-visible
-      label="Merci de préciser les autres objectifs ou effets"
-      :required="true"
-    />
-  </DsfrInputGroup>
-  <SectionTitle title="Adresse sur l'étiquetage" class="!mt-10" sizeTag="h6" icon="ri-home-2-fill" />
-  <div class="max-w-2xl mb-8 address-form">
-    <DsfrInputGroup>
-      <DsfrInput v-model="payload.address" label-visible label="Adresse" hint="Numéro et voie" :required="true" />
+    <DsfrInputGroup class="max-w-2xl mt-6">
+      <DsfrInput v-model="payload.instructions" label-visible label="Mode d'emploi" />
     </DsfrInputGroup>
-    <DsfrInputGroup>
+    <DsfrInputGroup class="max-w-2xl mt-6">
+      <DsfrInput is-textarea v-model="payload.warning" label-visible label="Mise en garde et avertissement" />
+    </DsfrInputGroup>
+    <SectionTitle title="Populations cible" class="!mt-10" sizeTag="h6" icon="ri-file-user-fill" />
+    <DsfrFieldset legend="Population cible" legendClass="fr-label">
+      <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
+        <div
+          v-for="population in populations"
+          :key="`effect-${population.id}`"
+          class="flex col-span-6 sm:col-span-3 lg:col-span-2"
+        >
+          <input
+            :id="`population-${population.id}`"
+            type="checkbox"
+            v-model="payload.populations"
+            :value="population.id"
+          />
+          <label :for="`population-${population.id}`" class="fr-label ml-2">{{ population.name }}</label>
+        </div>
+      </div>
+    </DsfrFieldset>
+
+    <DsfrFieldset legend="Consommation déconseillée" legendClass="fr-label">
+      <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
+        <div
+          v-for="condition in conditions"
+          :key="`condition-${condition.id}`"
+          class="flex col-span-6 sm:col-span-3 lg:col-span-2"
+        >
+          <input
+            :id="`condition-${condition.id}`"
+            type="checkbox"
+            v-model="payload.conditionsNotRecommended"
+            :value="condition.id"
+          />
+          <label :for="`condition-${condition.id}`" class="fr-label ml-2">{{ condition.name }}</label>
+        </div>
+      </div>
+    </DsfrFieldset>
+    <SectionTitle title="Objectifs / effets" class="!mt-10" sizeTag="h6" icon="ri-focus-2-fill" />
+    <DsfrFieldset>
+      <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
+        <div v-for="effect in effects" :key="`effect-${effect.id}`" class="flex col-span-6 sm:col-span-3 lg:col-span-2">
+          <input :id="`effect-${effect.id}`" type="checkbox" v-model="payload.effects" :value="effect.id" />
+          <label :for="`effect-${effect.id}`" class="fr-label ml-2">{{ effect.name }}</label>
+        </div>
+      </div>
+    </DsfrFieldset>
+
+    <DsfrInputGroup class="max-w-2xl mt-6" v-if="payload.effects && payload.effects.indexOf(otherEffectsId) > -1">
       <DsfrInput
-        v-model="payload.additionalDetails"
+        v-model="payload.otherEffects"
         label-visible
-        label="Complément d'adresse"
-        hint="Bâtiment, immeuble, escalier et numéro d’appartement"
+        label="Merci de préciser les autres objectifs ou effets"
+        :required="true"
       />
     </DsfrInputGroup>
-    <div class="grid grid-cols-7 gap-6">
-      <DsfrInputGroup class="col-span-12 md:col-span-3">
-        <DsfrInput v-model="payload.postalCode" label-visible label="Code Postal" :required="true" />
+    <SectionTitle title="Adresse sur l'étiquetage" class="!mt-10" sizeTag="h6" icon="ri-home-2-fill" />
+    <div class="max-w-2xl mb-8 address-form">
+      <DsfrInputGroup>
+        <DsfrInput v-model="payload.address" label-visible label="Adresse" hint="Numéro et voie" :required="true" />
       </DsfrInputGroup>
-      <DsfrInputGroup class="col-span-12 md:col-span-4">
-        <DsfrInput v-model="payload.city" label-visible label="Ville ou commune" :required="true" />
+      <DsfrInputGroup>
+        <DsfrInput
+          v-model="payload.additionalDetails"
+          label-visible
+          label="Complément d'adresse"
+          hint="Bâtiment, immeuble, escalier et numéro d’appartement"
+        />
+      </DsfrInputGroup>
+      <div class="grid grid-cols-7 gap-6">
+        <DsfrInputGroup class="col-span-12 md:col-span-3">
+          <DsfrInput v-model="payload.postalCode" label-visible label="Code Postal" :required="true" />
+        </DsfrInputGroup>
+        <DsfrInputGroup class="col-span-12 md:col-span-4">
+          <DsfrInput v-model="payload.city" label-visible label="Ville ou commune" :required="true" />
+        </DsfrInputGroup>
+      </div>
+      <DsfrInputGroup>
+        <DsfrInput v-model="payload.cedex" label-visible label="Cedex" />
+      </DsfrInputGroup>
+      <DsfrInputGroup>
+        <CountryField v-model="payload.country" />
       </DsfrInputGroup>
     </div>
-    <DsfrInputGroup>
-      <DsfrInput v-model="payload.cedex" label-visible label="Cedex" />
-    </DsfrInputGroup>
-    <DsfrInputGroup>
-      <CountryField v-model="payload.country" />
-    </DsfrInputGroup>
   </div>
 </template>
 <script setup>

--- a/frontend/src/views/ProducerFormPage/SummaryStep.vue
+++ b/frontend/src/views/ProducerFormPage/SummaryStep.vue
@@ -1,11 +1,13 @@
 <template>
-  <DsfrAlert v-if="!readonly">
-    <p class="mb-2">Veuillez vérifier les données ci-dessous avant de procéder à la validation de votre démarche</p>
-    <DsfrButton @click="emit('submit')" label="Soumettre ma démarche" />
-  </DsfrAlert>
+  <div>
+    <DsfrAlert v-if="!readonly">
+      <p class="mb-2">Veuillez vérifier les données ci-dessous avant de procéder à la validation de votre démarche</p>
+      <DsfrButton @click="emit('submit')" label="Soumettre ma démarche" />
+    </DsfrAlert>
 
-  <SectionTitle class="!mt-8" title="Votre démarche" sizeTag="h6" icon="ri-file-text-line" />
-  <DeclarationSummary v-model="payload" :readonly="readonly" />
+    <SectionTitle class="!mt-8" title="Votre démarche" sizeTag="h6" icon="ri-file-text-line" />
+    <DeclarationSummary v-model="payload" :readonly="readonly" />
+  </div>
 </template>
 
 <script setup>


### PR DESCRIPTION
Afin d'enlever les warnings de Vue concernant les composants qui render plusieurs nodes et qui reçoivent des attributs j'ai mis un div au premier niveau de chaque composant `step`.

```
[Vue warn]: Extraneous non-props attributes were passed to component 
but could not be automatically inherited because component renders fragment or 
text root nodes.
```

Ces `non-props attributes` existent car on utilise un composant générique pour rendre les différents steps, et certaines props ne sont pas applicables à tous les steps.

Pour un CR plus rapide, assurez-vous de faire "Hide whitespace". Le changement est vraiment petit

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/6bd02e08-90a5-495d-ae41-7d9c07697dda)

