### PR TITLE
Possibilité de voir le snapshot de la déclaration dans l'élément de l'historique 

### DIFF
--- a/frontend/src/views/InstructionPage/SnapshotItem.vue
+++ b/frontend/src/views/InstructionPage/SnapshotItem.vue
@@ -8,6 +8,10 @@
       'right-side': rightSide,
     }"
   >
+    <DsfrModal size="xl" :opened="modalOpened" @close="modalOpened = false" class="text-left">
+      <h2>Version de la déclaration au {{ date }}</h2>
+      <DeclarationSummary :readonly="true" v-model="snapshot.jsonDeclaration" />
+    </DsfrModal>
     <div class="initials rounded-full min-w-12 w-12 h-12 flex items-center justify-center">
       {{ initials }}
     </div>
@@ -20,9 +24,15 @@
           {{ snapshot.comment }}
         </div>
       </div>
-      <div class="fr-text--sm !mb-0 !text-slate-500">
-        {{ isoToPrettyDate(snapshot.creationDate) }} à
-        {{ isoToPrettyTime(snapshot.creationDate) }}
+      <div
+        :class="`${rightSide ? 'justify-end' : 'justify-start'} fr-text--sm !mb-0 !text-slate-500 flex gap-4 items-center pb-1`"
+      >
+        <div>
+          {{ date }}
+        </div>
+        <div>
+          <DsfrButton tertiary label="Voir" size="sm" @click="modalOpened = true" />
+        </div>
       </div>
       <div>
         {{ snapshot.user.firstName }} {{ snapshot.user.lastName }} a changé le status à «
@@ -35,12 +45,18 @@
 </template>
 
 <script setup>
-import { computed } from "vue"
+import { computed, ref } from "vue"
 import { statusProps } from "@/utils/mappings"
 import { isoToPrettyDate, isoToPrettyTime } from "@/utils/date"
+import DeclarationSummary from "@/components/DeclarationSummary"
+
 const props = defineProps({ snapshot: Object, rightSide: Boolean })
 
 const initials = computed(() => `${props.snapshot.user.firstName?.[0]}${props.snapshot.user.lastName?.[0]}`)
+const date = computed(
+  () => `${isoToPrettyDate(props.snapshot.creationDate)} à ${isoToPrettyTime(props.snapshot.creationDate)}`
+)
+const modalOpened = ref(false)
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Contexte

Aujourd'hui on a un onglet « Historique » dans le parcours d'instruction. Cet onglet montre les changements d'état de la déclaration avec un message facultatif ajouté par la personne ayant effectué le changement.

Téléicare aujourd'hui permet aussi de voir la déclaration tel qu'elle était au moment de cette transition. Ceci permet aux instructrices de comparer certains champs entre les différentes versions.

## UI

Cette PR est principalement UI car on avait déjà à l'intérieur du modèle `Snapshot` une représentation JSON de la déclaration au moment de la transition.

On ajoute donc un bouton « _Voir_ » à côté de la date :
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/b1a8c9a2-8e18-4112-9c65-27065b685538)

Ce bouton ouvre un modal qui montre les informations de la déclaration au moment de la transition : 
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/babe9aed-088a-4e5b-8945-69770b23d161)

## Démo

[Screencast from 25-06-24 14:46:55.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/7eede1b4-7fab-4a6e-a8b0-d6859ced0945)
