### PR TITLE
Accepter un visa/signature

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -154,6 +154,11 @@ urlpatterns = {
         views.DeclarationRefuseVisaView.as_view(),
         name="refuse_visa",
     ),
+    path(
+        "declarations/<int:pk>/accept-visa/",
+        views.DeclarationAcceptVisaView.as_view(),
+        name="accept_visa",
+    ),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -18,6 +18,7 @@ from .declaration.declaration import (
     DeclarationRejectWithVisa,
     DeclarationAuthorizeWithVisa,
     DeclarationRefuseVisaView,
+    DeclarationAcceptVisaView,
 )
 from .effect import EffectListView
 from .galenic_formulation import GalenicFormulationListView

--- a/api/views/declaration/declaration_flow.py
+++ b/api/views/declaration/declaration_flow.py
@@ -57,6 +57,22 @@ class DeclarationFlow:
     def refuse_visa(self):
         pass
 
+    @status.transition(source=Status.ONGOING_VISA, target=Status.AUTHORIZED)
+    def accept_visa_authorize(self):
+        pass
+
+    @status.transition(source=Status.ONGOING_VISA, target=Status.REJECTED)
+    def accept_visa_reject(self):
+        pass
+
+    @status.transition(source=Status.ONGOING_VISA, target=Status.OBJECTION)
+    def accept_visa_object(self):
+        pass
+
+    @status.transition(source=Status.ONGOING_VISA, target=Status.OBSERVATION)
+    def accept_visa_observe(self):
+        pass
+
     @status.transition(source=Status.OBSERVATION, target=Status.ABANDONED)
     def abandon(self):
         self.error()

--- a/frontend/src/views/VisaPage/VisaValidationTab.vue
+++ b/frontend/src/views/VisaPage/VisaValidationTab.vue
@@ -73,6 +73,16 @@ const refuseVisa = async () => {
   }
 }
 
+const acceptVisa = async () => {
+  const url = `/api/v1/declarations/${props.declaration.id}/accept-visa/`
+  const { response } = await useFetch(url, { headers: headers() }).post({ privateNotes: privateNotes.value }).json()
+  $externalResults.value = await handleError(response)
+  if (response.value.ok) {
+    useToaster().addSuccessMessage("Votre décision a été prise en compte")
+    emit("reload-declaration")
+  }
+}
+
 const decisionCategories = computed(() => {
   return [
     {
@@ -82,7 +92,7 @@ const decisionCategories = computed(() => {
       description: `Je suis d'accord pour donner mon visa et signature. La déclaration partirà en état «
           ${postValidationStatus.value} ».`,
       buttonText: "Valider",
-      buttonHandler: null,
+      buttonHandler: acceptVisa,
     },
     {
       title: "Je ne suis pas d'accord",

--- a/frontend/src/views/VisaPage/VisaValidationTab.vue
+++ b/frontend/src/views/VisaPage/VisaValidationTab.vue
@@ -98,7 +98,7 @@ const decisionCategories = computed(() => {
       title: "Je ne suis pas d'accord",
       icon: "ri-close-circle-fill",
       iconColor: "red",
-      description: `Je ne donne pas mon visa ni signature. La déclaration repartirà en instruction chez
+      description: `Je ne donne pas mon visa ni signature. La déclaration repartira en instruction chez
           ${instructorName.value}.`,
       buttonText: "Refuser",
       buttonHandler: refuseVisa,


### PR DESCRIPTION
> [!NOTE]  
> PR basée sur #618 

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/d4e5d0cc-1265-488a-ac73-f0d1ca3d98dc)

Comme pour les autres états, cette PR contient :

- la view pour la transition En cours de visa -> [Authorisé | Refusé | Objection | Observation]. L'état final est défini en fonction du champ `post_validation_state` de la déclaration.
- la transition viewflow (dans api/views/declaration/declaration_flow.py)
- l'URL exposé pour cette transition
- les tests du nouvel endpoint API
- l'appel depuis la UI à l'endpoint API

## Démo

[Screencast from 02-07-24 18:28:30.webm](https://github.com/betagouv/complements-alimentaires/assets/1225929/f92f8a04-3e61-40e3-aa93-881c96ca3d69)
