### PR TITLE
Ajout d'information dans la table de déclarations pour l'instructeur.ice

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -250,6 +250,7 @@ class AttachmentSerializer(IdPassthrough, serializers.ModelSerializer):
 
 
 class SimpleDeclarationSerializer(serializers.ModelSerializer):
+    instructor = SimpleUserSerializer(read_only=True, source="instructor.user")
     author = SimpleUserSerializer(read_only=True)
     company = SimpleCompanySerializer(read_only=True)
 
@@ -266,11 +267,13 @@ class SimpleDeclarationSerializer(serializers.ModelSerializer):
             "description",
             "modification_date",
             "creation_date",
+            "instructor",
         )
         read_only_fields = fields
 
 
 class DeclarationSerializer(serializers.ModelSerializer):
+    instructor = SimpleUserSerializer(read_only=True, source="instructor.user")
     author = serializers.PrimaryKeyRelatedField(read_only=True, allow_null=True)
     company = serializers.PrimaryKeyRelatedField(queryset=Company.objects.all(), allow_null=True)
     unit_measurement = serializers.PrimaryKeyRelatedField(
@@ -330,11 +333,13 @@ class DeclarationSerializer(serializers.ModelSerializer):
             "computed_substances",
             "attachments",
             "other_effects",
+            "instructor",
         )
         read_only_fields = (
             "id",
             "status",
             "author",
+            "instructor",
         )
 
     def create(self, validated_data):

--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -198,7 +198,7 @@ class TestDeclarationFlow(APITestCase):
     @authenticate
     def test_resubmit_declaration(self):
         """
-        Passage du OBSERVATION -> ONGOING_INSTRUCTION
+        Passage du OBSERVATION -> AWAITING_INSTRUCTION
         """
         company = CompanyFactory()
         declarant = DeclarantRoleFactory(user=authenticate.user, company=company)
