### PR TITLE
Switch entreprises 🔄 lors qu'on en a plus d'une

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -203,7 +203,7 @@ const routes = [
             },
           },
           {
-            path: "gestion-des-collaborateurs",
+            path: "gestion-des-collaborateurs/:id",
             name: "CollaboratorsPage",
             component: CollaboratorsPage,
             meta: {
@@ -280,9 +280,8 @@ const chooseAuthorisedRoute = async (to, from, next, store) => {
     }
     const authenticationCheck = !to.meta.authenticationRequired || store.loggedUser
     const roleCheck =
-      !to.meta.requiredRole ||
-      store.company?.roles?.some((x) => x.name === to.meta.requiredRole) ||
-      store.loggedUser?.globalRoles?.some((x) => x.name === to.meta.requiredRole)
+      !to.meta.requiredRole || store.companies?.some((c) => c.roles?.some((x) => x.name === to.meta.requiredRole))
+    store.loggedUser?.globalRoles?.some((x) => x.name === to.meta.requiredRole)
 
     authenticationCheck && roleCheck ? next() : next({ name: "LoginPage" })
   }

--- a/frontend/src/stores/root.js
+++ b/frontend/src/stores/root.js
@@ -28,10 +28,7 @@ export const useRootStore = defineStore("root", () => {
     // TODO: add error handling here, but weird bug with await and response
   }
 
-  const company = computed(() =>
-    // Pour le moment, prend la 1ère entreprise de la liste comme entreprise par défaut.
-    loggedUser.value.companies?.length > 0 ? loggedUser.value.companies[0] : null
-  )
+  const companies = computed(() => loggedUser.value.companies)
 
   const resetInitialData = () => {
     loggedUser.value = null
@@ -72,7 +69,7 @@ export const useRootStore = defineStore("root", () => {
   }
   return {
     loggedUser,
-    company,
+    companies,
     initialDataLoaded,
     fetchInitialData,
     resetInitialData,

--- a/frontend/src/views/CollaboratorsPage/index.vue
+++ b/frontend/src/views/CollaboratorsPage/index.vue
@@ -65,10 +65,13 @@ import { roleNameDisplayNameMapping } from "@/utils/mappings"
 import ClaimsBlock from "./ClaimsBlock"
 import SentInvitationsBlock from "./SentInvitationsBlock.vue"
 import AddNewCollaborator from "./AddNewCollaborator"
+import { useRoute } from "vue-router"
 
+const route = useRoute()
 const store = useRootStore()
-const { loggedUser, company } = storeToRefs(store)
+const { loggedUser, companies } = storeToRefs(store)
 
+const company = computed(() => companies.value?.find((c) => +c.id === +route.params.id))
 const canRoleBeAddedTo = (roleName, user) => !user.roles.some((role) => role.name === roleName)
 
 // Requête initiale pour récupérer les collaborateurs de l'entreprise

--- a/frontend/src/views/DashboardPage/RoleBarBlock.vue
+++ b/frontend/src/views/DashboardPage/RoleBarBlock.vue
@@ -7,11 +7,17 @@
             <v-icon class="text-blue-france-sun-113" name="ri-account-circle-line" />
             <div class="shrink-0 fr-notice__title text-blue-france-sun-113">Bienvenue, {{ name }}</div>
           </div>
-          <div v-if="company" class="flex gap-x-1.5">
-            <RoleTag v-for="role in company.roles" :key="role.name" :role="role" />
+          <div v-if="activeCompany" class="flex gap-x-1.5">
+            <RoleTag v-for="role in activeCompany.roles" :key="role.name" :role="role" />
           </div>
         </div>
-        <CompanyTag v-if="company" :name="company.socialName" />
+        <CompanyTag v-if="activeCompany && companies.length === 1" :name="activeCompany.socialName" />
+        <DsfrSelect
+          v-else-if="companies.length > 1"
+          :options="companiesSelectOptions"
+          :modelValue="activeCompany?.id"
+          @update:modelValue="(x) => emit('changeCompany', x)"
+        />
       </div>
     </div>
   </div>
@@ -20,6 +26,10 @@
 <script setup>
 import RoleTag from "@/components/RoleTag.vue"
 import CompanyTag from "@/components/CompanyTag.vue"
+import { computed } from "vue"
 
-defineProps({ name: String, company: Object })
+const emit = defineEmits(["changeCompany"])
+const props = defineProps({ name: String, activeCompany: Object, companies: Array })
+
+const companiesSelectOptions = computed(() => props.companies?.map((c) => ({ text: c.socialName, value: c.id })))
 </script>

--- a/frontend/src/views/DashboardPage/index.vue
+++ b/frontend/src/views/DashboardPage/index.vue
@@ -56,7 +56,7 @@ onMounted(() => {
   }
 })
 
-const onChangeCompany = (id) => router.replace({ query: { company: id } })
+const onChangeCompany = (id) => router.push({ query: { company: id } })
 
 const supervisorActions = computed(() => [
   {

--- a/frontend/src/views/DashboardPage/index.vue
+++ b/frontend/src/views/DashboardPage/index.vue
@@ -1,9 +1,14 @@
 <template>
   <div>
-    <RoleBarBlock :name="loggedUser.firstName" :company="company" />
+    <RoleBarBlock
+      @changeCompany="onChangeCompany"
+      :name="loggedUser.firstName"
+      :companies="companies"
+      :activeCompany="company"
+    />
     <div class="fr-container my-8 flex flex-col gap-8">
       <ActionGrid
-        v-if="isSupervisor"
+        v-if="isSupervisorForActiveCompany"
         :actions="supervisorActions"
         :title="`Gestion de l'entreprise ${company.socialName}`"
         icon="ri-home-4-line"
@@ -17,21 +22,39 @@
 </template>
 
 <script setup>
-import { computed } from "vue"
+import { computed, onMounted } from "vue"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import ActionGrid from "./ActionGrid"
 import RoleBarBlock from "./RoleBarBlock"
+import { useRoute } from "vue-router"
+import { useRouter } from "vue-router"
 
 const store = useRootStore()
-const { loggedUser, company } = storeToRefs(store)
+const router = useRouter()
+const route = useRoute()
+const { loggedUser, companies } = storeToRefs(store)
 
-const emptyRoles = computed(() => !company.value || !company.value.roles || company.value.roles.length === 0)
-const isSupervisor = computed(() => company.value?.roles.some((x) => x.name === "SupervisorRole"))
-const isDeclarant = computed(() => company.value?.roles.some((x) => x.name === "DeclarantRole"))
+const company = computed(() => companies.value?.find((c) => +c.id === +route.query.company))
+const isSupervisor = computed(() => companies?.value.some((c) => c.roles?.some((x) => x.name === "SupervisorRole")))
+const isDeclarant = computed(() => companies?.value.some((c) => c.roles?.some((x) => x.name === "DeclarantRole")))
 const isInstructor = computed(() => loggedUser.value?.globalRoles.some((x) => x.name === "InstructionRole"))
+const emptyRoles = computed(() => !isSupervisor.value && !isDeclarant.value && !isInstructor.value)
 
-const supervisorActions = [
+const isSupervisorForActiveCompany = computed(() => company.value?.roles?.some((x) => x.name === "SupervisorRole"))
+
+// Si on voulait lier le bloc délcarant.e à l'entreprise active, on pourrait utiliser cette
+// computed var dans le v-if de ce bloc
+// const isDeclarantForActiveCompany = computed(() => company.value?.roles?.some((x) => x.name === "DeclarantRole"))
+
+// Sélectionne une entreprise si l'user est un superviseur et qu'on n'a pas le queryparam
+onMounted(() => {
+  if (companies.value?.length && !route.query.company) router.replace({ query: { company: companies.value[0].id } })
+})
+
+const onChangeCompany = (id) => router.replace({ query: { company: id } })
+
+const supervisorActions = computed(() => [
   {
     title: "Les déclarations de mon entreprise",
     description: "Visualisez et gérez les déclarations de votre entreprise",
@@ -39,19 +62,19 @@ const supervisorActions = [
   {
     title: "Les collaborateurs de mon entreprise",
     description: "Gérez les différents collaborateurs, leurs rôles, les demandes, et invitez-en des nouveaux",
-    link: { name: "CollaboratorsPage" },
+    link: { name: "CollaboratorsPage", params: { id: company.value?.id } },
   },
   {
     title: "Les coordonnées de l'entreprise",
     description: "Consultez et mettez à jour les données de votre entreprise",
-    link: { name: "CompanyPage", params: { id: company.value.id } },
+    link: { name: "CompanyPage", params: { id: company.value?.id } },
   },
   {
     title: "Nouvelle entreprise",
     description: "Créez ou rejoignez une nouvelle entreprise",
     link: { name: "CompanyFormPage" },
   },
-]
+])
 
 const declarantActions = [
   {

--- a/frontend/src/views/DashboardPage/index.vue
+++ b/frontend/src/views/DashboardPage/index.vue
@@ -49,7 +49,11 @@ const isSupervisorForActiveCompany = computed(() => company.value?.roles?.some((
 
 // Sélectionne une entreprise si l'user est un superviseur et qu'on n'a pas le queryparam
 onMounted(() => {
-  if (companies.value?.length && !route.query.company) router.replace({ query: { company: companies.value[0].id } })
+  const hasInvalidCompanyParam = route.query.company && !company.value
+  if (hasInvalidCompanyParam || !route.query.company) {
+    const query = companies.value?.length ? { company: companies.value[0].id } : {}
+    router.replace({ query })
+  }
 })
 
 const onChangeCompany = (id) => router.replace({ query: { company: id } })


### PR DESCRIPTION
Ceci est une version initiale du switch de l'entreprise. Ça permet de tester plus simplement les différents cas et de voir les différents rôles par entreprise.

- L'entreprise choisie est affichée dans le URL et persisté dans l'historique (donc possibilité de back/fwd)
- Les actions de gestion sont dynamiques (les liens incluent le paramètre de l'entreprise)

## Out of scope
- Sauvegarde dans le local storage de la dernière entreprise sélectionnée

#### Pas de changements pour les cas 0 ou 1 entreprise : 
Aucun changement là dessus pour l'existant. 
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/c9c0d9ab-5db6-4df6-af49-9e3a1e5a6082)

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/02f5c2b0-0ab9-4268-bd36-ba175782bd41)


## Lors qu'on a plus d'une entreprise : 

Par contre, si on a plus d'une entreprise on a un select (pas très beau) qui permet de la changer. Par la suite on pourra améliorer la UI également.

[Screencast from 04-06-24 12:01:54.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/5c484012-8386-449e-8a73-1120905d9353)

