### PR TITLE
Extraction des contacts utilisants TeleIcare.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,5 +69,28 @@
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"
     }
-  }
+  },
+  // sql
+  "sqlfluff.dialect": "mysql",
+  "sqlfluff.excludeRules": ["L009"],
+  "sqlfluff.executablePath": "/home/perrine/.cache/pypoetry/virtualenvs/complalim-CF5WuROI-py3.11/bin/sqlfluff",
+  "sqlfluff.ignoreLocalConfig": false,
+  "sqlfluff.ignoreParsing": false,
+  "sqlfluff.rules": [],
+  "sqlfluff.suppressNotifications": false,
+  "sqlfluff.workingDirectory": "",
+  /* Linter */
+  "sqlfluff.linter.arguments": [],
+  "sqlfluff.linter.run": "onType",
+  "sqlfluff.linter.diagnosticSeverity": "error",
+  "sqlfluff.linter.diagnosticSeverityByRule": [
+    {
+      "rule": "L010",
+      "severity": "warning"
+    }
+  ],
+  "sqlfluff.linter.lintEntireProject": true,
+  /* Formatter */
+  "sqlfluff.format.arguments": ["--FIX-EVEN-UNPARSABLE"],
+  "sqlfluff.format.enabled": true,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ redis = "^5.0.7"
 
 # Dev dependencies (not installed on remote environments)
 [tool.poetry.group.dev.dependencies]
+sqlfluff = "*"
 
 ######################################################################################################################
 # Data tools

--- a/stats/teleicare_users_extraction.sql
+++ b/stats/teleicare_users_extraction.sql
@@ -1,0 +1,117 @@
+/*Compte le nombre d'établissement*/
+SELECT COUNT(*) FROM ICA_ETABLISSEMENT;
+/* 7209 établissements */
+
+/*Compte le nombre d'administrateur.ice par établissement*/
+SELECT
+    ETAB_IDENT,
+    COUNT(ADM_IDENT) AS NB_ADM
+FROM ICA_ADMINISTRATEUR
+GROUP BY ETAB_IDENT
+HAVING COUNT(ADM_IDENT) != 1;
+/* 1 seul administrateur.ice par établissement*/
+/* 6558 administrateur.ice => il y a des établissements sans administrateur.ice */
+
+/* Compte le nombre de contact par établissement*/
+SELECT
+    NB_CTACT,
+    COUNT(ETAB_IDENT) AS NB_ETAB
+FROM (
+    SELECT
+        ETAB_IDENT,
+        COUNT(CTACT_IDENT) AS NB_CTACT
+    FROM ICA_CONTACT
+    GROUP BY ETAB_IDENT
+) AS SUB_TABLE GROUP BY NB_CTACT;
+-- NB_CTACT NB_ETAB
+-- 1    229
+-- 2    26
+-- 3    7
+-- 4    1
+/* Il y a beaucoup d'établissements sans contact */
+SELECT COUNT(*)
+FROM ICA_ETABLISSEMENT
+LEFT OUTER JOIN
+    ICA_CONTACT
+    ON ICA_ETABLISSEMENT.ETAB_IDENT = ICA_CONTACT.ETAB_IDENT
+WHERE ICA_CONTACT.ETAB_IDENT IS NULL
+/* 6946 établissements sans contact, et 306 contacts seulement */
+/* Hypothèse : ICA_CONTACT était obsolète */
+
+/* Compte le nombre d'usager par établissement*/
+SELECT
+    NB_USER,
+    COUNT(ETAB_IDENT) AS NB_ETAB
+FROM (
+    SELECT
+        ADM_IDENT,
+        ETAB_IDENT,
+        COUNT(USR_IDENT) AS NB_USER
+    FROM ICA_USAGER GROUP BY ADM_IDENT, ETAB_IDENT
+) AS SUB_TABLE GROUP BY NB_USER ORDER BY NB_USER DESC;
+-- NB_USER  NB_ETAB
+-- 12   1
+-- 11   1
+-- 10   4
+-- 9    4
+-- 8    2
+-- 7    8
+-- 6    18
+-- 5    26
+-- 4    58
+-- 3    91
+-- 2    296
+-- 1    6778
+
+
+
+
+/* Calcul des contact qui sont aussi administrateur.ice = même nom, adresse mail, téléphone */
+
+/* Tous les courriels reliés à une entreprise :
+* soit dans la table ICA_ETABLISSEMENT
+* soit dans la table ICA_CONTACT
+ */
+SELECT
+    ETAB_SIRET,
+    ETAB_NUMERO_TVA_INTRA,
+    ETAB_RAISON_SOCIALE,
+    ETAB_ENSEIGNE,
+    ETAB_TELEPHONE,
+    ETAB_COURRIEL,
+    ETAB_SITE_INTERNET,
+    ETAB_NUM_ADH_TELE_PROC,
+    ETAB_DATE_ADHESION,
+    ADM_NOM,
+    ADM_PRENOM,
+    ADM_FONCTION,
+    ADM_TELECOPIE,
+    ADM_TELEPHONE,
+    CTACT_NOM,
+    CTACT_PRENOM,
+    CTACT_TELEPHONE,
+    CTACT_FONCTION,
+    CTACT_COURRIEL,
+    CTACT_TELECOPIE
+FROM ICA_ETABLISSEMENT
+INNER JOIN
+    ICA_ADMINISTRATEUR
+    ON ICA_ETABLISSEMENT.ETAB_IDENT = ICA_ADMINISTRATEUR.ETAB_IDENT
+INNER JOIN ICA_CONTACT ON ICA_ETABLISSEMENT.ETAB_IDENT = ICA_CONTACT.ETAB_IDENT;
+
+/* Toutes les fonctions liées à une entreprise
+* soit dans la table ICA_ADMINISTRATEUR
+* soit dans la table ICA_CONTACT
+* soit dans la table ICA_USAGER
+*/
+
+
+/* Tous les siret liés à une déclaration */
+--   join ICA_ETS_CLIENT
+-- [ETAB_CLIENT_SIRET]
+
+/* Les users actifs */
+-- [aspnet_Users] [LastActivityDate]
+
+
+-- [Aspnet_Membership_2021_09_13] [Email]

