### PR TITLE
:lady_beetle: Résolution du bug concernant la table des substances

### DIFF
--- a/frontend/src/views/ProducerFormPage/NewElementModal.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementModal.vue
@@ -68,7 +68,7 @@ const actions = [
 ]
 
 // Note : Sur téléicare on ne peux pas ajouter des substances directement
-const types = typesMapping
+const types = Object.assign({}, typesMapping)
 delete types["substance"]
 
 watch(


### PR DESCRIPTION
Suite à une session de pair-programming avec @pletelli, on a identifié la source du bug. Cette PR : 

- Résout le problème du mot _Substances_ qui ne s'affichait pas - on voyait seulement une « _s_ » ([code](https://github.com/betagouv/complements-alimentaires/compare/bug-substance?expand=1#diff-b2d0f2578e66f4c23b5d4e8b70d00cff86e2ca38f9c3161e04bbf3cd741e1027R71))
- Remet le `objectType` des éléments ajoutés - différent du `apiType` ([code](https://github.com/betagouv/complements-alimentaires/compare/bug-substance?expand=1#diff-1addd1f33e2fdf5125cbdf24da3cfb973f3c76c33f21934a2984ca38c54e6676R135))
- S'assure qu'un élément ne s'affiche pas en dupliqué ([code](https://github.com/betagouv/complements-alimentaires/compare/bug-substance?expand=1#diff-1addd1f33e2fdf5125cbdf24da3cfb973f3c76c33f21934a2984ca38c54e6676R135))
- Enlève les doublons dans la variable `allElements` ([code](https://github.com/betagouv/complements-alimentaires/compare/bug-substance?expand=1#diff-1addd1f33e2fdf5125cbdf24da3cfb973f3c76c33f21934a2984ca38c54e6676R98))

## Démo
[Screencast from 22-07-24 17:10:21.webm](https://github.com/user-attachments/assets/115309b4-e5cf-492c-90d6-116905154d5f)
