### PR TITLE
Fix pour les éléments dy type `ingredient`

### DIFF
--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -36,6 +36,7 @@ export const frontToAPITypesSlugMapping = {
   substance: "substance",
   // déprécié
   "autre-ingredient": "ingredient",
+  ingredient: "ingredient",
 }
 export const getTypeInFrench = (type) => {
   return typesMapping[type] || null
@@ -54,6 +55,7 @@ export const getApiType = (type) => {
     case "additive":
     case "active_ingredient":
     case "non_active_ingredient":
+    case "ingredient":
       return "other-ingredient"
     default:
       return `${type.replace("_", "-")}`

--- a/frontend/src/views/ProducerFormPage/CompositionStep.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionStep.vue
@@ -36,7 +36,7 @@
       :elements="payload.declaredIngredients.filter((obj) => obj.element.objectType == 'additive')"
     />
     <ElementList
-      @remove="removeElemenpropertyt"
+      @remove="removeElement"
       objectType="active_ingredient"
       :elements="payload.declaredIngredients.filter((obj) => obj.element.objectType == 'active_ingredient')"
     />


### PR DESCRIPTION
Petite PR pour deux fix rapides :

1- Coquille sur le nom de la fonction à appeler pour enlever un élément
2- Ajout des ingrédients legacy dans les fonctions du mapping API, notamment ceux pour qui le type est toujours "ingredient"
