### PR TITLE
Fix pre-démo : coquilles, affichage des champs, wording, accès aux déclarations et affichage d'unités de mesure

### DIFF
--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -682,7 +682,7 @@ class TestDeclarationApi(APITestCase):
     @authenticate
     def test_get_all_declarations_visor(self):
         """
-        Un utilisateur ayant le rôle de visa peut récuperer tous les déclarations
+        Un utilisateur ayant le rôle de visa peut récuperer toutes les déclarations
         """
         VisaRoleFactory(user=authenticate.user)
 

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -23,6 +23,7 @@ from data.factories import (
     SubstanceFactory,
     SubstanceUnitFactory,
     SupervisorRoleFactory,
+    VisaRoleFactory,
 )
 from data.models import Attachment, Declaration
 
@@ -668,13 +669,27 @@ class TestDeclarationApi(APITestCase):
     @authenticate
     def test_get_all_declarations(self):
         """
-        Un utilisateur ayant le rôle d'instruction peut récuperer tous les déclarations
+        Un utilisateur ayant le rôle d'instruction peut récuperer toutes les déclarations
         """
         InstructionRoleFactory(user=authenticate.user)
 
         for _ in range(3):
             DeclarationFactory(status=Declaration.DeclarationStatus.AWAITING_INSTRUCTION)
         response = self.client.get(reverse("api:list_all_declarations"), format="json")
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+
+    @authenticate
+    def test_get_all_declarations_visor(self):
+        """
+        Un utilisateur ayant le rôle de visa peut récuperer tous les déclarations
+        """
+        VisaRoleFactory(user=authenticate.user)
+
+        for _ in range(3):
+            DeclarationFactory(status=Declaration.DeclarationStatus.AWAITING_INSTRUCTION)
+        response = self.client.get(reverse("api:list_all_declarations"), format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 3)
 

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -134,7 +134,7 @@ class GenericDeclarationsListView(ListAPIView):
 
 class OngoingDeclarationsListView(GenericDeclarationsListView):
     serializer_class = SimpleDeclarationSerializer
-    permission_classes = [IsInstructor]
+    permission_classes = [(IsInstructor | IsVisor)]
     ordering_fields = ["creation_date", "modification_date", "name"]
     queryset = Declaration.objects.exclude(status=Declaration.DeclarationStatus.DRAFT)
 

--- a/frontend/src/components/DeclarationAlert.vue
+++ b/frontend/src/components/DeclarationAlert.vue
@@ -1,7 +1,7 @@
 <template>
   <DsfrAlert
     :type="status === 'AUTHORIZED' ? 'success' : 'info'"
-    :title="`Cette déclaration est en status « ${statusProps[status].label} »`"
+    :title="`Cette déclaration est en statut « ${statusProps[status].label} »`"
   />
 </template>
 

--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -79,13 +79,14 @@ import { useRouter } from "vue-router"
 import SummaryModificationButton from "./SummaryModificationButton"
 
 const router = useRouter()
