### PR TITLE
Remplissage automatique de l'adresse dans le formulaire de la déclaration

### DIFF
--- a/api/serializers/company.py
+++ b/api/serializers/company.py
@@ -10,6 +10,12 @@ class SimpleCompanySerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "social_name",
+            "address",
+            "additional_details",
+            "postal_code",
+            "city",
+            "cedex",
+            "country",
         )
 
 

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -56,24 +56,22 @@ class TestGetLoggedUser(ProjectAPITestCase):
         supervisor_role_2 = SupervisorRoleFactory(user=user, company=company_2)
 
         response = self.get(self.url())
+        companies = response.data["companies"]
+        self.assertEqual(len(companies), 2)
+        self.assertEqual(len(list(filter(lambda x: x["id"] == company_1.id, companies))), 1)
+        self.assertEqual(len(list(filter(lambda x: x["id"] == company_2.id, companies))), 1)
+
+        json_company_1 = next(filter(lambda x: x["id"] == company_1.id, companies))
+        json_company_2 = next(filter(lambda x: x["id"] == company_2.id, companies))
+
         self.assertCountEqual(
-            response.data["companies"],
+            json_company_1["roles"],
             [
-                {
-                    "id": company_1.id,
-                    "social_name": company_1.social_name,
-                    "roles": [
-                        {"id": supervisor_role_1.id, "name": "SupervisorRole"},
-                        {"id": declarant_role.id, "name": "DeclarantRole"},
-                    ],
-                },
-                {
-                    "id": company_2.id,
-                    "social_name": company_2.social_name,
-                    "roles": [{"id": supervisor_role_2.id, "name": "SupervisorRole"}],
-                },
+                {"id": supervisor_role_1.id, "name": "SupervisorRole"},
+                {"id": declarant_role.id, "name": "DeclarantRole"},
             ],
         )
+        self.assertCountEqual(json_company_2["roles"], [{"id": supervisor_role_2.id, "name": "SupervisorRole"}])
 
     def test_global_roles(self):
         """


### PR DESCRIPTION
_Note_ : Ceci est le fix d'une régression. 

On doit préremplir les champs de l'adresse lors qu'on sélectionne une compagnie dans le formulaire de la déclaration. Cette fonctionnalité était déjà en place côté frontend, mais le serializer ne retournait plus les champs concernant cet adresse, et donc le remplissage ne marchait pas.

## Démo

[Screencast from 25-06-24 23:21:59.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/2f65df10-8731-487d-8162-e9c114bac2d0)
