### PR TITLE
Lien « mot de passe oublié »

### DIFF
--- a/frontend/src/views/LoginPage.vue
+++ b/frontend/src/views/LoginPage.vue
@@ -16,7 +16,7 @@
           </template>
         </DsfrInput>
         <div class="mt-2">
-          <a class="fr-link" href="#">Mot de passe oublié ?</a>
+          <a class="fr-link" href="/reinitialisation-mot-de-passe">Mot de passe oublié ?</a>
         </div>
       </DsfrInputGroup>
       <DsfrButton class="!block !w-full" :disabled="isFetching" label="Se connecter" @click="submit" />


### PR DESCRIPTION
## Contexte

Aujourd'hui on a deux sets de pages auth : 
- celles gérées par Django (comme le login de l'admin et celui qu'on a sous `web`), et
- celles gérées par Vue et notre API (comme celle sous _frontend/src/views/LoginPage.vue_ qui appelle l'endpoint API _api/v1/login/_)

Les pages auth normalement contiennent plusieurs pages : login, sign-up, confirm-email, etc etc... Et apparement la page _mot de passe oublié_ n'a jamais été faite côté VueJS. Par contre, elle existe bien sous le premier set - celui géré par Django.

## Solution choisie

Pour ne pas passer du temps à créer une page _mot de passe oublié_ côté Vue ainsi que l'endpoint API, je link simplement à la page existante.

Ce n'est pas du strict DSFR, mais ça fait le boulot et c'est une page très peu utilisé. Par la suite on verra si ça vaut la peine de la recoder ou simplement de mettre à jour le CSS dessus pour que ça colle au DSFR

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/a5feb7b2-3034-4995-b359-9236c0496a0d)
