### PR TITLE
Envoi des emails pour les changements de statut des déclarations

### DIFF
--- a/api/tests/test_flow_emails.py
+++ b/api/tests/test_flow_emails.py
@@ -1,0 +1,226 @@
+from datetime import timedelta
+from unittest import mock
+
+from django.test.utils import override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from rest_framework.test import APITestCase
+
+from config import tasks
+from data.factories import (
+    AuthorizedDeclarationFactory,
+    CompanyFactory,
+    DeclarantRoleFactory,
+    InstructionReadyDeclarationFactory,
+    InstructionRoleFactory,
+    ObjectionDeclarationFactory,
+    ObservationDeclarationFactory,
+    OngoingInstructionDeclarationFactory,
+    OngoingVisaDeclarationFactory,
+    SnapshotFactory,
+    VisaRoleFactory,
+)
+from data.models import Declaration
+
+from .utils import authenticate
+
+
+@override_settings(ANYMAIL={"SENDINBLUE_API_KEY": "fake-api-key"})
+@override_settings(CONTACT_EMAIL="contact@example.com")
+@mock.patch("config.email.send_sib_template")
+class TestDeclarationFlow(APITestCase):
+    @authenticate
+    def test_submit_declaration(self, mocked_brevo):
+        """
+        Passage du DRAFT -> AWAITING_INSTRUCTION = Template 3
+        """
+        declarant_role = DeclarantRoleFactory(user=authenticate.user)
+        company = declarant_role.company
+        template_number = 3
+        declaration = InstructionReadyDeclarationFactory(author=authenticate.user, company=company)
+
+        self.client.post(reverse("api:submit_declaration", kwargs={"pk": declaration.id}), format="json")
+
+        mocked_brevo.assert_called_once_with(
+            template_number, None, authenticate.user.email, authenticate.user.get_full_name()
+        )
+
+    @authenticate
+    def test_observe_declaration(self, mocked_brevo):
+        """
+        Passage du ONGOING_INSTRUCTION -> OBSERVATION = Template 4
+        """
+        instructor = InstructionRoleFactory(user=authenticate.user)
+        declaration = OngoingInstructionDeclarationFactory(instructor=instructor)
+        template_number = 4
+
+        self.client.post(reverse("api:observe_no_visa", kwargs={"pk": declaration.id}), format="json")
+
+        mocked_brevo.assert_called_once_with(
+            template_number, None, authenticate.user.email, authenticate.user.get_full_name()
+        )
+
+    @authenticate
+    def test_authorize_declaration(self, mocked_brevo):
+        """
+        Passage du ONGOING_INSTRUCTION -> AUTHORIZED = Template 6
+        """
+        instructor = InstructionRoleFactory(user=authenticate.user)
+        declaration = OngoingInstructionDeclarationFactory(instructor=instructor)
+        template_number = 6
+
+        self.client.post(reverse("api:authorize_no_visa", kwargs={"pk": declaration.id}), format="json")
+
+        mocked_brevo.assert_called_once_with(
+            template_number, None, authenticate.user.email, authenticate.user.get_full_name()
+        )
+
+    @authenticate
+    def test_resubmit_declaration(self, mocked_brevo):
+        """
+        Passage du OBSERVATION -> AWAITING_INSTRUCTION = Pas d'email
+        """
+        company = CompanyFactory()
+        declarant = DeclarantRoleFactory(user=authenticate.user, company=company)
+        declaration = ObservationDeclarationFactory(author=declarant.user, company=company)
+
+        self.client.post(reverse("api:resubmit_declaration", kwargs={"pk": declaration.id}), format="json")
+
+        mocked_brevo.assert_not_called()
+
+    @authenticate
+    def test_authorize_with_visa(self, mocked_brevo):
+        """
+        Passage de ONGOING_VISA à AUTHORIZED = Template 6
+        """
+        VisaRoleFactory(user=authenticate.user)
+        template_number = 6
+
+        declaration = OngoingVisaDeclarationFactory(
+            post_validation_status=Declaration.DeclarationStatus.AUTHORIZED,
+            post_validation_producer_message="À authoriser",
+            post_validation_expiration_days=12,
+        )
+
+        self.client.post(reverse("api:accept_visa", kwargs={"pk": declaration.id}), format="json")
+
+        mocked_brevo.assert_called_once_with(
+            template_number, None, authenticate.user.email, authenticate.user.get_full_name()
+        )
+
+    @authenticate
+    def test_refuse_with_visa(self, mocked_brevo):
+        """
+        Passage de ONGOING_VISA à REJECTED = Template 7
+        """
+        VisaRoleFactory(user=authenticate.user)
+        template_number = 7
+
+        declaration = OngoingVisaDeclarationFactory(
+            post_validation_status=Declaration.DeclarationStatus.REJECTED,
+            post_validation_producer_message="À refuser",
+            post_validation_expiration_days=20,
+        )
+
+        self.client.post(reverse("api:accept_visa", kwargs={"pk": declaration.id}), format="json")
+
+        mocked_brevo.assert_called_once_with(
+            template_number, None, authenticate.user.email, authenticate.user.get_full_name()
+        )
+
+    @authenticate
+    def test_observe_with_visa(self, mocked_brevo):
+        """
+        Passage de ONGOING_VISA à OBSERVATION = Template 4
+        """
+        VisaRoleFactory(user=authenticate.user)
+        template_number = 4
+
+        declaration = OngoingVisaDeclarationFactory(
+            post_validation_status=Declaration.DeclarationStatus.OBSERVATION,
+            post_validation_producer_message="Observation",
+            post_validation_expiration_days=23,
+        )
+
+        self.client.post(reverse("api:accept_visa", kwargs={"pk": declaration.id}), format="json")
+
+        mocked_brevo.assert_called_once_with(
+            template_number, None, authenticate.user.email, authenticate.user.get_full_name()
+        )
+
+    @authenticate
+    def test_object_with_visa(self, mocked_brevo):
+        """
+        Passage de ONGOING_VISA à OBJECTION = Template 5
+        """
+        VisaRoleFactory(user=authenticate.user)
+        template_number = 5
+
+        declaration = OngoingVisaDeclarationFactory(
+            post_validation_status=Declaration.DeclarationStatus.OBJECTION,
+            post_validation_producer_message="Objection",
+            post_validation_expiration_days=22,
+        )
+
+        self.client.post(reverse("api:accept_visa", kwargs={"pk": declaration.id}), format="json")
+
+        mocked_brevo.assert_called_once_with(
+            template_number, None, authenticate.user.email, authenticate.user.get_full_name()
+        )
+
+    @authenticate
+    def test_withdraw(self, mocked_brevo):
+        """
+        Passage de AUTHORIZED à WITHDRAWN = Template 8
+        """
+        declaration = AuthorizedDeclarationFactory(author=authenticate.user)
+        template_number = 8
+
+        self.client.post(reverse("api:withdraw", kwargs={"pk": declaration.id}), format="json")
+
+        mocked_brevo.assert_called_once_with(
+            template_number, None, authenticate.user.email, authenticate.user.get_full_name()
+        )
+
+    def test_expire_observed_declaration(self, mocked_brevo):
+        """
+        Passage de OBSERVATION à ABANDONED = Template 9
+        """
+        template_number = 9
+        today = timezone.now()
+        observed_declaration = ObservationDeclarationFactory()
+        snapshot = SnapshotFactory(
+            declaration=observed_declaration,
+            status=Declaration.DeclarationStatus.OBSERVATION,
+            expiration_days=5,
+        )
+        # On se dit que le snapshot a été créé il y a cinq jours
+        snapshot.creation_date = today - timedelta(days=5, minutes=1)
+        snapshot.save()
+        tasks.expire_declarations()
+
+        mocked_brevo.assert_called_once_with(
+            template_number, None, observed_declaration.author.email, observed_declaration.author.get_full_name()
+        )
+
+    def test_expire_objected_declaration(self, mocked_brevo):
+        """
+        Passage de OBJECTION à ABANDONED = Template 9
+        """
+        template_number = 9
+        today = timezone.now()
+        objected_declaration = ObjectionDeclarationFactory()
+        snapshot = SnapshotFactory(
+            declaration=objected_declaration,
+            status=Declaration.DeclarationStatus.OBJECTION,
+            expiration_days=5,
+        )
+        # On se dit que le snapshot a été créé il y a cinq jours
+        snapshot.creation_date = today - timedelta(days=5, minutes=1)
+        snapshot.save()
+        tasks.expire_declarations()
+
+        mocked_brevo.assert_called_once_with(
+            template_number, None, objected_declaration.author.email, objected_declaration.author.get_full_name()
+        )

