### PR TITLE
Retirer un produit du marché

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -159,6 +159,11 @@ urlpatterns = {
         views.DeclarationAcceptVisaView.as_view(),
         name="accept_visa",
     ),
+    path(
+        "declarations/<int:pk>/withdraw/",
+        views.DeclarationWithdrawView.as_view(),
+        name="withdraw",
+    ),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -19,6 +19,7 @@ from .declaration.declaration import (
     DeclarationAuthorizeWithVisa,
     DeclarationRefuseVisaView,
     DeclarationAcceptVisaView,
+    DeclarationWithdrawView,
 )
 from .effect import EffectListView
 from .galenic_formulation import GalenicFormulationListView

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -300,6 +300,17 @@ class DeclarationResubmitView(DeclarationFlowView):
         return Snapshot.SnapshotActions.RESPOND_TO_OBJECTION
 
 
+class DeclarationWithdrawView(DeclarationFlowView):
+    """
+    AUTHORIZED -> WITHDRAWN
+    """
+
+    permission_classes = [(IsDeclarationAuthor | IsInstructor | IsVisor)]
+    transition = "withdraw"
+    create_snapshot = True
+    snapshot_action = Snapshot.SnapshotActions.WITHDRAW
+
+
 class VisaDecisionView(DeclarationFlowView):
     permission_classes = [IsVisor]
     create_snapshot = True

--- a/api/views/declaration/declaration_flow.py
+++ b/api/views/declaration/declaration_flow.py
@@ -73,6 +73,10 @@ class DeclarationFlow:
     def accept_visa_observe(self):
         pass
 
+    @status.transition(source=Status.AUTHORIZED, target=Status.WITHDRAWN)
+    def withdraw(self):
+        pass
+
     @status.transition(source=Status.OBSERVATION, target=Status.ABANDONED)
     def abandon(self):
         self.error()

--- a/data/factories/__init__.py
+++ b/data/factories/__init__.py
@@ -26,6 +26,7 @@ from .declaration import (
     AwaitingVisaDeclarationFactory,
     OngoingVisaDeclarationFactory,
     ObjectionDeclarationFactory,
+    AuthorizedDeclarationFactory,
 )
 from .solicitation import CollaborationInvitationFactory, CoSupervisionClaimFactory, SupervisionClaimFactory
 from .global_roles import InstructionRoleFactory, VisaRoleFactory

--- a/data/factories/declaration.py
+++ b/data/factories/declaration.py
@@ -189,6 +189,12 @@ class AwaitingVisaDeclarationFactory(CompleteDeclarationFactory):
     instructor = factory.SubFactory(InstructionRoleFactory)
 
 
+class AuthorizedDeclarationFactory(CompleteDeclarationFactory):
+    status = Declaration.DeclarationStatus.AUTHORIZED
+    author = factory.SubFactory(UserFactory)
+    instructor = factory.SubFactory(InstructionRoleFactory)
+
+
 class OngoingVisaDeclarationFactory(CompleteDeclarationFactory):
     status = Declaration.DeclarationStatus.ONGOING_VISA
     author = factory.SubFactory(UserFactory)

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -39,6 +39,7 @@ class Declaration(Historisable, TimeStampable):
         ABANDONED = "ABANDONED", "Abandonnée"
         AUTHORIZED = "AUTHORIZED", "Autorisée"
         REJECTED = "REJECTED", "Refusée"
+        WITHDRAWN = "WITHDRAWN", "Retiré du marché"
 
     class RejectionReason(models.TextChoices):
         MISSING_DATA = "MISSING_DATA", "Le dossier manque des données nécessaires"

--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -1,71 +1,77 @@
 <template>
-  <h3 class="fr-h6">
-    Informations sur le produit
-    <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(0))" />
-  </h3>
   <div>
