### PR TITLE
Vue de l'historique pour l'instruction

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -20,3 +20,4 @@ from .autocomplete_item import AutocompleteItemSerializer
 from .declaration import DeclarationSerializer, DeclarationShortSerializer, SimpleDeclarationSerializer
 from .company import CompanySerializer
 from .solicitation import CollaborationInvitationSerializer, CoSupervisionClaimSerializer, AddNewCollaboratorSerializer
+from .snapshot import SnapshotSerializer

--- a/api/serializers/snapshot.py
+++ b/api/serializers/snapshot.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+from data.models import Snapshot
+
+from .user import SimpleUserSerializer
+
+
+class SnapshotSerializer(serializers.ModelSerializer):
+    user = SimpleUserSerializer()
+
+    class Meta:
+        model = Snapshot
+
+        fields = ["creation_date", "comment", "status", "json_declaration", "user", "id"]
+        read_only_fields = fields

--- a/api/tests/test_snapshot.py
+++ b/api/tests/test_snapshot.py
@@ -32,3 +32,24 @@ class TestSnapshotApi(APITestCase):
         self.assertEqual(snapshot.declaration, declaration)
         self.assertEqual(snapshot.user, declarant_role.user)
         self.assertEqual(snapshot.comment, "Voici notre nouveau produit")
+
+    @authenticate
+    def test_snapshot_list_view(self):
+        declarant_role = DeclarantRoleFactory(user=authenticate.user)
+        company = declarant_role.company
+
+        # Une déclaration avec toutes les conditions nécessaires pour l'instruction
+        declaration = InstructionReadyDeclarationFactory(author=authenticate.user, company=company)
+        payload = {"comment": "Voici notre nouveau produit"}
+        self.client.post(reverse("api:submit_declaration", kwargs={"pk": declaration.id}), payload, format="json")
+        declaration.refresh_from_db()
+        snapshot = declaration.snapshots.first()
+
+        # On obtient les snapshots liés à cette déclaration
+
+        response = self.client.get(reverse("api:declaration_snapshots", kwargs={"pk": declaration.id}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body), 1)
+        self.assertEqual(body[0]["id"], snapshot.id)
+        self.assertEqual(body[0]["comment"], snapshot.comment)

--- a/api/urls.py
+++ b/api/urls.py
@@ -101,6 +101,11 @@ urlpatterns = {
     ),
     path("declarations/", views.AllDeclarationsListView.as_view(), name="list_all_declarations"),
     path("declarations/<int:pk>", views.DeclarationRetrieveUpdateView.as_view(), name="retrieve_update_declaration"),