--- a/config/email.py
+++ b/config/email.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+
+import sib_api_v3_sdk
+
+configuration = sib_api_v3_sdk.Configuration()
+configuration.api_key["api-key"] = settings.ANYMAIL.get("SENDINBLUE_API_KEY")
+api_client = sib_api_v3_sdk.ApiClient(configuration)
+email_api_instance = sib_api_v3_sdk.TransactionalEmailsApi(api_client)
+
+
+def send_sib_template(template_id, parameters, to_email, to_name):
+    """
+    Permet d'envoyer un email transactionnel précédemment défini dans Brevo.
+    """
+    send_smtp_email = sib_api_v3_sdk.SendSmtpEmail(
+        to=[{"email": to_email, "name": to_name}],
+        params=parameters,
+        sender={"email": settings.CONTACT_EMAIL, "name": "Compl'Alim"},
+        reply_to={"email": settings.CONTACT_EMAIL, "name": "Compl'Alim"},
+        template_id=template_id,
+    )
+    email_api_instance.send_transac_email(send_smtp_email)

--- a/config/tests/test_expiration.py
+++ b/config/tests/test_expiration.py
@@ -40,9 +40,9 @@ class TestExpiration(TestCase):
         le temps alloué pour la réponse.
         """
         today = timezone.now()
-        observed_declaration = ObjectionDeclarationFactory()
+        objected_declaration = ObjectionDeclarationFactory()
         snapshot = SnapshotFactory(
-            declaration=observed_declaration,
+            declaration=objected_declaration,
             status=Declaration.DeclarationStatus.OBJECTION,
             expiration_days=5,
         )
@@ -51,8 +51,8 @@ class TestExpiration(TestCase):
         snapshot.save()
         tasks.expire_declarations()
 
-        observed_declaration.refresh_from_db()
-        self.assertEqual(observed_declaration.status, Declaration.DeclarationStatus.ABANDONED)
+        objected_declaration.refresh_from_db()
+        self.assertEqual(objected_declaration.status, Declaration.DeclarationStatus.ABANDONED)
 
     def test_do_not_expire_before_cutoff(self):
         """


### PR DESCRIPTION
Closes #653 

## Contexte

Certains changements de statut des déclarations devront déclencher un envoi d'email. Ces emails sont des opérations transactionnelles qui appellent un template ID côté Brevo. Voici le diagramme de ces emails :

![image](https://github.com/user-attachments/assets/00b9fafe-4cf9-42a8-bc07-0544d9e1c248)

Cette PR couvre les boîtes vertes (çad le template numéro 10 est hors scope)

## Précisions

- Pour les tests automatiques on mock la fonction `config.email.send_sib_template`
- L'échec d'un envoi d'email log une erreur mais n'empêche pas l'operation de se finir en 200-OK. Ceci nous permet de suivre les erreurs sans devoir envoyer des vrais messages en local ni éventuellement staging (et dans le futur la plateforme démo)
- Sur Brevo, les templates doivent être activés. Pour l'instant il n'y a qu'un seul qui est activé pour des raisons de test
- Une fois que les templates soient finis, il se peut qu'on doive ajouter des paramètres dynamiques. Ça se ferait dans une seconde PR.

## Exemple d'email envoyé depuis Brevo

![image](https://github.com/user-attachments/assets/88de1933-d5ef-4c48-8758-bf8d14e807ba)

