### PR TITLE
Possibilité de voir les images et PDFs joints dans les déclarations

### DIFF
--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="border p-4 flex flex-col gap-2">
+    <DsfrModal size="xl" v-if="!isPDF" :opened="imageModalOpened" @close="imageModalOpened = false">
+      <img :src="file.file" class="object-contain" :alt="`Image téléchargée ${props.file.name}`" />
+    </DsfrModal>
     <div class="border-b -mx-4 -mt-4 h-32 bg-blue-france-975 flex justify-center items-center">
       <v-icon v-if="isPDF" scale="3" name="ri-file-text-line" />
       <img v-else :src="file.file" class="object-contain h-32" :alt="`Image téléchargée ${props.file.name}`" />
@@ -15,14 +18,28 @@
       />
     </DsfrInputGroup>
     <div v-else>{{ documentTypes.find((x) => x.value === file.type)?.text }}</div>
-    <div v-if="!props.readonly">
-      <DsfrButton @click="$emit('remove', file)" label="Supprimer" secondary size="sm" />
+    <div class="flex gap-2">
+      <a :href="file.file" v-if="isPDF" target="_blank" class="fr-btn fr-btn--secondary fr-btn--sm inline-flex">
+        Télécharger PDF
+      </a>
+
+      <DsfrButton icon="ri-eye-line" @click="imageModalOpened = true" v-else label="Voir image" secondary size="sm" />
+      <DsfrButton
+        icon="ri-close-fill"
+        @click="$emit('remove', file)"
+        label="Supprimer"
+        secondary
+        size="sm"
+        v-if="!props.readonly"
+      />
     </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from "vue"
+import { computed, ref } from "vue"
+
+const imageModalOpened = ref(false)
 
 const props = defineProps({ file: Object, hideTypeSelection: Boolean, readonly: Boolean })
 const isPDF = computed(() => props.file?.name?.endsWith("pdf"))


### PR DESCRIPTION
## Contexte

Aujourd'hui on montre seulement la petite carte avec le preview de l'image. On a donc besoin de pouvoir agrandir les images ou de pouvoir télécharger les PDFs.

## Solution

Pour les images on utilise un `DSFRModal` qui affiche l'image en plus grand. Pour les PDFs on ouvre le PDF dans un nouvel onglet.

## Démo
[Screencast from 18-06-24 10:30:17.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/885ff3ed-2cb9-40b8-8059-07bcfb0fd575)