@@ -208,12 +208,12 @@ class TestDeclarationFlow(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         declaration.refresh_from_db()
-        self.assertEqual(declaration.status, Declaration.DeclarationStatus.ONGOING_INSTRUCTION)
+        self.assertEqual(declaration.status, Declaration.DeclarationStatus.AWAITING_INSTRUCTION)
 
     @authenticate
     def test_resubmit_declaration_unauthorized(self):
         """
-        Passage du OBSERVATION -> ONGOING_INSTRUCTION
+        Passage du OBSERVATION -> AWAITING_INSTRUCTION
         Seulement possible pour l'auteur de la déclaration
         """
         declaration = ObservationDeclarationFactory()
@@ -224,7 +224,7 @@ class TestDeclarationFlow(APITestCase):
 
     def test_resubmit_declaration_unauthenticated(self):
         """
-        Passage du OBSERVATION -> ONGOING_INSTRUCTION
+        Passage du OBSERVATION -> AWAITING_INSTRUCTION
         Pas possible pour personnes non-authentifiées
         """
         declaration = ObservationDeclarationFactory()

--- a/api/views/declaration/declaration_flow.py
+++ b/api/views/declaration/declaration_flow.py
@@ -26,7 +26,7 @@ class DeclarationFlow:
     def submit(self):
         self.ensure_validators([validate_number_of_elements, validate_mandatory_fields])
 
-    @status.transition(source=Status.OBSERVATION, target=Status.ONGOING_INSTRUCTION)
+    @status.transition(source=Status.OBSERVATION, target=Status.AWAITING_INSTRUCTION)
     def resubmit(self):
         self.ensure_validators([validate_number_of_elements, validate_mandatory_fields])
 

--- a/frontend/src/views/AllDeclarationsPage/InstructionDeclarationsTable.vue
+++ b/frontend/src/views/AllDeclarationsPage/InstructionDeclarationsTable.vue
@@ -14,25 +14,38 @@
 import { computed } from "vue"
 import { timeAgo } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
+import { useRootStore } from "@/stores/root"
+import { storeToRefs } from "pinia"
+
+const { loggedUser } = storeToRefs(useRootStore())
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 
-const headers = ["Nom du produit", "Entreprise", "Auteur", "État de la déclaration", "Date de modification"]
+const headers = ["", "Nom du produit", "Entreprise", "État de la déclaration", "Date de modification", "Instruit par"]
 const rows = computed(() =>
   props.data?.results?.map((x) => ({
+    rowAttrs: { class: needsAttention(x) ? "font-bold" : "" },
     rowData: [
+      needsAttention(x) ? { component: "div", class: "h-3 w-3 rounded-full bg-orange-400" } : "",
       {
         component: "router-link",
         text: x.name,
         to: { name: "InstructionPage", params: { declarationId: x.id } },
       },
       x.company.socialName,
-      `${x.author.firstName} ${x.author.lastName}`,
       getStatusTagForCell(x.status),
       timeAgo(x.modificationDate),
+      x.instructor
+        ? `${x.instructor.firstName} ${x.instructor.lastName}`
+        : { component: "span", text: "Non-assigné", class: "italic" },
     ],
   }))
 )
+
+const needsAttention = (declaration) =>
+  !!declaration.instructor &&
+  declaration.instructor.id === loggedUser.value.id &&
+  declaration.status === "AWAITING_INSTRUCTION"
 </script>
 
 <style scoped>

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -140,15 +140,10 @@ const selectTab = (index) => {
   selectedTabIndex.value = index
 }
 
-const takeDeclaration = async () => {
+const instructDeclaration = async () => {
   const url = `/api/v1/declarations/${props.declarationId}/take-for-instruction/`
   const { response } = await useFetch(url, { headers: headers() }).post({}).json()
   $externalResults.value = await handleError(response)
-  return response
-}
-
-const instructDeclaration = async () => {
-  const response = await takeDeclaration()
 
   if (response.value.ok) {
     await executeDeclarationFetch()


### PR DESCRIPTION
## Contexte

Aujourd'hui on a une table qui liste toutes les déclarations non-brouillon pour les personnes ayant le rôle d'instructeur.ice. Dans cette table certaines informations était manquantes, notamment : 
- si la déclaration était assignée et a qui, et
- si elle était "non-lue" (çad assignée à la personne identifiée et nécessitant d'attention)

## Flow

Voici un petit rappel de la state machine. On va se focaliser sur les états représentés par les boîtes bleues.

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/971dfb45-a39b-409e-9fe1-ff04ea7b16cc)

Une fois qu'une personne soumet une déclaration, celle-ci se trouve en état `AWAITING_INSTRUCTION` et n'est pas assignée a aucune instructrice, donc sa propriété `instructor` est _null_, Dans la table, ça s'afficherait comme ça :

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/63f51911-e33c-449f-a83b-94874b6e9807)

Une fois qu'on clique dessus on peut s'assigner cette déclaration. Elle passe donc dans l'état `ONGOING_INSTRUCTION` et se voit assignée un.e instructeur.ice. L'affichage est comme ça : 

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/b397d30a-7200-49d9-9f1d-2963d1d1f09b)

Le ou la instructeur.ice peut mettre la déclaration en observation. L'affichage : 
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/0a5a0f34-d7ab-4ec6-a666-1dd2002e0dcd)

Et finalement le ou la déclarant.e peut re-soumettre sa déclaration après l'observation. Ceci remet son état à `AWAITING_INSTRUCTION` mais cette fois-ci on a un personne assignée, donc on sait qui doit être notifié. On montre ce cas comme ça : 

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/ef866065-53d0-4507-9171-447ddf4b5c0f)

Si l'instructeur.ice click sur la ligne, elle passe automatiquement à `ONGOING_INSTRUCTION`

## Captures d'écran

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/d2ad9bb0-66bd-4912-8351-e3ed1533396b)