+    path(
+        "declarations/<int:pk>/snapshots/",
+        views.DeclarationSnapshotListView.as_view(),
+        name="declaration_snapshots",
+    ),
     # Flow de la délcaration (state machine)
     path("declarations/<int:pk>/submit/", views.DeclarationSubmitView.as_view(), name="submit_declaration"),
     path(

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -52,3 +52,4 @@ from .solicitation import (
     CollaborationInvitationListView,
     AddNewCollaboratorView,
 )
+from .snapshot import DeclarationSnapshotListView

--- a/api/views/snapshot.py
+++ b/api/views/snapshot.py
@@ -1,0 +1,16 @@
+from django.shortcuts import get_object_or_404
+
+from rest_framework.generics import ListAPIView
+
+from api.serializers import SnapshotSerializer
+from data.models import Declaration, Snapshot
+
+
+class DeclarationSnapshotListView(ListAPIView):
+    model = Snapshot
+    serializer_class = SnapshotSerializer
+    permission_classes = []  # TODO (permission sur la declaration)
+
+    def get_queryset(self):
+        declaration = get_object_or_404(Declaration, pk=self.kwargs[self.lookup_field])
+        return declaration.snapshots.all()

--- a/api/views/snapshot.py
+++ b/api/views/snapshot.py
@@ -13,4 +13,4 @@ class DeclarationSnapshotListView(ListAPIView):
 
     def get_queryset(self):
         declaration = get_object_or_404(Declaration, pk=self.kwargs[self.lookup_field])
-        return declaration.snapshots.all()
+        return declaration.snapshots.order_by("-creation_date").all()

--- a/api/views/snapshot.py
+++ b/api/views/snapshot.py
@@ -2,6 +2,7 @@ from django.shortcuts import get_object_or_404
 
 from rest_framework.generics import ListAPIView
 
+from api.permissions import IsDeclarationAuthor, IsInstructor
 from api.serializers import SnapshotSerializer
 from data.models import Declaration, Snapshot
 
@@ -9,8 +10,10 @@ from data.models import Declaration, Snapshot
 class DeclarationSnapshotListView(ListAPIView):
     model = Snapshot
     serializer_class = SnapshotSerializer
-    permission_classes = []  # TODO (permission sur la declaration)
+    permission_classes = (IsDeclarationAuthor | IsInstructor,)
 
     def get_queryset(self):
         declaration = get_object_or_404(Declaration, pk=self.kwargs[self.lookup_field])
+        self.check_object_permissions(self.request, declaration)
+        self.check_permissions(self.request)
         return declaration.snapshots.order_by("-creation_date").all()

--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -1,84 +1,98 @@
 <template>
   <div>
-    <DsfrInputGroup>
-      <div class="grid grid-cols-2 gap-6">
-        <DsfrRadioButton
-          v-for="category in decisionCategories"
-          :key="category.value"
-          v-model="decisionCategory"
-          :value="category.value"
-          name="decisionCategory"
-          class="col-span-2 sm:col-span-1 !mb-0"
-        >
-          <template v-slot:label>
-            <div class="font-bold">
-              <v-icon :color="category.color" :name="category.icon" aria-hidden />
-              {{ category.title }}
-            </div>
-            <p class="fr-text--sm !mb-0">
-              {{ category.description }}
-            </p>
-          </template>
-        </DsfrRadioButton>
-      </div>
-    </DsfrInputGroup>
-  </div>
-  <div v-if="decisionCategory === 'modify'" class="reject-reasons">
-    <hr />
-    <div class="mb-8" v-for="reason in rejectReasons" :key="reason.title">
-      <p class="font-bold">{{ reason.title }}</p>
-      <DsfrInputGroup v-for="item in reason.items" :key="item">
-        <DsfrCheckbox :label="item" />
+    <div>
+      <DsfrInputGroup>
+        <div class="grid grid-cols-2 gap-6">
+          <DsfrRadioButton
+            v-for="category in decisionCategories"
+            :key="category.value"
+            v-model="decisionCategory"
+            :value="category.value"
+            name="decisionCategory"
+            class="col-span-2 sm:col-span-1 !mb-0"
+          >
+            <template v-slot:label>
+              <div class="font-bold">
+                <v-icon :color="category.color" :name="category.icon" aria-hidden />
+                {{ category.title }}
+              </div>
+              <p class="fr-text--sm !mb-0">
+                {{ category.description }}
+              </p>
+            </template>
+          </DsfrRadioButton>
+        </div>
       </DsfrInputGroup>
     </div>
-  </div>
-  <div v-if="decisionCategory">
-    <hr />
-    <h3>Décision</h3>
-    <DsfrHighlight>
-      <template v-slot:default>
-        <div class="sm:flex gap-4">
-          <div class="grow max-w-96">
-            <DsfrInputGroup>
-              <DsfrSelect label="Proposition" v-model="proposal" :options="proposalOptions"></DsfrSelect>
-            </DsfrInputGroup>
-          </div>
-          <div class="visa-checkbox content-end">
-            <DsfrInputGroup>
-              <DsfrCheckbox label="À viser" />
-            </DsfrInputGroup>
-          </div>
-          <div class="content-end" v-if="decisionCategory != 'approve'">
-            <DsfrInputGroup>
-              <DsfrInput v-model="delayDays" label="Délai de réponse (jours)" label-visible />
-            </DsfrInputGroup>
-          </div>
-        </div>
-        <DsfrInputGroup>
-          <DsfrInput
-            is-textarea
-            label-visible
-            label="Motivation de la décision (à destination du professionel)"
-            v-if="decisionCategory != 'approve'"
-          />
+    <div v-if="decisionCategory === 'modify'" class="reject-reasons">
+      <hr />
+      <div class="mb-8" v-for="reason in rejectReasons" :key="reason.title">
+        <p class="font-bold">{{ reason.title }}</p>
+        <DsfrInputGroup v-for="item in reason.items" :key="item">
+          <DsfrCheckbox :label="item" />
         </DsfrInputGroup>
-      </template>
-    </DsfrHighlight>
-    <hr />
-    <DsfrInputGroup>
-      <DsfrInput is-textarea label-visible label="Notes de l'expert (à destination de l'administration)" />
-    </DsfrInputGroup>
+      </div>
+    </div>
+    <div v-if="decisionCategory">
+      <hr />
+      <h3>Décision</h3>
+      <DsfrHighlight>
+        <template v-slot:default>
+          <div class="sm:flex gap-4">
+            <div class="grow max-w-96">
+              <DsfrInputGroup>
+                <DsfrSelect label="Proposition" v-model="proposal" :options="proposalOptions"></DsfrSelect>
+              </DsfrInputGroup>
+            </div>
+            <div class="visa-checkbox content-end">
+              <DsfrInputGroup>
+                <DsfrCheckbox disabled label="À viser" />
+              </DsfrInputGroup>
+            </div>
+            <div class="content-end" v-if="decisionCategory != 'approve'">
+              <DsfrInputGroup>
+                <DsfrInput v-model="delayDays" label="Délai de réponse (jours)" label-visible />
+              </DsfrInputGroup>
+            </div>
+          </div>
+          <DsfrInputGroup>
+            <DsfrInput
+              is-textarea
+              label-visible
+              label="Motivation de la décision (à destination du professionel)"
+              v-if="decisionCategory != 'approve'"
+              v-model="comment"
+            />
+          </DsfrInputGroup>
+          <DsfrButton label="Soumettre" :disabled="!canSubmitDecision" @click="submitDecision" />
+        </template>
+      </DsfrHighlight>
+      <hr />
+      <DsfrInputGroup>
+        <DsfrInput is-textarea label-visible label="Notes de l'expert (à destination de l'administration)" />
+      </DsfrInputGroup>
+    </div>
   </div>
 </template>
 
 <script setup>
 import { ref, computed, watch } from "vue"
+import { useFetch } from "@vueuse/core"
+import { headers } from "@/utils/data-fetching"
+import useToaster from "@/composables/use-toaster"
+import { handleError } from "@/utils/error-handling"
+
+const $externalResults = ref({})
+const props = defineProps(["declarationId"])
+
+const emit = defineEmits(["reload-declaration"])
 
 const decisionCategory = ref(null)
 watch(decisionCategory, () => (proposal.value = decisionCategory.value === "approve" ? "approve" : null))
 
 const proposal = ref(null)
 const delayDays = ref(30)
+const comment = ref("")
 
 const decisionCategories = [
   {
@@ -140,11 +154,28 @@ const proposalOptions = computed(() => {
   if (decisionCategory.value === "approve") return [{ text: "Autorisation", value: "autorisation" }]
 
   return [
-    { text: "Objection", value: "objection" },
+    // { text: "Objection", value: "objection" },
     { text: "Observation", value: "observation" },
-    { text: "Refus", value: "rejection" },
+    // { text: "Refus", value: "rejection" },
   ]
 })
+
+const canSubmitDecision = computed(() => !!proposal.value && !!delayDays.value)
+const submitDecision = async () => {
+  const actions = {
+    observation: "observe-no-visa",
+    approve: "authorize-no-visa",
+  }
+
+  const url = `/api/v1/declarations/${props.declarationId}/${actions[proposal.value]}/`
+  const { response } = await useFetch(url, { headers: headers() }).post({ comment: comment.value }).json()
+  $externalResults.value = await handleError(response)
+
+  if (response.value.ok) {
+    useToaster().addSuccessMessage("Votre décision a été prise en compte")
+    emit("reload-declaration")
+  }
+}
 </script>
 
 <style scoped>

--- a/frontend/src/views/InstructionPage/HistoryTab.vue
+++ b/frontend/src/views/InstructionPage/HistoryTab.vue
@@ -3,8 +3,16 @@
     <div v-if="isFetching" class="flex justify-center items-center min-h-60">
       <ProgressSpinner />
     </div>
-    <div v-if="snapshots">
-      <SnapshotItem v-for="snapshot in snapshots" :key="`snapshot-${snapshot.id}`" :snapshot="snapshot" />
+    <div v-if="snapshots && snapshots.length" class="flex flex-col gap-6">
+      <SnapshotItem
+        v-for="snapshot in snapshots"
+        :key="`snapshot-${snapshot.id}`"
+        :snapshot="snapshot"
+        :rightSide="showOnRight(snapshot)"
+      />
+    </div>
+    <div v-else>
+      <p>Nous n'avons pas l'historique pour cette déclaration.</p>
     </div>
   </div>
 </template>
@@ -31,4 +39,9 @@ onMounted(async () => {
   await execute()
   handleError(response)
 })
+
+const showOnRight = (snapshot) => {
+  const rightSideStatus = ["OBSERVATION", "AUTHORIZED"]
+  return rightSideStatus.indexOf(snapshot.status) > -1
+}
 </script>

--- a/frontend/src/views/InstructionPage/HistoryTab.vue
+++ b/frontend/src/views/InstructionPage/HistoryTab.vue
@@ -1,7 +1,34 @@
 <template>
-  <DsfrAlert
-    type="info"
-    title="En cours de développement"
-    description="L'onglet « historique » est en cours de création"
-  />
+  <div>
+    <div v-if="isFetching" class="flex justify-center items-center min-h-60">
+      <ProgressSpinner />
+    </div>
+    <div v-if="snapshots">
+      <SnapshotItem v-for="snapshot in snapshots" :key="`snapshot-${snapshot.id}`" :snapshot="snapshot" />
+    </div>
+  </div>
 </template>
+
+<script setup>
+import { useFetch } from "@vueuse/core"
+import { onMounted } from "vue"
+import { handleError } from "@/utils/error-handling"
+import ProgressSpinner from "@/components/ProgressSpinner"
+import SnapshotItem from "@/views/InstructionPage/SnapshotItem"
+
+const props = defineProps(["declarationId"])
+
+const {
+  response,
+  data: snapshots,
+  execute,
+  isFetching,
+} = useFetch(() => `/api/v1/declarations/${props.declarationId}/snapshots/`, { immediate: false })
+  .get()
+  .json()
+
+onMounted(async () => {
+  await execute()
+  handleError(response)
+})
+</script>

--- a/frontend/src/views/InstructionPage/SnapshotItem.vue
+++ b/frontend/src/views/InstructionPage/SnapshotItem.vue
@@ -7,12 +7,12 @@
       <div v-if="snapshot.comment" class="italic mb-2 rounded-xl bg-slate-100 p-4 rounded-tl-none">
         {{ snapshot.comment }}
       </div>
-      <div>
+      <div class="fr-text--sm !mb-0 !text-slate-500">
         {{ isoToPrettyDate(snapshot.creationDate) }} à
         {{ isoToPrettyTime(snapshot.creationDate) }}
       </div>
       <div>
-        {{ snapshot.user.firstName }} {{ snapshot.user.lastName }} a changé le statut à «
+        {{ snapshot.user.firstName }} {{ snapshot.user.lastName }} a changé le status à «
         <span class="font-bold">{{ statusProps[snapshot.status].label }}</span>
         »
         <span v-if="!snapshot.comment">sans laisser de message</span>

--- a/frontend/src/views/InstructionPage/SnapshotItem.vue
+++ b/frontend/src/views/InstructionPage/SnapshotItem.vue
@@ -1,11 +1,24 @@
 <template>
-  <div class="flex gap-4">
-    <div class="rounded-full w-12 h-12 bg-blue-france-925 flex items-center justify-center">
+  <div
+    :class="{
+      flex: true,
+      'gap-4': true,
+      'flex-row-reverse': rightSide,
+      'text-right': rightSide,
+      'right-side': rightSide,
+    }"
+  >
+    <div class="initials rounded-full min-w-12 w-12 h-12 flex items-center justify-center">
       {{ initials }}
     </div>
     <div class="max-w-xl">
-      <div v-if="snapshot.comment" class="italic mb-2 rounded-xl bg-slate-100 p-4 rounded-tl-none">
-        {{ snapshot.comment }}
+      <div :class="`flex ${rightSide ? 'justify-end' : 'justify-start'}`">
+        <div
+          v-if="snapshot.comment"
+          :class="`comment italic mb-2 rounded-xl p-4 ${rightSide ? 'rounded-tr-none' : 'rounded-tl-none'}`"
+        >
+          {{ snapshot.comment }}
+        </div>
       </div>
       <div class="fr-text--sm !mb-0 !text-slate-500">
         {{ isoToPrettyDate(snapshot.creationDate) }} à
@@ -25,7 +38,18 @@
 import { computed } from "vue"
 import { statusProps } from "@/utils/mappings"
 import { isoToPrettyDate, isoToPrettyTime } from "@/utils/date"
-const props = defineProps({ snapshot: Object })
+const props = defineProps({ snapshot: Object, rightSide: Boolean })
 
 const initials = computed(() => `${props.snapshot.user.firstName?.[0]}${props.snapshot.user.lastName?.[0]}`)
 </script>
+
+<style scoped>
+.initials,
+.comment {
+  @apply bg-blue-france-950;
+}
+.right-side .initials,
+.right-side .comment {
+  @apply bg-slate-100;
+}
+</style>

--- a/frontend/src/views/InstructionPage/SnapshotItem.vue
+++ b/frontend/src/views/InstructionPage/SnapshotItem.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="flex gap-4">
+    <div class="rounded-full w-12 h-12 bg-blue-france-925 flex items-center justify-center">
+      {{ initials }}
+    </div>
+    <div class="max-w-xl">
+      <div v-if="snapshot.comment" class="italic mb-2 rounded-xl bg-slate-100 p-4 rounded-tl-none">
+        {{ snapshot.comment }}
+      </div>
+      <div>
+        {{ isoToPrettyDate(snapshot.creationDate) }} à
+        {{ isoToPrettyTime(snapshot.creationDate) }}
+      </div>
+      <div>
+        {{ snapshot.user.firstName }} {{ snapshot.user.lastName }} a changé le statut à «
+        <span class="font-bold">{{ statusProps[snapshot.status].label }}</span>
+        »
+        <span v-if="!snapshot.comment">sans laisser de message</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue"
+import { statusProps } from "@/utils/mappings"
+import { isoToPrettyDate, isoToPrettyTime } from "@/utils/date"
+const props = defineProps({ snapshot: Object })
+
+const initials = computed(() => `${props.snapshot.user.firstName?.[0]}${props.snapshot.user.lastName?.[0]}`)
+</script>

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -29,7 +29,7 @@
           <SummaryTab v-model="declaration" />
         </DsfrTabContent>
         <DsfrTabContent panelId="tab-content-2" tabId="tab-2" :selected="selectedTabIndex === 2" :asc="asc">
-          <HistoryTab />
+          <HistoryTab :declarationId="declaration?.id" />
         </DsfrTabContent>
         <DsfrTabContent panelId="tab-content-3" tabId="tab-3" :selected="selectedTabIndex === 3" :asc="asc">
           <DecisionTab />

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -12,36 +12,52 @@
       <ProgressSpinner />
     </div>
     <div v-else>
-      <DsfrAlert v-if="isDraft" type="warning" title="Cette déclaration n'est pas encore prête pour instruction">
-        <p>La déclaration est en mode brouillon et peut encore être modifié par l'utilisateur.</p>
-        <DsfrButton
-          class="mt-2"
-          label="Retour à la liste de déclarations"
-          tertiary
-          @click="$router.push({ name: 'AllDeclarations' })"
-        />
+      <DsfrAlert
+        class="mb-4"
+        v-if="isAwaitingInstruction"
+        type="info"
+        title="Cette déclaration n'est pas encore assignée"
+      >
+        <p>Vous pouvez vous assigner cette déclaration pour instruction</p>
+        <DsfrButton class="mt-2" label="Instruire" tertiary @click="instructDeclaration" />
       </DsfrAlert>
-      <DsfrTabs v-if="declaration" ref="tabs" :tab-titles="tabTitles" :initialSelectedIndex="0" @select-tab="selectTab">
-        <DsfrTabContent panelId="tab-content-0" tabId="tab-0" :selected="selectedTabIndex === 0" :asc="asc">
-          <IdentityTab :user="declarant" :company="company" />
-        </DsfrTabContent>
-        <DsfrTabContent panelId="tab-content-1" tabId="tab-1" :selected="selectedTabIndex === 1" :asc="asc">
-          <SummaryTab v-model="declaration" />
-        </DsfrTabContent>
-        <DsfrTabContent panelId="tab-content-2" tabId="tab-2" :selected="selectedTabIndex === 2" :asc="asc">
-          <HistoryTab :declarationId="declaration?.id" />
-        </DsfrTabContent>
-        <DsfrTabContent panelId="tab-content-3" tabId="tab-3" :selected="selectedTabIndex === 3" :asc="asc">
-          <DecisionTab />
-        </DsfrTabContent>
-      </DsfrTabs>
+      <DsfrAlert
+        class="mb-4"
+        v-else-if="!canInstruct"
+        :type="declaration.status === 'AUTHORIZED' ? 'success' : 'info'"
+        :title="`Cette déclaration est en status « ${statusProps[declaration.status].label} »`"
+      />
+      <div v-if="declaration">
+        <SummaryTab v-model="declaration" v-if="isAwaitingInstruction" />
+
+        <DsfrTabs v-else ref="tabs" :tab-titles="tabTitles" :initialSelectedIndex="0" @select-tab="selectTab">
+          <DsfrTabContent panelId="tab-content-0" tabId="tab-0" :selected="selectedTabIndex === 0" :asc="asc">
+            <IdentityTab :user="declarant" :company="company" />
+          </DsfrTabContent>
+          <DsfrTabContent panelId="tab-content-1" tabId="tab-1" :selected="selectedTabIndex === 1" :asc="asc">
+            <SummaryTab v-model="declaration" />
+          </DsfrTabContent>
+          <DsfrTabContent panelId="tab-content-2" tabId="tab-2" :selected="selectedTabIndex === 2" :asc="asc">
+            <HistoryTab :declarationId="declaration?.id" />
+          </DsfrTabContent>
+          <DsfrTabContent
+            v-if="canInstruct"
+            panelId="tab-content-3"
+            tabId="tab-3"
+            :selected="selectedTabIndex === 3"
+            :asc="asc"
+          >
+            <DecisionTab :declarationId="declaration?.id" @reload-declaration="reloadDeclaration" />
+          </DsfrTabContent>
+        </DsfrTabs>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
 import { useRootStore } from "@/stores/root"
-import { onMounted, computed, ref } from "vue"
+import { onMounted, computed, ref, nextTick } from "vue"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
@@ -49,15 +65,20 @@ import SummaryTab from "./SummaryTab"
 import IdentityTab from "./IdentityTab"
 import HistoryTab from "./HistoryTab"
 import DecisionTab from "./DecisionTab"
+import { headers } from "@/utils/data-fetching"
+import { statusProps } from "@/utils/mappings"
 
 const store = useRootStore()
 store.fetchDeclarationFieldsData()
+const $externalResults = ref({})
+const tabs = ref(null) // Corresponds to the template ref (https://vuejs.org/guide/essentials/template-refs.html#accessing-the-refs)
 
 const props = defineProps({
   declarationId: String,
 })
 
-const isDraft = computed(() => declaration.value?.status === "DRAFT")
+const isAwaitingInstruction = computed(() => declaration.value?.status === "AWAITING_INSTRUCTION")
+const canInstruct = computed(() => declaration.value?.status === "ONGOING_INSTRUCTION")
 
 // Requêtes
 const isFetching = ref(true)
@@ -94,16 +115,36 @@ onMounted(async () => {
 })
 
 // Tab management
-const tabTitles = [
-  { title: "Identité", icon: "ri-shield-user-line", tabId: "tab-0", panelId: "tab-content-0" },
-  { title: "Le produit", icon: "ri-flask-line", tabId: "tab-1", panelId: "tab-content-1" },
-  { title: "Historique", icon: "ri-chat-3-line", tabId: "tab-2", panelId: "tab-content-2" },
-  { title: "Décision", icon: "ri-checkbox-circle-line", tabId: "tab-3", panelId: "tab-content-3" },
-]
+const tabTitles = computed(() => {
+  const tabs = [
+    { title: "Identité", icon: "ri-shield-user-line", tabId: "tab-0", panelId: "tab-content-0" },
+    { title: "Le produit", icon: "ri-flask-line", tabId: "tab-1", panelId: "tab-content-1" },
+    { title: "Historique", icon: "ri-chat-3-line", tabId: "tab-2", panelId: "tab-content-2" },
+  ]
+  if (canInstruct.value)
+    tabs.push({ title: "Décision", icon: "ri-checkbox-circle-line", tabId: "tab-3", panelId: "tab-content-3" })
+  return tabs
+})
 const selectedTabIndex = ref(0)
 const asc = ref(true) // Je n'aime pas le nommage mais ça vient de ce paramètre : https://vue-dsfr.netlify.app/?path=/docs/composants-dsfrtabs--docs
 const selectTab = (index) => {
   asc.value = selectedTabIndex.value < index
   selectedTabIndex.value = index
+}
+
+const instructDeclaration = async () => {
+  const url = `/api/v1/declarations/${props.declarationId}/take-for-instruction/`
+  const { response } = await useFetch(url, { headers: headers() }).post({}).json()
+  $externalResults.value = await handleError(response)
+
+  if (response.value.ok) {
+    await executeDeclarationFetch()
+  }
+}
+
+const reloadDeclaration = async () => {
+  tabs.value?.selectIndex?.(0)
+  await nextTick()
+  await executeDeclarationFetch()
 }
 </script>

--- a/frontend/src/views/ProducerFormPage/ProductStep.vue
+++ b/frontend/src/views/ProducerFormPage/ProductStep.vue
@@ -199,13 +199,17 @@
           hint="Bâtiment, immeuble, escalier et numéro d’appartement"
         />
       </DsfrInputGroup>
-      <div class="grid grid-cols-7 gap-6">
-        <DsfrInputGroup class="col-span-12 md:col-span-3">
-          <DsfrInput v-model="payload.postalCode" label-visible label="Code Postal" :required="true" />
-        </DsfrInputGroup>
-        <DsfrInputGroup class="col-span-12 md:col-span-4">
-          <DsfrInput v-model="payload.city" label-visible label="Ville ou commune" :required="true" />
-        </DsfrInputGroup>
+      <div class="grid grid-cols-12 gap-6">
+        <div class="col-span-12 md:col-span-4">
+          <DsfrInputGroup>
+            <DsfrInput v-model="payload.postalCode" label-visible label="Code Postal" :required="true" />
+          </DsfrInputGroup>
+        </div>
+        <div class="col-span-12 md:col-span-5">
+          <DsfrInputGroup>
+            <DsfrInput v-model="payload.city" label-visible label="Ville ou commune" :required="true" />
+          </DsfrInputGroup>
+        </div>
       </div>
       <DsfrInputGroup>
         <DsfrInput v-model="payload.cedex" label-visible label="Cedex" />

--- a/frontend/src/views/ProducerFormPage/SummaryStep.vue
+++ b/frontend/src/views/ProducerFormPage/SummaryStep.vue
@@ -2,7 +2,16 @@
   <div>
     <DsfrAlert v-if="!readonly">
       <p class="mb-2">Veuillez vérifier les données ci-dessous avant de procéder à la validation de votre démarche</p>
-      <DsfrButton @click="emit('submit')" label="Soumettre ma démarche" />
+      <DsfrInputGroup>
+        <DsfrInput
+          class="!max-w-lg"
+          label="Commentaires à destination de l'administration"
+          labelVisible
+          v-model="comment"
+          :isTextarea="true"
+        />
+      </DsfrInputGroup>
+      <DsfrButton @click="emit('submit', comment)" label="Soumettre ma démarche" />
     </DsfrAlert>
 
     <SectionTitle class="!mt-8" title="Votre démarche" sizeTag="h6" icon="ri-file-text-line" />
@@ -11,10 +20,12 @@
 </template>
 
 <script setup>
+import { ref } from "vue"
 import DeclarationSummary from "@/components/DeclarationSummary"
 import SectionTitle from "@/components/SectionTitle"
 
 const payload = defineModel()
 const emit = defineEmits(["submit"])
+const comment = ref("")
 defineProps({ readonly: Boolean })
 </script>

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -5,7 +5,11 @@
     </div>
   </div>
 
-  <div class="fr-container" v-if="!isFetching">
+  <div v-if="isFetching" class="flex justify-center items-center min-h-60">
+    <ProgressSpinner />
+  </div>
+
+  <div class="fr-container" v-else>
     <StepButtons
       class="mb-6 mt-3"
       @next="goForward"
@@ -34,6 +38,7 @@
   </div>
 </template>
 <script setup>
+import ProgressSpinner from "@/components/ProgressSpinner"
 import { useRootStore } from "@/stores/root"
 import { onMounted, ref, computed, watch } from "vue"
 import ProductStep from "./ProductStep"
@@ -138,9 +143,9 @@ const savePayload = async () => {
   }
 }
 
-const submitPayload = async () => {
+const submitPayload = async (comment) => {
   const url = `/api/v1/declarations/${payload.value.id}/submit/`
-  const { response } = await useFetch(url, { headers: headers() }).post().json()
+  const { response } = await useFetch(url, { headers: headers() }).post({ comment }).json()
   $externalResults.value = await handleError(response)
 
   if ($externalResults.value) {


### PR DESCRIPTION
## Contexte

La PR #559 introduit les _snapshots_, un objet utilisé pour le tab « historique » de l'instruction. Cette PR vise à passer les snapshots au frontend pour les afficher.

## Scope de la PR

- Un nouveau champ de texte libre permet au déclarant.e d'ajouter un commentaire avant de soumettre sa déclaration. Ce commentaire sera ajouté au snapshot créé.
- Un serializer et URL permettent d'obtenir les snapshots d'une déclaration particulière (`declarations/<int:pk>/snapshots/`)
- La view pour les instructrices contient un tab « historique ». Les snapshots sont affichés à cet endroit.

## Captures d'écran
Plusieurs snapshots avec des commentaries :
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/ae37028a-4367-426c-907e-17964d2d8b94)

Un snapshot avec un commentaire : 
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/0063cf3a-26fa-43c1-ab1d-0a38359fb61a)

Un snapshot sans commentaire : 
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/10f22e61-6d56-4813-9a2f-d2fce1212389)

Le champ pour ajouter le commentaire : 
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/e164a9d5-c77b-49c7-868b-35fc76a9e346)

Du point de vue d'un.e instructeur.ice, lors qu'une déclaration n'a pas encore été assignée : 
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/6b0a7cef-3e9e-48af-aa6b-baa3a33a3d93)
