### PR TITLE
Retour à la liste des déclarations avec les filtres activés

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -30,6 +30,7 @@ import VisaDeclarationsPage from "@/views/VisaDeclarationsPage"
 import VisaPage from "@/views/VisaPage"
 import CompanyDeclarationsPage from "@/views/CompanyDeclarationsPage"
 import A11yPage from "@/views/A11yPage.vue"
+import { ref } from "vue"
 
 const routes = [
   {
@@ -356,8 +357,13 @@ const ensureDefaultQueryParams = (route, next) => {
   return false
 }
 
+// This utility function allows us to find the previous route
+const previousRoute = ref(null)
+router.getPreviousRoute = () => previousRoute
+
 router.beforeEach((to, from, next) => {
   const store = useRootStore()
+  previousRoute.value = from
   if (ensureDefaultQueryParams(to, next)) chooseAuthorisedRoute(to, from, next, store)
 })
 

--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -90,7 +90,7 @@ import { handleError } from "@/utils/error-handling"
 const $externalResults = ref({})
 const declaration = defineModel()
 
-const emit = defineEmits(["reload-declaration"])
+const emit = defineEmits(["decision-done"])
 
 const decisionCategory = ref(null)
 watch(decisionCategory, () => (proposal.value = decisionCategory.value === "approve" ? "approve" : null))
@@ -192,7 +192,7 @@ const submitDecision = async () => {
 
   if (response.value.ok) {
     useToaster().addSuccessMessage("Votre décision a été prise en compte")
-    emit("reload-declaration")
+    emit("decision-done")
   }
 }
 </script>

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -44,7 +44,7 @@
               :privateNotes="declaration?.privateNotes"
               :user="declarant"
               :company="company"
-              @reload-declaration="reloadDeclaration"
+              @decision-done="onDecisionDone"
             ></component>
           </DsfrTabContent>
         </DsfrTabs>
@@ -56,7 +56,7 @@
 <script setup>
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
-import { onMounted, computed, ref, nextTick } from "vue"
+import { onMounted, computed, ref } from "vue"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
@@ -70,6 +70,7 @@ import DeclarationAlert from "@/components/DeclarationAlert"
 import { useRouter } from "vue-router"
 import { tabTitles } from "@/utils/mappings"
 const router = useRouter()
+const previousRoute = router.getPreviousRoute()
 
 const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
@@ -151,10 +152,9 @@ const instructDeclaration = async () => {
   }
 }
 
-const reloadDeclaration = async () => {
-  tabs.value?.selectIndex?.(0)
-  await nextTick()
-  await executeDeclarationFetch()
+const onDecisionDone = () => {
+  const previousQuery = previousRoute.value.name === "InstructionDeclarations" ? previousRoute.value.query : {}
+  router.push({ name: "InstructionDeclarations", query: previousQuery })
 }
 
 const onWithdrawal = () =>

--- a/frontend/src/views/VisaPage/VisaValidationTab.vue
+++ b/frontend/src/views/VisaPage/VisaValidationTab.vue
@@ -54,7 +54,7 @@ import useToaster from "@/composables/use-toaster"
 import VisaInfoLine from "./VisaInfoLine.vue"
 
 const $externalResults = ref({})
-const emit = defineEmits(["reload-declaration"])
+const emit = defineEmits(["decision-done"])
 const declaration = defineModel()
 
 const privateNotes = ref(declaration.value?.privateNotes || "")
@@ -69,7 +69,7 @@ const refuseVisa = async () => {
   $externalResults.value = await handleError(response)
   if (response.value.ok) {
     useToaster().addSuccessMessage("Votre décision a été prise en compte")
-    emit("reload-declaration")
+    emit("decision-done")
   }
 }
 
@@ -79,7 +79,7 @@ const acceptVisa = async () => {
   $externalResults.value = await handleError(response)
   if (response.value.ok) {
     useToaster().addSuccessMessage("Votre décision a été prise en compte")
-    emit("reload-declaration")
+    emit("decision-done")
   }
 }
 

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -44,7 +44,7 @@
               :privateNotes="declaration?.privateNotes"
               :user="declarant"
               :company="company"
-              @reload-declaration="reloadDeclaration"
+              @decision-done="onDecisionDone"
             ></component>
           </DsfrTabContent>
         </DsfrTabs>
@@ -56,7 +56,7 @@
 <script setup>
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
-import { onMounted, computed, ref, nextTick } from "vue"
+import { onMounted, computed, ref } from "vue"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
@@ -71,6 +71,7 @@ import { useRouter } from "vue-router"
 import { tabTitles } from "@/utils/mappings"
 
 const router = useRouter()
+const previousRoute = router.getPreviousRoute()
 
 const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
@@ -151,10 +152,9 @@ const takeDeclaration = async () => {
   }
 }
 
-const reloadDeclaration = async () => {
-  tabs.value?.selectIndex?.(0)
-  await nextTick()
-  await executeDeclarationFetch()
+const onDecisionDone = () => {
+  const previousQuery = previousRoute.value.name === "VisaDeclarations" ? previousRoute.value.query : {}
+  router.push({ name: "VisaDeclarations", query: previousQuery })
 }
 const onWithdrawal = () => router.replace({ name: "VisaDeclarations", query: { status: "WITHDRAWN,AUTHORIZED" } })
 </script>


### PR DESCRIPTION
Closes #682 

## Contexte

Après une décision prise (soit par une instructrice que par une viseuse) précédemment on revenait vers le premier onglet. L'issue #682 décrit bien le besoin de plutôt revenir à la liste des déclarations tout en gardant les éventuels filtres que l'utilisatrice aurait appliqué.

## Développement

Sur Vue, lors qu'on utilise la _composition API_ comme nous, tout le code dans `<script setup>` est exécuté après la résolution de la route. C'est à dire, on ne peut plus avoir l'information sur l'objet `route` précédent ni utiliser les navigation-guards comme `beforeRouteEnter`.

Or, nous avons besoin de l'information concernant la route précédent pour en extraire les filtres utilisés.

Pour en arriver, j'ai ajouté une fonction dans le router qui s'appelle `router.getPreviousRoute` qui retournera la route précédente. Cette route est mise à jour à chaque changement de route grâce au `beforeEach`.

## Démo

[Screencast from 23-07-24 15:54:54.webm](https://github.com/user-attachments/assets/96f68ecd-43bb-4484-b161-5372ee9c2453)