-    <SummaryInfoSegment label="Nom du produit" :value="payload.name" />
-    <SummaryInfoSegment label="Marque" :value="payload.brand" />
-    <SummaryInfoSegment label="Gamme" :value="payload.gamme" />
-    <SummaryInfoSegment label="Arôme" :value="payload.flavor" />
-    <SummaryInfoSegment label="Description" :value="payload.description" />
-    <SummaryInfoSegment label="Forme galénique" :value="galenicFormulationsNames" />
-    <SummaryInfoSegment label="Unité de consommation" :value="unitInfo" />
-    <SummaryInfoSegment label="Conditionnements" :value="payload.conditioning" />
-    <SummaryInfoSegment label="Dose journalière recommandée" :value="payload.dailyRecommendedDose" />
-    <SummaryInfoSegment label="Durabilité minimale / DLUO (en mois)" :value="payload.minimumDuration" />
-    <SummaryInfoSegment label="Mode d'emploi" :value="payload.instructions" />
-    <SummaryInfoSegment label="Mise en garde et avertissement" :value="payload.warnings" />
-    <SummaryInfoSegment label="Populations cible" :value="populationNames" />
-    <SummaryInfoSegment label="Consommation déconseillée" :value="conditionNames" />
-    <SummaryInfoSegment label="Objectifs / effets" :value="effectsNames" />
-  </div>
+    <h3 class="fr-h6">
+      Informations sur le produit
+      <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(0))" />
+    </h3>
+    <div>
+      <SummaryInfoSegment label="Nom du produit" :value="payload.name" />
+      <SummaryInfoSegment label="Marque" :value="payload.brand" />
+      <SummaryInfoSegment label="Gamme" :value="payload.gamme" />
+      <SummaryInfoSegment label="Arôme" :value="payload.flavor" />
+      <SummaryInfoSegment label="Description" :value="payload.description" />
+      <SummaryInfoSegment label="Forme galénique" :value="galenicFormulationsNames" />
+      <SummaryInfoSegment label="Unité de consommation" :value="unitInfo" />
+      <SummaryInfoSegment label="Conditionnements" :value="payload.conditioning" />
+      <SummaryInfoSegment label="Dose journalière recommandée" :value="payload.dailyRecommendedDose" />
+      <SummaryInfoSegment label="Durabilité minimale / DLUO (en mois)" :value="payload.minimumDuration" />
+      <SummaryInfoSegment label="Mode d'emploi" :value="payload.instructions" />
+      <SummaryInfoSegment label="Mise en garde et avertissement" :value="payload.warnings" />
+      <SummaryInfoSegment label="Populations cible" :value="populationNames" />
+      <SummaryInfoSegment label="Consommation déconseillée" :value="conditionNames" />
+      <SummaryInfoSegment label="Objectifs / effets" :value="effectsNames" />
+    </div>
 
-  <h3 class="fr-h6 !mt-8">
-    Composition
-    <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(1))" />
-  </h3>
+    <h3 class="fr-h6 !mt-8">
+      Composition
+      <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(1))" />
+    </h3>
 
-  <SummaryElementList objectType="plant" :elements="payload.declaredPlants" />
-  <SummaryElementList objectType="microorganism" :elements="payload.declaredMicroorganisms" />
-  <SummaryElementList
-    objectType="form_of_supply"
-    :elements="payload.declaredIngredients.filter((obj) => obj.objectType == 'form_of_supply')"
-  />
-  <SummaryElementList
-    objectType="aroma"
-    :elements="payload.declaredIngredients.filter((obj) => obj.objectType == 'aroma')"
-  />
-  <SummaryElementList
-    objectType="additive"
-    :elements="payload.declaredIngredients.filter((obj) => obj.objectType == 'additive')"
-  />
-  <SummaryElementList
-    objectType="active_ingredient"
-    :elements="payload.declaredIngredients.filter((obj) => obj.objectType == 'active_ingredient')"
-  />
-  <SummaryElementList
-    objectType="non_active_ingredient"
-    :elements="payload.declaredIngredients.filter((obj) => obj.objectType == 'non_active_ingredient')"
-  />
-  <SummaryElementList objectType="substance" :elements="payload.declaredSubstances" />
-
-  <SubstancesTable v-model="payload" readonly />
-
-  <h3 class="fr-h6 !mt-8">
-    Pièces jointes
-    <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(2))" />
-  </h3>
-  <div class="grid grid-cols-12 gap-3 mb-8">
-    <FilePreview
-      class="col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-3"
-      v-for="(file, index) in payload.attachments"
-      :key="`file-${index}`"
-      :file="file"
-      readonly
+    <SummaryElementList objectType="plant" :elements="payload.declaredPlants" />
+    <SummaryElementList objectType="microorganism" :elements="payload.declaredMicroorganisms" />
+    <SummaryElementList
+      objectType="form_of_supply"
+      :elements="payload.declaredIngredients.filter((obj) => obj.objectType == 'form_of_supply')"
     />
+    <SummaryElementList
+      objectType="aroma"
+      :elements="payload.declaredIngredients.filter((obj) => obj.objectType == 'aroma')"
+    />
+    <SummaryElementList
+      objectType="additive"
+      :elements="payload.declaredIngredients.filter((obj) => obj.objectType == 'additive')"
+    />
+    <SummaryElementList
+      objectType="active_ingredient"
+      :elements="payload.declaredIngredients.filter((obj) => obj.objectType == 'active_ingredient')"
+    />
+    <SummaryElementList
+      objectType="non_active_ingredient"
+      :elements="payload.declaredIngredients.filter((obj) => obj.objectType == 'non_active_ingredient')"
+    />
+    <SummaryElementList objectType="substance" :elements="payload.declaredSubstances" />
+
+    <SubstancesTable v-model="payload" readonly />
+
+    <h3 class="fr-h6 !mt-8">
+      Pièces jointes
+      <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(2))" />
+    </h3>
+    <div class="grid grid-cols-12 gap-3 mb-8">
+      <FilePreview
+        class="col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-3"
+        v-for="(file, index) in payload.attachments"
+        :key="`file-${index}`"
+        :file="file"
+        readonly
+      />
+    </div>
   </div>
 </template>
+
+<script>
+export default { name: "DeclarationSummary" }
+</script>
 
 <script setup>
 import { computed } from "vue"

--- a/frontend/src/components/IdentityTab.vue
+++ b/frontend/src/components/IdentityTab.vue
@@ -1,38 +1,44 @@
 <template>