-const { populations, conditions, effects, galenicFormulation } = storeToRefs(useRootStore())
+const { units, populations, conditions, effects, galenicFormulation } = storeToRefs(useRootStore())
 
 const payload = defineModel()
 defineProps({ readonly: Boolean })
 const unitInfo = computed(() => {
   if (!payload.value.unitQuantity) return null
-  return `${payload.value.unitQuantity} ${payload.value.unitMeasurement || "-"}`
+  const unitMeasurement = units.value?.find?.((x) => x.id === payload.value.unitMeasurement)?.name || "-"
+  return `${payload.value.unitQuantity} ${unitMeasurement}`
 })
 
 const galenicFormulationsNames = computed(() => {

--- a/frontend/src/components/HistoryTab.vue
+++ b/frontend/src/components/HistoryTab.vue
@@ -3,6 +3,10 @@
     <div v-if="isFetching" class="flex justify-center items-center min-h-60">
       <ProgressSpinner />
     </div>
+    <div class="bg-gray-100 rounded p-2 mb-8" v-if="privateNotes">
+      <p class="font-bold my-2">Notes à destination de l'administration</p>
+      <p class="m-0 italic">{{ privateNotes }}</p>
+    </div>
     <div v-if="snapshots && snapshots.length" class="flex flex-col gap-6">
       <SnapshotItem
         v-for="snapshot in snapshots"
@@ -24,7 +28,7 @@ import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import SnapshotItem from "@/components/SnapshotItem"
 
-const props = defineProps(["declarationId"])
+const props = defineProps(["declarationId", "privateNotes"])
 
 const {
   response,

--- a/frontend/src/components/SnapshotItem.vue
+++ b/frontend/src/components/SnapshotItem.vue
@@ -38,7 +38,7 @@
         {{ actionText }}
       </div>
       <div v-else>
-        {{ fullName }} a changé le status à « {{ statusProps[snapshot.status].label }} »
+        {{ fullName }} a changé le statut à « {{ statusProps[snapshot.status].label }} »
         <span v-if="!snapshot.comment && !isInValidationState">sans laisser de message</span>
       </div>
     </div>

--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -59,7 +59,7 @@
             <DsfrInput
               is-textarea
               label-visible
-              label="Motivation de la décision (à destination du professionel)"
+              label="Motivation de la décision (à destination du professionnel)"
               v-if="decisionCategory != 'approve'"
               v-model="comment"
             />
@@ -112,7 +112,7 @@ const decisionCategories = [
     value: "approve",
     title: "Bon pour autorisation",
     icon: "ri-checkbox-circle-fill",
-    description: "La déclaration ne pose pas de problème et peut être autorisé en l'état.",
+    description: "La déclaration ne pose pas de problème et peut être autorisée en l'état.",
     color: "green",
   },
   {

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -33,7 +33,7 @@
             <DeclarationSummary :readonly="true" v-model="declaration" />
           </DsfrTabContent>
           <DsfrTabContent panelId="tab-content-2" tabId="tab-2" :selected="selectedTabIndex === 2" :asc="asc">
-            <HistoryTab :declarationId="declaration?.id" />
+            <HistoryTab :declarationId="declaration?.id" :privateNotes="declaration.privateNotes" />
           </DsfrTabContent>
           <DsfrTabContent
             v-if="canInstruct"

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -23,7 +23,7 @@
       v-if="readonly && payload"
       class="mb-4"
       :type="payload.status === 'AUTHORIZED' ? 'success' : 'info'"
-      :title="`Cette déclaration est en status « ${statusProps[payload.status].label} »`"
+      :title="`Cette déclaration est en statut « ${statusProps[payload.status].label} »`"
     />
     <StepButtons
       class="mb-6 mt-3"

--- a/frontend/src/views/VisaPage/VisaValidationTab.vue
+++ b/frontend/src/views/VisaPage/VisaValidationTab.vue
@@ -89,8 +89,7 @@ const decisionCategories = computed(() => {
       title: "Je valide cette décision",
       icon: "ri-checkbox-circle-fill",
       iconColor: "green",
-      description: `Je suis d'accord pour donner mon visa et signature. La déclaration partirà en état «
-          ${postValidationStatus.value} ».`,
+      description: "Je vise cette déclaration et signe.",
       buttonText: "Valider",
       buttonHandler: acceptVisa,
     },
@@ -98,8 +97,7 @@ const decisionCategories = computed(() => {
       title: "Je ne suis pas d'accord",
       icon: "ri-close-circle-fill",
       iconColor: "red",
-      description: `Je ne donne pas mon visa ni signature. La déclaration repartira en instruction chez
-          ${instructorName.value}.`,
+      description: "Je renvoie le dossier en instruction.",
       buttonText: "Refuser",
       buttonHandler: refuseVisa,
     },

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -33,7 +33,7 @@
             <DeclarationSummary :readonly="true" v-model="declaration" />
           </DsfrTabContent>
           <DsfrTabContent panelId="tab-content-2" tabId="tab-2" :selected="selectedTabIndex === 2" :asc="asc">
-            <HistoryTab :declarationId="declaration?.id" />
+            <HistoryTab :declarationId="declaration?.id" :privateNotes="declaration.privateNotes" />
           </DsfrTabContent>
           <DsfrTabContent
             v-if="canInstruct"


### PR DESCRIPTION
Suite à l'appel avec @Fantine-py 

##### Problème d'accès à certaines déclarations (https://github.com/betagouv/complements-alimentaires/pull/651/commits/a2047de1fc1fb8f2e2a3aa2457e93b700cb50aeb)
Closes #648

##### Affichage des notes privées (https://github.com/betagouv/complements-alimentaires/pull/651/commits/627a6bdf3f40ed834757c4b256b6bf13f5359b7d)
Closes #646 

##### Affichage de l'unité de mesure dans la vue _Summary_ (https://github.com/betagouv/complements-alimentaires/pull/651/commits/15baf30468abe6b35fb939903ab25e5c8c66054c)
Closes #644

##### Wording et coquilles (https://github.com/betagouv/complements-alimentaires/pull/651/commits/102f0b66652c220c5553f2c80ddb3280d82108aa)
Closes #649 
Closes #647 
Closes #645 