### PR TITLE
:lady_beetle:  Bug fix : Les `containers` sont dynamiques

### DIFF
--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -77,7 +77,7 @@ import { handleError } from "@/utils/error-handling"
 import SectionTitle from "@/components/SectionTitle"
 
 const payload = defineModel()
-const containers = {
+const containers = computed(() => ({
   plant: payload.value.declaredPlants,
   microorganism: payload.value.declaredMicroorganisms,
   substance: payload.value.declaredSubstances,
@@ -90,8 +90,8 @@ const containers = {
   // TODO déprecier après l'import de données extraites en mai 2024
   // qui contient les types plus précis
   ingredient: payload.value.declaredIngredients,
-}
-const allElements = computed(() => [].concat(...Object.values(containers)))
+}))
+const allElements = computed(() => [].concat(...Object.values(containers.value)))
 const hasActiveSubstances = computed(() =>
   allElements.value.some((x) => x.active && !x.new && x.element?.substances?.length)
 )
@@ -102,7 +102,7 @@ const selectOption = async (result) => {
 }
 
 const removeElement = (element) => {
-  Object.values(containers).forEach((container) => {
+  Object.values(containers.value).forEach((container) => {
     const index = container.indexOf(element)
     if (index > -1) container.splice(index, 1)
   })
@@ -114,7 +114,7 @@ const addElement = (item, objectType, newlyAdded = false) => {
   const toAdd = newlyAdded
     ? { ...item, ...{ active: item.activity, disabled: activityNotEditable, new: true } }
     : { element: item, active: item.activity, disabled: activityNotEditable }
-  containers[objectType].unshift(toAdd)
+  containers.value[objectType].unshift(toAdd)
 }
 
 const fetchElement = async (type, id) => {

--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -112,8 +112,8 @@ const addElement = (item, objectType, newlyAdded = false) => {
   // à terme toutes les plantes seront actives et si elles sont non actives c'est que ce sont des support/agent de charge
   const activityNotEditable = getActivityReadonlyByType(objectType)
   const toAdd = newlyAdded
-    ? { ...item, ...{ active: item.activity, disabled: activityNotEditable, new: true } }
-    : { element: item, active: item.activity, disabled: activityNotEditable }
+    ? { ...item, ...{ active: !!item.activity, disabled: activityNotEditable, new: true } }
+    : { element: item, active: !!item.activity, disabled: activityNotEditable }
   containers.value[objectType].unshift(toAdd)
 }
 


### PR DESCRIPTION
## Contexte

FYI @pletelli 

Le bug qu'on a trouvé en démo vient du fait que la variable `container` de `CompositionTab` s'initialise à partir du modèle `payload`. 

Par contre, lors qu'on ouvre une déclaration, le payload est fetché du backend. La variable `container` n'étant pas réactive, elle restait avec la référence caduque et donc les ingrédients n'étaient jamais à jour correctement.

En rendant `container` réactive, le bug est réglé.

J'en ai profité pour forcer `active` à boolean, pour éviter un warning de Vue.