### PR TITLE
Refuser un visa/signature

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -149,6 +149,11 @@ urlpatterns = {
         views.DeclarationAuthorizeWithVisa.as_view(),
         name="authorize_with_visa",
     ),
+    path(
+        "declarations/<int:pk>/refuse-visa/",
+        views.DeclarationRefuseVisaView.as_view(),
+        name="refuse_visa",
+    ),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -17,6 +17,7 @@ from .declaration.declaration import (
     DeclarationObjectWithVisa,
     DeclarationRejectWithVisa,
     DeclarationAuthorizeWithVisa,
+    DeclarationRefuseVisaView,
 )
 from .effect import EffectListView
 from .galenic_formulation import GalenicFormulationListView

--- a/api/views/declaration/declaration_flow.py
+++ b/api/views/declaration/declaration_flow.py
@@ -53,6 +53,10 @@ class DeclarationFlow:
     def request_visa(self):
         pass
 
+    @status.transition(source=Status.ONGOING_VISA, target=Status.AWAITING_INSTRUCTION)
+    def refuse_visa(self):
+        pass
+
     @status.transition(source=Status.OBSERVATION, target=Status.ABANDONED)
     def abandon(self):
         self.error()

--- a/data/factories/__init__.py
+++ b/data/factories/__init__.py
@@ -24,6 +24,7 @@ from .declaration import (
     AwaitingInstructionDeclarationFactory,
     ObservationDeclarationFactory,
     AwaitingVisaDeclarationFactory,
+    OngoingVisaDeclarationFactory,
 )
 from .solicitation import CollaborationInvitationFactory, CoSupervisionClaimFactory, SupervisionClaimFactory
 from .global_roles import InstructionRoleFactory, VisaRoleFactory

--- a/data/factories/declaration.py
+++ b/data/factories/declaration.py
@@ -6,7 +6,7 @@ from .company import CompanyFactory
 from .condition import ConditionFactory
 from .effect import EffectFactory
 from .galenic_formulation import GalenicFormulationFactory
-from .global_roles import InstructionRoleFactory
+from .global_roles import InstructionRoleFactory, VisaRoleFactory
 from .ingredient import IngredientFactory
 from .microorganism import MicroorganismFactory
 from .plant import PlantFactory
@@ -181,3 +181,14 @@ class AwaitingVisaDeclarationFactory(CompleteDeclarationFactory):
     status = Declaration.DeclarationStatus.AWAITING_VISA
     author = factory.SubFactory(UserFactory)
     instructor = factory.SubFactory(InstructionRoleFactory)
+
+
+class OngoingVisaDeclarationFactory(CompleteDeclarationFactory):
+    status = Declaration.DeclarationStatus.ONGOING_VISA
+    author = factory.SubFactory(UserFactory)
+    instructor = factory.SubFactory(InstructionRoleFactory)
+    visor = factory.SubFactory(VisaRoleFactory)
+
+    post_validation_status = Declaration.DeclarationStatus.AUTHORIZED
+    post_validation_producer_message = factory.Faker("text", max_nb_chars=20)
+    post_validation_expiration_days = factory.Faker("random_int", min=3, max=40)

--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -1,5 +1,3 @@
-const flip = (data) => Object.fromEntries(Object.entries(data).map(([key, value]) => [value, key]))
-
 export const getTypeIcon = (type) => {
   const iconMapping = {
     plant: "ri-plant-line",

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -42,7 +42,7 @@
             :selected="selectedTabIndex === 3"
             :asc="asc"
           >
-            <VisaValidationTab :declaration="declaration" />
+            <VisaValidationTab :declaration="declaration" @reload-declaration="reloadDeclaration" />
           </DsfrTabContent>
         </DsfrTabs>
       </div>
@@ -53,7 +53,7 @@
 <script setup>
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
-import { onMounted, computed, ref } from "vue"
+import { onMounted, computed, ref, nextTick } from "vue"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
@@ -143,5 +143,11 @@ const takeDeclaration = async () => {
   if (response.value.ok) {
     await executeDeclarationFetch()
   }
+}
+
+const reloadDeclaration = async () => {
+  tabs.value?.selectIndex?.(0)
+  await nextTick()
+  await executeDeclarationFetch()
 }
 </script>


### PR DESCRIPTION
Cette PR permet de refuser un visa / signature

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/0dfbf707-8539-4264-b7fa-fbeeb609671d)


Comme pour les autres états, cette PR contient : 
- la `view` pour la transition _En cours de visa_ -> _En attente d'instruction_
- la transition viewflow (dans _api/views/declaration/declaration_flow.py_)
- l'URL exposé pour cette transition
- les tests du nouvel endpoint API
- l'appel depuis la UI à l'endpoint API

## Démo

[Screencast from 02-07-24 15:25:51.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/03cf78e5-2b82-4201-a136-b3d07bb2d547)

