### PR TITLE
Page déclarations pour l'entreprise

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -265,6 +265,7 @@ class SimpleDeclarationSerializer(serializers.ModelSerializer):
             "gamme",
             "description",
             "modification_date",
+            "creation_date",
         )
         read_only_fields = fields
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -48,6 +48,11 @@ urlpatterns = {
     path("companies/", views.CompanyCreateView.as_view(), name="company_create"),
     path("companies/<int:pk>", views.CompanyRetrieveUpdateView.as_view(), name="company_retrieve_update"),
     path(
+        "companies/<int:pk>/declarations/",
+        views.CompanyDeclarationsListView.as_view(),
+        name="company_declarations_list_view",
+    ),
+    path(
         "companies/<int:pk>/collaborators",
         views.CompanyCollaboratorsListView.as_view(),
         name="get_company_collaborators",

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -7,6 +7,7 @@ from .declaration import (
     DeclarationRetrieveUpdateView,
     DeclarationSubmitView,
     AllDeclarationsListView,
+    CompanyDeclarationsListView,
 )
 from .effect import EffectListView
 from .galenic_formulation import GalenicFormulationListView

--- a/api/views/declaration/__init__.py
+++ b/api/views/declaration/__init__.py
@@ -3,4 +3,5 @@ from .declaration import (  # noqa: F401
     DeclarationRetrieveUpdateView,
     DeclarationSubmitView,
     AllDeclarationsListView,
+    CompanyDeclarationsListView,
 )

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -30,6 +30,7 @@ import CollaboratorsPage from "@/views/CollaboratorsPage"
 import AllDeclarationsPage from "@/views/AllDeclarationsPage"
 import InstructionPage from "@/views/InstructionPage"
 import OfficialLetterPage from "@/views/OfficialLetterPage"
+import CompanyDeclarationsPage from "@/views/CompanyDeclarationsPage"
 
 const routes = [
   {
@@ -209,6 +210,19 @@ const routes = [
             meta: {
               title: "Gestion des collaborateurs",
               requiredRole: "SupervisorRole",
+            },
+          },
+          {
+            path: "les-declarations-de-mon-entreprise/:id",
+            name: "CompanyDeclarationsPage",
+            component: CompanyDeclarationsPage,
+            meta: {
+              title: "Les déclarations de mon entreprise",
+              requiredRole: "SupervisorRole",
+              defaultQueryParams: {
+                page: 1,
+                status: "",
+              },
             },
           },
           {

--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -45,3 +45,11 @@ export const statusProps = {
 }
 
 export const roleNameDisplayNameMapping = { DeclarantRole: "déclarant", SupervisorRole: "gestionnaire" }
+
+export const statusFilterOptions = [
+  { value: "", text: "Tous les statuts" },
+  { value: "AWAITING_INSTRUCTION", text: "En attente d'instruction" },
+  { value: "AWAITING_PRODUCER", text: "En attente de retour du producteur" },
+  { value: "REJECTED", text: "Rejeté" },
+  { value: "APPROVED", text: "Validé" },
+]

--- a/frontend/src/views/AllDeclarationsPage/index.vue
+++ b/frontend/src/views/AllDeclarationsPage/index.vue
@@ -62,6 +62,7 @@ import InstructionDeclarationsTable from "./InstructionDeclarationsTable"
 import { useRoute, useRouter } from "vue-router"
 import { getPagesForPagination } from "@/utils/components"
 import { DsfrInput } from "@gouvminint/vue-dsfr"
+import { statusFilterOptions } from "@/utils/mappings"
 
 const router = useRouter()
 const route = useRoute()
@@ -73,14 +74,6 @@ const offset = computed(() => (page.value - 1) * limit)
 const limit = 10
 const pages = computed(() => getPagesForPagination(data.value.count, limit, route.path))
 const openDeclaration = (id) => router.push({ name: "InstructionPage", params: { declarationId: id } })
-
-const statusFilterOptions = [
-  { value: "", text: "Tous les statuts" },
-  { value: "AWAITING_INSTRUCTION", text: "En attente d'instruction" },
-  { value: "AWAITING_PRODUCER", text: "En attente de retour du producteur" },
-  { value: "REJECTED", text: "Rejeté" },
-  { value: "APPROVED", text: "Validé" },
-]
 
 // Valeurs obtenus du queryparams
 const page = computed(() => parseInt(route.query.page))

--- a/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
@@ -1,0 +1,42 @@
+<template>
+  <DsfrTable
+    ref="table"
+    class="w-full"
+    title="Toutes les déclarations"
+    :headers="headers"
+    :rows="rows"
+    :no-caption="true"
+    :pagination="false"
+  />
+</template>
+
+<script setup>
+import { computed } from "vue"
+import { timeAgo } from "@/utils/date"
+import { getStatusTagForCell } from "@/utils/components"
+
+const props = defineProps({ data: { type: Object, default: () => {} } })
+
+const headers = ["Nom du produit", "Auteur", "État de la déclaration", "Date de création", "Date de modification"]
+const rows = computed(() =>
+  props.data?.results?.map((x) => ({
+    rowData: [
+      {
+        component: "router-link",
+        text: x.name,
+        to: { name: "DeclarationPage", params: { id: x.id } }, // TODO Change to a more enteprisey view
+      },
+      `${x.author.firstName} ${x.author.lastName}`,
+      getStatusTagForCell(x.status),
+      timeAgo(x.creationDate),
+      timeAgo(x.modificationDate),
+    ],
+  }))
+)
+</script>
+
+<style scoped>
+.fr-table :deep(table) {
+  @apply !table;
+}
+</style>

--- a/frontend/src/views/CompanyDeclarationsPage/index.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/index.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="fr-container">
+    <DsfrBreadcrumb
+      class="mb-8"
+      :links="[
+        { to: { name: 'DashboardPage' }, text: 'Tableau de bord' },
+        { text: `Les déclarations de l'entreprise ${company.socialName}` },
+      ]"
+    />
+    <div class="border px-4 pb-4 mb-2 sm:flex gap-8 items-baseline filters">
+      <DsfrInputGroup>
+        <DsfrSelect
+          :modelValue="filteredStatus"
+          label="Filtrer par statut"
+          :options="statusFilterOptions"
+          @update:modelValue="updateStatusFilter"
+        />
+      </DsfrInputGroup>
+    </div>
+    <div v-if="isFetching" class="flex justify-center my-10">
+      <ProgressSpinner />
+    </div>
+    <div v-else-if="hasDeclarations">
+      <CompanyDeclarationsTable :data="data" />
+    </div>
+    <p v-else class="mb-8">Il n'y a pas encore de déclarations.</p>
+    <DsfrPagination
+      v-if="showPagination"
+      @update:currentPage="updatePage"
+      :pages="pages"
+      :current-page="page - 1"
+      :truncLimit="5"
+    />
+  </div>
+</template>
+
+<script setup>
+import { useFetch } from "@vueuse/core"
+import { storeToRefs } from "pinia"
+import { useRootStore } from "@/stores/root"
+import { computed, watch } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import { handleError } from "@/utils/error-handling"
+import CompanyDeclarationsTable from "./CompanyDeclarationsTable"
+import ProgressSpinner from "@/components/ProgressSpinner"
+import { statusFilterOptions } from "@/utils/mappings"
+
+const route = useRoute()
+const store = useRootStore()
+const router = useRouter()
+const { loggedUser, companies } = storeToRefs(store)
+const company = computed(() => companies.value?.find((c) => +c.id === +route.params.id))
+
+const limit = 10
+const hasDeclarations = computed(() => data.value?.count > 0)
+const showPagination = computed(() => data.value?.count > data.value?.results?.length)
+const offset = computed(() => (page.value - 1) * limit)
+
+// Valeurs obtenus du queryparams
+const page = computed(() => parseInt(route.query.page))
+const filteredStatus = computed(() => route.query.status)
+
+const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...newQuery } })
+const updateStatusFilter = (status) => updateQuery({ status })
+const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
+
+const url = computed(
+  () =>
+    `/api/v1/declarations/?company=${company.value?.id}&limit=${limit}&offset=${offset.value}&status=${filteredStatus.value || ""}`
+)
+const { response, data, isFetching, execute } = useFetch(url).get().json()
+const fetchSearchResults = async () => {
+  await execute()
+  await handleError(response)
+}
+
+watch([page, filteredStatus], fetchSearchResults)
+</script>

--- a/frontend/src/views/CompanyDeclarationsPage/index.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/index.vue
@@ -66,7 +66,7 @@ const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
 
 const url = computed(
   () =>
-    `/api/v1/declarations/?company=${company.value?.id}&limit=${limit}&offset=${offset.value}&status=${filteredStatus.value || ""}`
+    `/api/v1/companies/${company.value?.id}/declarations/?&limit=${limit}&offset=${offset.value}&status=${filteredStatus.value || ""}`
 )
 const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {

--- a/frontend/src/views/DashboardPage/index.vue
+++ b/frontend/src/views/DashboardPage/index.vue
@@ -62,6 +62,7 @@ const supervisorActions = computed(() => [
   {
     title: "Les déclarations de mon entreprise",
     description: "Visualisez et gérez les déclarations de votre entreprise",
+    link: { name: "CompanyDeclarationsPage", params: { id: company.value?.id } },
   },
   {
     title: "Les collaborateurs de mon entreprise",


### PR DESCRIPTION
> [!WARNING]  
> Cette branche est basée sur #545 : switch entreprise

## Démo 

[Screencast from 04-06-24 15:51:34.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/77a659f8-b608-4428-abd8-80a690e25476)

Cette PR ajoute une table de déclarations basique dans la tuile "déclarations de mon entreprise".

J'ai décidé d'utiliser une nouvelle route `api/v1/companies/id/declarations` au lieu d'utiliser `api/v1/declarations` car cette dernière est utilisée par la modalité instruction - et ça sera utile d'avoir les deux séparées pour pouvoir par exemple les sérialiser de façon différente (des commentaires privées à destination de l'administration ne devraient pas se retrouver dans la vue des gestionnaires).

À terme on continuera à peaufiner les données qu'on renvoie, pour l'instant on a au moins une table basique avec les déclarations par entreprise.
