### PR TITLE
:lady_beetle: Fix du bug avec Boto 3

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -179,7 +179,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # Media and file storage
 DEFAULT_FILE_STORAGE = env("DEFAULT_FILE_STORAGE")
 
-if DEFAULT_FILE_STORAGE == "storages.backends.s3.S3Storage":
+if DEFAULT_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
     AWS_ACCESS_KEY_ID = env("CELLAR_KEY")
     AWS_SECRET_ACCESS_KEY = env("CELLAR_SECRET")
     AWS_S3_ENDPOINT_URL = env("CELLAR_HOST")


### PR DESCRIPTION
Lors qu'on utilise boto3 comme _file storage_, nous avons besoin de fournir des variables d'environnement en plus pour l'authentification.

C'est le cas en staging et prod parce qu'on utilise Cellar. Ce n'est pas le cas en local.

La condition pour savoir dans quel cas de figure on se trouve n'était pas correcte. Ce tout petit fix règle la situation.