-  <SectionTitle title="Déclarant ou déclarante" icon="ri-user-fill" />
-  <p>{{ user.firstName }} {{ user.lastName }}</p>
-  <p>
-    Adresse email :
-    <a :href="`mailto:${user.email}`" target="_blank">{{ user.email }}</a>
-  </p>
+  <div>
+    <SectionTitle title="Déclarant ou déclarante" icon="ri-user-fill" />
+    <p>{{ user.firstName }} {{ user.lastName }}</p>
+    <p>
+      Adresse email :
+      <a :href="`mailto:${user.email}`" target="_blank">{{ user.email }}</a>
+    </p>
 
-  <SectionTitle class="!mt-8" title="Entreprise" icon="ri-home-2-fill" />
-  <p class="font-bold">{{ company.socialName }}</p>
-  <p v-if="company.siret">
-    Numéro SIRET : {{ company.siret }}
-    <a class="ml-1" :href="`https://annuaire-entreprises.data.gouv.fr/etablissement/${company.siret}`" target="_blank">
-      (voir dans l'annuaire des entreprises)
-    </a>
-  </p>
+    <SectionTitle class="!mt-8" title="Entreprise" icon="ri-home-2-fill" />
+    <p class="font-bold">{{ company.socialName }}</p>
+    <p v-if="company.siret">
+      Numéro SIRET : {{ company.siret }}
+      <a
+        class="ml-1"
+        :href="`https://annuaire-entreprises.data.gouv.fr/etablissement/${company.siret}`"
+        target="_blank"
+      >
+        (voir dans l'annuaire des entreprises)
+      </a>
+    </p>
 
-  <p v-if="company.vat">Numéro de TVA : {{ company.vat }}</p>
-  <p v-if="company.phoneNumber">
-    Numéro téléphone :
-    <a :href="`tel:${company.phoneNumber}`" target="_blank">{{ company.phoneNumber }}</a>
-  </p>
-  <p v-if="company.address">
-    <span>
-      Adresse :
-      <address class="inline">
-        {{ company.address }}
-        {{ company.additional_details }}
-        {{ company.postal_code }}
-        {{ company.city }}
-        {{ company.country }}
-        <span v-if="company.cedex">- CEDEX : {{ company.cedex }}</span>
-      </address>
-    </span>
-  </p>
+    <p v-if="company.vat">Numéro de TVA : {{ company.vat }}</p>
+    <p v-if="company.phoneNumber">
+      Numéro téléphone :
+      <a :href="`tel:${company.phoneNumber}`" target="_blank">{{ company.phoneNumber }}</a>
+    </p>
+    <p v-if="company.address">
+      <span>
+        Adresse :
+        <address class="inline">
+          {{ company.address }}
+          {{ company.additional_details }}
+          {{ company.postal_code }}
+          {{ company.city }}
+          {{ company.country }}
+          <span v-if="company.cedex">- CEDEX : {{ company.cedex }}</span>
+        </address>
+      </span>
+    </p>
+  </div>
 </template>
 
 <script setup>

--- a/frontend/src/components/StatusFilter.vue
+++ b/frontend/src/components/StatusFilter.vue
@@ -48,6 +48,7 @@ const statusFilterOptions = [
   { value: "ABANDONED", text: "Abandon" },
   { value: "AUTHORIZED", text: "Autorisée" },
   { value: "REJECTED", text: "Refusée" },
+  { value: "WITHDRAWN", text: "Retiré du marché" },
 ]
 const options = statusFilterOptions
   .filter((x) => props.exclude.indexOf(x.value) === -1)

--- a/frontend/src/components/WithdrawalTab.vue
+++ b/frontend/src/components/WithdrawalTab.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <h2>Retirer du marché</h2>
+    <p>
+      Votre produit « {{ declaration.name }} » a été authorisé. Vous pouvez néanmoins déclarer son arrêt de
+      commercialisation en cliquant ci-dessous. Veuillez noter que cette opération est irreversible.
+    </p>
+    <DsfrButton secondary label="Retirer ce complément" @click="confirmationModalOpened = true" />
+
+    <DsfrModal title="Veuillez confirmer" :opened="confirmationModalOpened" @close="confirmationModalOpened = false">
+      <p>Êtes vous sur de vouloir retirer ce produit du marché ?</p>
+      <div class="flex gap-4">
+        <DsfrButton secondary label="Non" @click="confirmationModalOpened = false" />
+        <DsfrButton label="Oui, je veux le retirer" @click="withdrawDeclaration" />
+      </div>
+    </DsfrModal>
+  </div>
+</template>
+
+<script setup>
+import { useFetch } from "@vueuse/core"
+import { ref } from "vue"
+import { handleError } from "@/utils/error-handling"
+import { headers } from "@/utils/data-fetching"
+import useToaster from "@/composables/use-toaster"
+
+const declaration = defineModel()
+const $externalResults = ref({})
+const confirmationModalOpened = ref(false)
+const emit = defineEmits("withdraw")
+
+const withdrawDeclaration = async () => {
+  const url = `/api/v1/declarations/${declaration.value.id}/withdraw/`
+  const { response } = await useFetch(url, { headers: headers() }).post().json()
+  $externalResults.value = await handleError(response)
+
+  if (response.value.ok) {
+    useToaster().addSuccessMessage("Votre produit a été retiré du marché")
+    // router.replace({ name: "DeclarationsHomePage", query: { status: "WITHDRAWN,AUTHORIZED" } })
+    emit("withdraw")
+  }
+}
+</script>

--- a/frontend/src/components/WithdrawalTab.vue
+++ b/frontend/src/components/WithdrawalTab.vue
@@ -36,7 +36,6 @@ const withdrawDeclaration = async () => {
 
   if (response.value.ok) {
     useToaster().addSuccessMessage("Votre produit a été retiré du marché")
-    // router.replace({ name: "DeclarationsHomePage", query: { status: "WITHDRAWN,AUTHORIZED" } })
     emit("withdraw")
   }
 }

--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -119,3 +119,76 @@ export const statusProps = {
 }
 
 export const roleNameDisplayNameMapping = { DeclarantRole: "déclarant", SupervisorRole: "gestionnaire" }
+
+export const tabTitles = (components, useSubmission = false) => {
+  const idx = (x) => components.findIndex((y) => (y.name || y.__name) === x)
+  const titleMap = {
+    IdentityTab: {
+      title: "Identité",
+      icon: "ri-shield-user-line",
+      tabId: `tab-${idx("IdentityTab")}`,
+      panelId: `tab-content-${idx("IdentityTab")}`,
+    },
+    DeclarationSummary: {
+      title: "Le produit",
+      icon: "ri-flask-line",
+      tabId: `tab-${idx("DeclarationSummary")}`,
+      panelId: `tab-content-${idx("DeclarationSummary")}`,
+    },
+    DecisionTab: {
+      title: "Décision",
+      icon: "ri-checkbox-circle-line",
+      tabId: `tab-${idx("DecisionTab")}`,
+      panelId: `tab-content-${idx("DecisionTab")}`,
+    },
+    HistoryTab: {
+      title: "Historique",
+      icon: "ri-chat-3-line",
+      tabId: `tab-${idx("HistoryTab")}`,
+      panelId: `tab-content-${idx("HistoryTab")}`,
+    },
+    SummaryTab: {
+      title: useSubmission ? "Soumettre" : "Résumé",
+      icon: useSubmission ? "ri-mail-send-line" : "ri-survey-line",
+      tabId: `tab-${idx("SummaryTab")}`,
+      panelId: `tab-content-${idx("SummaryTab")}`,
+    },
+    ProductTab: {
+      title: "Le produit",
+      icon: "ri-capsule-fill",
+      tabId: `tab-${idx("ProductTab")}`,
+      panelId: `tab-content-${idx("ProductTab")}`,
+    },
+    CompositionTab: {
+      title: "Composition",
+      icon: "ri-test-tube-line",
+      tabId: `tab-${idx("CompositionTab")}`,
+      panelId: `tab-content-${idx("CompositionTab")}`,
+    },
+    AttachmentTab: {
+      title: "Pièces jointes",
+      icon: "ri-file-text-line",
+      tabId: `tab-${idx("AttachmentTab")}`,
+      panelId: `tab-content-${idx("AttachmentTab")}`,
+    },
+    NewElementTab: {
+      title: "Nouveaux éléments",
+      icon: "ri-flask-line",
+      tabId: `tab-${idx("NewElementTab")}`,
+      panelId: `tab-content-${idx("NewElementTab")}`,
+    },
+    WithdrawalTab: {
+      title: "Retirer du marché",
+      icon: "ri-close-fill",
+      tabId: `tab-${idx("WithdrawalTab")}`,
+      panelId: `tab-content-${idx("WithdrawalTab")}`,
+    },
+    VisaValidationTab: {
+      title: "Visa / Signature",
+      icon: "ri-checkbox-circle-line",
+      tabId: `tab-${idx("VisaValidationTab")}`,
+      panelId: `tab-content-${idx("VisaValidationTab")}`,
+    },
+  }
+  return components.map((x) => titleMap[x.__name || x.name])
+}

--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -112,6 +112,10 @@ export const statusProps = {
     icon: "ri-error-warning-fill",
     label: "Refusée",
   },
+  WITHDRAWN: {
+    icon: "ri-close-fill",
+    label: "Retirée du marché",
+  },
 }
 
 export const roleNameDisplayNameMapping = { DeclarantRole: "déclarant", SupervisorRole: "gestionnaire" }

--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -88,7 +88,7 @@ import useToaster from "@/composables/use-toaster"
 import { handleError } from "@/utils/error-handling"
 
 const $externalResults = ref({})
-const props = defineProps(["declaration"])
+const declaration = defineModel()
 
 const emit = defineEmits(["reload-declaration"])
 
@@ -98,7 +98,7 @@ watch(decisionCategory, () => (proposal.value = decisionCategory.value === "appr
 const proposal = ref(null)
 const delayDays = ref(30)
 const comment = ref("")
-const privateNotes = ref(props.declaration?.privateNotes || "")
+const privateNotes = ref(declaration.value?.privateNotes || "")
 
 const needsVisa = ref(false)
 const mandatoryVisaProposals = ["objection", "rejection"]
@@ -184,7 +184,7 @@ const submitDecision = async () => {
   const visaPath = needsVisa.value ? "with-visa" : "no-visa"
   const urlPath = `${actions[proposal.value]}-${visaPath}`
 
-  const url = `/api/v1/declarations/${props.declaration.id}/${urlPath}/`
+  const url = `/api/v1/declarations/${declaration.value?.id}/${urlPath}/`
   const { response } = await useFetch(url, { headers: headers() })
     .post({ comment: comment.value, privateNotes: privateNotes.value })
     .json()

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -44,6 +44,15 @@
           >
             <DecisionTab :declaration="declaration" @reload-declaration="reloadDeclaration" />
           </DsfrTabContent>
+          <DsfrTabContent
+            v-else-if="showWithdrawal"
+            panelId="tab-content-3"
+            tabId="tab-3"
+            :selected="selectedTabIndex === 3"
+            :asc="asc"
+          >
+            <WithdrawalTab @withdraw="onWithdrawal" v-model="declaration" />
+          </DsfrTabContent>
         </DsfrTabs>
       </div>
     </div>
@@ -60,9 +69,12 @@ import ProgressSpinner from "@/components/ProgressSpinner"
 import DeclarationSummary from "@/components/DeclarationSummary"
 import IdentityTab from "@/components/IdentityTab"
 import HistoryTab from "@/components/HistoryTab"
+import WithdrawalTab from "@/components/WithdrawalTab"
 import DecisionTab from "./DecisionTab"
 import { headers } from "@/utils/data-fetching"
 import DeclarationAlert from "@/components/DeclarationAlert"
+import { useRouter } from "vue-router"
+const router = useRouter()
 
 const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
@@ -117,6 +129,8 @@ onMounted(async () => {
   isFetching.value = false
 })
 
+const showWithdrawal = computed(() => declaration.value?.status === "AUTHORIZED")
+
 // Tab management
 const tabTitles = computed(() => {
   const tabs = [
@@ -126,6 +140,8 @@ const tabTitles = computed(() => {
   ]
   if (canInstruct.value)
     tabs.push({ title: "Décision", icon: "ri-checkbox-circle-line", tabId: "tab-3", panelId: "tab-content-3" })
+  else if (showWithdrawal.value)
+    tabs.push({ title: "Retirer du marché", icon: "ri-close-fill", tabId: "tab-3", panelId: "tab-content-3" })
   return tabs
 })
 const selectedTabIndex = ref(0)
@@ -150,4 +166,7 @@ const reloadDeclaration = async () => {
   await nextTick()
   await executeDeclarationFetch()
 }
+
+const onWithdrawal = () =>
+  router.replace({ name: "InstructionDeclarations", query: { status: "WITHDRAWN,AUTHORIZED" } })
 </script>

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -25,33 +25,27 @@
       <div v-if="declaration">
         <DeclarationSummary :readonly="true" v-model="declaration" v-if="isAwaitingInstruction" />
 
-        <DsfrTabs v-else ref="tabs" :tab-titles="tabTitles" :initialSelectedIndex="0" @select-tab="selectTab">
-          <DsfrTabContent panelId="tab-content-0" tabId="tab-0" :selected="selectedTabIndex === 0" :asc="asc">
-            <IdentityTab :user="declarant" :company="company" />
-          </DsfrTabContent>
-          <DsfrTabContent panelId="tab-content-1" tabId="tab-1" :selected="selectedTabIndex === 1" :asc="asc">
-            <DeclarationSummary :readonly="true" v-model="declaration" />
-          </DsfrTabContent>
-          <DsfrTabContent panelId="tab-content-2" tabId="tab-2" :selected="selectedTabIndex === 2" :asc="asc">
-            <HistoryTab :declarationId="declaration?.id" :privateNotes="declaration.privateNotes" />
-          </DsfrTabContent>
+        <DsfrTabs v-else ref="tabs" :tab-titles="titles" :initialSelectedIndex="0" @select-tab="selectTab">
           <DsfrTabContent
-            v-if="canInstruct"
-            panelId="tab-content-3"
-            tabId="tab-3"
-            :selected="selectedTabIndex === 3"
+            v-for="(component, idx) in components"
+            :key="`component-${idx}`"
+            :panelId="`tab-content-${idx}`"
+            :tabId="`tab-${idx}`"
+            :selected="selectedTabIndex === idx"
             :asc="asc"
           >
-            <DecisionTab :declaration="declaration" @reload-declaration="reloadDeclaration" />
-          </DsfrTabContent>
-          <DsfrTabContent
-            v-else-if="showWithdrawal"
-            panelId="tab-content-3"
-            tabId="tab-3"
-            :selected="selectedTabIndex === 3"
-            :asc="asc"
-          >
-            <WithdrawalTab @withdraw="onWithdrawal" v-model="declaration" />
+            <component
+              :is="component"
+              v-model="declaration"
+              :externalResults="$externalResults"
+              :readonly="true"
+              :declarationId="declaration?.id"
+              @withdraw="onWithdrawal"
+              :privateNotes="declaration?.privateNotes"
+              :user="declarant"
+              :company="company"
+              @reload-declaration="reloadDeclaration"
+            ></component>
           </DsfrTabContent>
         </DsfrTabs>
       </div>
@@ -74,6 +68,7 @@ import DecisionTab from "./DecisionTab"
 import { headers } from "@/utils/data-fetching"
 import DeclarationAlert from "@/components/DeclarationAlert"
 import { useRouter } from "vue-router"
+import { tabTitles } from "@/utils/mappings"
 const router = useRouter()
 
 const store = useRootStore()
@@ -132,18 +127,13 @@ onMounted(async () => {
 const showWithdrawal = computed(() => declaration.value?.status === "AUTHORIZED")
 
 // Tab management
-const tabTitles = computed(() => {
-  const tabs = [
-    { title: "Identité", icon: "ri-shield-user-line", tabId: "tab-0", panelId: "tab-content-0" },
-    { title: "Le produit", icon: "ri-flask-line", tabId: "tab-1", panelId: "tab-content-1" },
-    { title: "Historique", icon: "ri-chat-3-line", tabId: "tab-2", panelId: "tab-content-2" },
-  ]
-  if (canInstruct.value)
-    tabs.push({ title: "Décision", icon: "ri-checkbox-circle-line", tabId: "tab-3", panelId: "tab-content-3" })
-  else if (showWithdrawal.value)
-    tabs.push({ title: "Retirer du marché", icon: "ri-close-fill", tabId: "tab-3", panelId: "tab-content-3" })
-  return tabs
+const components = computed(() => {
+  const baseComponents = [IdentityTab, DeclarationSummary, HistoryTab]
+  if (canInstruct.value) baseComponents.push(DecisionTab)
+  else if (showWithdrawal.value) baseComponents.push(WithdrawalTab)
+  return baseComponents
 })
+const titles = computed(() => tabTitles(components.value))
 const selectedTabIndex = ref(0)
 const asc = ref(true) // Je n'aime pas le nommage mais ça vient de ce paramètre : https://vue-dsfr.netlify.app/?path=/docs/composants-dsfrtabs--docs
 const selectTab = (index) => {

--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script setup>
-import { computed, defineModel } from "vue"
+import { computed } from "vue"
 import { useFetch } from "@vueuse/core"
 import { getApiType, getActivityReadonlyByType } from "@/utils/mappings"
 import ElementAutocomplete from "@/components/ElementAutocomplete.vue"

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -22,7 +22,7 @@
       <DsfrTabs
         v-if="payload"
         ref="tabs"
-        :tab-titles="tabTitles"
+        :tab-titles="titles"
         :initialSelectedIndex="parseInt(route.query.tab)"
         @select-tab="(tab) => router.replace({ query: { tab } })"
       >
@@ -67,7 +67,7 @@ import { handleError } from "@/utils/error-handling"
 import FormWrapper from "@/components/FormWrapper"
 import { headers } from "@/utils/data-fetching"
 import useToaster from "@/composables/use-toaster"
-import { statusProps } from "@/utils/mappings"
+import { statusProps, tabTitles } from "@/utils/mappings"
 
 const $externalResults = ref({})
 const route = useRoute()
@@ -145,54 +145,7 @@ const components = computed(() => {
   return baseComponents
 })
 
-const tabTitles = computed(() => {
-  const idx = (x) => components.value.findIndex((y) => y.__name === x)
-  const titleMap = {
-    HistoryTab: {
-      title: "Historique",
-      icon: "ri-chat-3-line",
-      tabId: `tab-${idx("HistoryTab")}`,
-      panelId: `tab-content-${idx("HistoryTab")}`,
-    },
-    SummaryTab: {
-      title: readonly.value ? "Résumé" : "Soumettre",
-      icon: readonly.value ? "ri-survey-line" : "ri-mail-send-line",
-      tabId: `tab-${idx("SummaryTab")}`,
-      panelId: `tab-content-${idx("SummaryTab")}`,
-    },
-    ProductTab: {
-      title: "Le produit",
-      icon: "ri-capsule-fill",
-      tabId: `tab-${idx("ProductTab")}`,
-      panelId: `tab-content-${idx("ProductTab")}`,
-    },
-    CompositionTab: {
-      title: "Composition",
-      icon: "ri-test-tube-line",
-      tabId: `tab-${idx("CompositionTab")}`,
-      panelId: `tab-content-${idx("CompositionTab")}`,
-    },
-    AttachmentTab: {
-      title: "Pièces jointes",
-      icon: "ri-file-text-line",
-      tabId: `tab-${idx("AttachmentTab")}`,
-      panelId: `tab-content-${idx("AttachmentTab")}`,
-    },
-    NewElementTab: {
-      title: "Nouveaux éléments",
-      icon: "ri-flask-line",
-      tabId: `tab-${idx("NewElementTab")}`,
-      panelId: `tab-content-${idx("NewElementTab")}`,
-    },
-    WithdrawalTab: {
-      title: "Retirer du marché",
-      icon: "ri-close-fill",
-      tabId: `tab-${idx("WithdrawalTab")}`,
-      panelId: `tab-content-${idx("WithdrawalTab")}`,
-    },
-  }
-  return components.value.map((x) => titleMap[x.__name])
-})
+const titles = computed(() => tabTitles(components.value, !readonly.value))
 
 const savePayload = async () => {
   const isNewDeclaration = !payload.value.id

--- a/frontend/src/views/VisaPage/VisaValidationTab.vue
+++ b/frontend/src/views/VisaPage/VisaValidationTab.vue
@@ -55,16 +55,16 @@ import VisaInfoLine from "./VisaInfoLine.vue"
 
 const $externalResults = ref({})
 const emit = defineEmits(["reload-declaration"])
+const declaration = defineModel()
 
-const props = defineProps({ declaration: Object })
-const privateNotes = ref(props.declaration?.privateNotes || "")
+const privateNotes = ref(declaration.value?.privateNotes || "")
 
 const instructorName = computed(
-  () => `${props.declaration?.instructor?.firstName} ${props.declaration?.instructor?.lastName}`
+  () => `${declaration.value?.instructor?.firstName} ${declaration.value?.instructor?.lastName}`
 )
-const postValidationStatus = computed(() => statusProps[props.declaration.postValidationStatus].label)
+const postValidationStatus = computed(() => statusProps[declaration.value.postValidationStatus].label)
 const refuseVisa = async () => {
-  const url = `/api/v1/declarations/${props.declaration.id}/refuse-visa/`
+  const url = `/api/v1/declarations/${declaration.value.id}/refuse-visa/`
   const { response } = await useFetch(url, { headers: headers() }).post({ privateNotes: privateNotes.value }).json()
   $externalResults.value = await handleError(response)
   if (response.value.ok) {
@@ -74,7 +74,7 @@ const refuseVisa = async () => {
 }
 
 const acceptVisa = async () => {
-  const url = `/api/v1/declarations/${props.declaration.id}/accept-visa/`
+  const url = `/api/v1/declarations/${declaration.value.id}/accept-visa/`
   const { response } = await useFetch(url, { headers: headers() }).post({ privateNotes: privateNotes.value }).json()
   $externalResults.value = await handleError(response)
   if (response.value.ok) {

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -25,33 +25,27 @@
       <div v-if="declaration">
         <DeclarationSummary :readonly="true" v-model="declaration" v-if="isAwaitingVisa" />
 
-        <DsfrTabs v-else ref="tabs" :tab-titles="tabTitles" :initialSelectedIndex="0" @select-tab="selectTab">
-          <DsfrTabContent panelId="tab-content-0" tabId="tab-0" :selected="selectedTabIndex === 0" :asc="asc">
-            <IdentityTab :user="declarant" :company="company" />
-          </DsfrTabContent>
-          <DsfrTabContent panelId="tab-content-1" tabId="tab-1" :selected="selectedTabIndex === 1" :asc="asc">
-            <DeclarationSummary :readonly="true" v-model="declaration" />
-          </DsfrTabContent>
-          <DsfrTabContent panelId="tab-content-2" tabId="tab-2" :selected="selectedTabIndex === 2" :asc="asc">
-            <HistoryTab :declarationId="declaration?.id" :privateNotes="declaration.privateNotes" />
-          </DsfrTabContent>
+        <DsfrTabs v-else ref="tabs" :tab-titles="titles" :initialSelectedIndex="0" @select-tab="selectTab">
           <DsfrTabContent
-            v-if="canInstruct"
-            panelId="tab-content-3"
-            tabId="tab-3"
-            :selected="selectedTabIndex === 3"
+            v-for="(component, idx) in components"
+            :key="`component-${idx}`"
+            :panelId="`tab-content-${idx}`"
+            :tabId="`tab-${idx}`"
+            :selected="selectedTabIndex === idx"
             :asc="asc"
           >
-            <VisaValidationTab :declaration="declaration" @reload-declaration="reloadDeclaration" />
-          </DsfrTabContent>
-          <DsfrTabContent
-            v-else-if="showWithdrawal"
-            panelId="tab-content-3"
-            tabId="tab-3"
-            :selected="selectedTabIndex === 3"
-            :asc="asc"
-          >
-            <WithdrawalTab @withdraw="onWithdrawal" v-model="declaration" />
+            <component
+              :is="component"
+              v-model="declaration"
+              :externalResults="$externalResults"
+              :readonly="true"
+              :declarationId="declaration?.id"
+              @withdraw="onWithdrawal"
+              :privateNotes="declaration?.privateNotes"
+              :user="declarant"
+              :company="company"
+              @reload-declaration="reloadDeclaration"
+            ></component>
           </DsfrTabContent>
         </DsfrTabs>
       </div>
@@ -74,6 +68,8 @@ import DeclarationAlert from "@/components/DeclarationAlert"
 import VisaValidationTab from "./VisaValidationTab"
 import { headers } from "@/utils/data-fetching"
 import { useRouter } from "vue-router"
+import { tabTitles } from "@/utils/mappings"
+
 const router = useRouter()
 
 const store = useRootStore()
@@ -131,18 +127,13 @@ onMounted(async () => {
 })
 
 // Tab management
-const tabTitles = computed(() => {
-  const tabs = [
-    { title: "Identité", icon: "ri-shield-user-line", tabId: "tab-0", panelId: "tab-content-0" },
-    { title: "Le produit", icon: "ri-flask-line", tabId: "tab-1", panelId: "tab-content-1" },
-    { title: "Historique", icon: "ri-chat-3-line", tabId: "tab-2", panelId: "tab-content-2" },
-  ]
-  if (canInstruct.value)
-    tabs.push({ title: "Visa / Signature", icon: "ri-checkbox-circle-line", tabId: "tab-3", panelId: "tab-content-3" })
-  else if (showWithdrawal.value)
-    tabs.push({ title: "Retirer du marché", icon: "ri-close-fill", tabId: "tab-3", panelId: "tab-content-3" })
-  return tabs
+const components = computed(() => {
+  const baseComponents = [IdentityTab, DeclarationSummary, HistoryTab]
+  if (canInstruct.value) baseComponents.push(VisaValidationTab)
+  else if (showWithdrawal.value) baseComponents.push(WithdrawalTab)
+  return baseComponents
 })
+const titles = computed(() => tabTitles(components.value))
 const selectedTabIndex = ref(0)
 const asc = ref(true) // Je n'aime pas le nommage mais ça vient de ce paramètre : https://vue-dsfr.netlify.app/?path=/docs/composants-dsfrtabs--docs
 const selectTab = (index) => {

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -44,6 +44,15 @@
           >
             <VisaValidationTab :declaration="declaration" @reload-declaration="reloadDeclaration" />
           </DsfrTabContent>
+          <DsfrTabContent
+            v-else-if="showWithdrawal"
+            panelId="tab-content-3"
+            tabId="tab-3"
+            :selected="selectedTabIndex === 3"
+            :asc="asc"
+          >
+            <WithdrawalTab @withdraw="onWithdrawal" v-model="declaration" />
+          </DsfrTabContent>
         </DsfrTabs>
       </div>
     </div>
@@ -60,9 +69,12 @@ import ProgressSpinner from "@/components/ProgressSpinner"
 import DeclarationSummary from "@/components/DeclarationSummary"
 import IdentityTab from "@/components/IdentityTab"
 import HistoryTab from "@/components/HistoryTab"
+import WithdrawalTab from "@/components/WithdrawalTab"
 import DeclarationAlert from "@/components/DeclarationAlert"
 import VisaValidationTab from "./VisaValidationTab"
 import { headers } from "@/utils/data-fetching"
+import { useRouter } from "vue-router"
+const router = useRouter()
 
 const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
@@ -76,6 +88,7 @@ const props = defineProps({
 
 const isAwaitingVisa = computed(() => declaration.value?.status === "AWAITING_VISA")
 const canInstruct = computed(() => declaration.value?.status === "ONGOING_VISA")
+const showWithdrawal = computed(() => declaration.value?.status === "AUTHORIZED")
 
 // Requêtes
 const isFetching = ref(true)
@@ -126,6 +139,8 @@ const tabTitles = computed(() => {
   ]
   if (canInstruct.value)
     tabs.push({ title: "Visa / Signature", icon: "ri-checkbox-circle-line", tabId: "tab-3", panelId: "tab-content-3" })
+  else if (showWithdrawal.value)
+    tabs.push({ title: "Retirer du marché", icon: "ri-close-fill", tabId: "tab-3", panelId: "tab-content-3" })
   return tabs
 })
 const selectedTabIndex = ref(0)
@@ -150,4 +165,5 @@ const reloadDeclaration = async () => {
   await nextTick()
   await executeDeclarationFetch()
 }
+const onWithdrawal = () => router.replace({ name: "VisaDeclarations", query: { status: "WITHDRAWN,AUTHORIZED" } })
 </script>


### PR DESCRIPTION
## Contexte

On doit pouvoir déclarer le retrait d'un complément autorisé du marché (étape en vert dans le diagramme ci-dessous)

![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/3096cb14-2aa3-4aa7-847e-c1a0a920dc55)

## Développement
**_:information_source: Il y a quelques des changements de whitespace, en regardant la diff sur Github c'est plus simple on désactive le whitespace pour avoir une meilleure compréhension des vrais changements._**
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/94a5c6cb-1626-4d82-8c0e-8de9678ea3d3)


- Les auteurs·ices des déclarations ont le droit de retirer un produit authorisé. Les instructrices et viseuses ont aussi ce droit (à voir par la suite si on veut le laisser @Fantine-py)
- Après l'action de retirer un produit du marché on tombe dans la view table avec les produits retirés et autorisés visibles
- J'en ai profité pour uniformiser un peu les différentes vues contenant des onglets (déclarant·e / instruction / visa)

_Note : Aujourd'hui on n'a pas prévu de remettre dans le marché un complément alimentaire qu'on a précédemment enlevé du marche. À voir par la suite si cela est souhaitable._

## Captures d'écran
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/517213c1-5065-46ef-a19f-6fc41a415337)

Modal de confirmation : 
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/7c5c1750-3df4-4e32-80d0-40e53ddcebd7)

Écran après l'avoir retirer :
![image](https://github.com/betagouv/complements-alimentaires/assets/1225929/3d209fce-44dd-40d5-93ac-a6124cc20e4a)