--- a/stats/teleicare_users_extraction.sql
+++ b/stats/teleicare_users_extraction.sql
@@ -95,7 +95,8 @@ INNER JOIN ICA_CONTACT ON ICA_ETABLISSEMENT.ETAB_IDENT = ICA_CONTACT.ETAB_IDENT;
 
 /* Les users actifs et leurs emails */
 /* La vue V_Users sur aspnet_User filtre les user qui ont effectivement un compte ICA_USAGER ou ICA_ADMINISTRATEUR */
-/* Nous créons la vue V_UsersImproved pour extraire les informations nécessaires */
+/* Nous créons la vue V_UsersForExport pour extraire les informations nécessaires */
+/* TODO: Il faudrait rajouter à cette vue les contact des tables ICA_ETABLISSEMENT et ICA_CONTACT */
 CREATE VIEW [dbo].[V_UsersForExport]
 AS
    select u.USR_IDENT as UsrIdent,
@@ -125,7 +126,6 @@ select null as UsrIdent,
                 a.ADM_FONCTION as Fonction,
                 au.LastActivityDate as LastActivityDate,
                 am.Email as Email,
-                a.ETAB_IDENT as EtabIdent,
                 e.ETAB_RAISON_SOCIALE as EtabRaisonSociale,
                 e.ETAB_ENSEIGNE as EtabEnseigne,
                 e.Etab_Siret as EtabSiret,
@@ -150,7 +150,6 @@ SELECT COUNT(*) FROM V_UsersForExport
 
 /*Extract via PowerShell des utilisateurs ayant eu une activité ces 2 dernières années */
 SELECT Nom, Prenom, Email, EtabRaisonSociale, EtabEnseigne, EtabSiret, EtabNumeroTvaIntra, Fonction, RoleAsp FROM [TELEICARE].[dbo].[V_UsersForExport] where LASTACTIVITYDATE > '2022-08-01'
-
 
 
 /* Reste à creuser */


### PR DESCRIPTION
Plusieurs tables contiennent des données de contact (cf. image) : 

**ICA_ETABLISSEMENT :**
- ETAB_COURRIEL

**ICA_CONTACT :**
- CTACT_COURRIEL (associé à un nom et un prénom)


Les users TELEICARE (ICA_USAGER) ne sont pas forcément liés à un courriel et ne sont pas liés directement à la table ICA_CONTACT.


![image](https://github.com/user-attachments/assets/a5627d71-1827-4c87-87eb-91608ee10643)

Fix #713 

L'extract respecte les conditions d'usage de Brevo (avec une utilisation de la plateforme depuis moins de 2 ans)
![image](https://github.com/user-attachments/assets/38e17f8e-4c39-4184-8d0a-8eef237c0eb8)
