### PR TITLE
Ajustements sur l'onglet « identité »

### DIFF
--- a/frontend/src/components/AddressLine.vue
+++ b/frontend/src/components/AddressLine.vue
@@ -1,0 +1,14 @@
+<template>
+  <address>
+    {{ payload.address }}
+    {{ payload.additional_details }}
+    {{ payload.postal_code }}
+    {{ payload.city }}
+    {{ payload.country }}
+    <span v-if="payload.cedex">- CEDEX : {{ payload.cedex }}</span>
+  </address>
+</template>
+
+<script setup>
+defineProps(["payload"])
+</script>

--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -53,6 +53,12 @@
     <SubstancesTable v-model="payload" readonly />
 
     <h3 class="fr-h6 !mt-8">
+      Adresse sur l'étiquetage
+      <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(1))" />
+    </h3>
+    <AddressLine :payload="payload" />
+
+    <h3 class="fr-h6 !mt-8">
       Pièces jointes
       <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(2))" />
     </h3>
@@ -74,6 +80,7 @@ export default { name: "DeclarationSummary" }
 
 <script setup>
 import { computed } from "vue"
+import AddressLine from "@/components/AddressLine"
 import SummaryInfoSegment from "./SummaryInfoSegment"
 import SummaryElementList from "./SummaryElementList"
 import SubstancesTable from "@/components/SubstancesTable"

--- a/frontend/src/components/IdentityTab.vue
+++ b/frontend/src/components/IdentityTab.vue
@@ -28,14 +28,7 @@
     <p v-if="company.address">
       <span>
         Adresse :
-        <address class="inline">
-          {{ company.address }}
-          {{ company.additional_details }}
-          {{ company.postal_code }}
-          {{ company.city }}
-          {{ company.country }}
-          <span v-if="company.cedex">- CEDEX : {{ company.cedex }}</span>
-        </address>
+        <AddressLine class="inline" :payload="company" />
       </span>
     </p>
   </div>
@@ -43,6 +36,7 @@
 
 <script setup>
 import SectionTitle from "@/components/SectionTitle"
+import AddressLine from "@/components/AddressLine"
 defineProps({ user: Object, company: Object })
 </script>
 

--- a/frontend/src/components/IdentityTab.vue
+++ b/frontend/src/components/IdentityTab.vue
@@ -1,13 +1,6 @@
 <template>
   <div>
-    <SectionTitle title="Déclarant ou déclarante" icon="ri-user-fill" />
-    <p>{{ user.firstName }} {{ user.lastName }}</p>
-    <p>
-      Adresse email :
-      <a :href="`mailto:${user.email}`" target="_blank">{{ user.email }}</a>
-    </p>
-
-    <SectionTitle class="!mt-8" title="Entreprise" icon="ri-home-2-fill" />
+    <SectionTitle title="Entreprise" icon="ri-home-2-fill" />
     <p class="font-bold">{{ company.socialName }}</p>
     <p v-if="company.siret">
       Numéro SIRET : {{ company.siret }}
@@ -30,6 +23,12 @@
         Adresse :
         <AddressLine class="inline" :payload="company" />
       </span>
+    </p>
+    <SectionTitle class="!mt-8" title="Déclarant ou déclarante" icon="ri-user-fill" />
+    <p>{{ user.firstName }} {{ user.lastName }}</p>
+    <p>
+      Adresse email :
+      <a :href="`mailto:${user.email}`" target="_blank">{{ user.email }}</a>
     </p>
   </div>
 </template>

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -126,8 +126,9 @@ onMounted(async () => {
 
 // Tab management
 const components = computed(() => {
-  const baseComponents = [DeclarationSummary, IdentityTab, HistoryTab]
+  const baseComponents = [DeclarationSummary, HistoryTab]
   if (canInstruct.value) baseComponents.push(DecisionTab)
+  baseComponents.push(IdentityTab)
   return baseComponents
 })
 const titles = computed(() => tabTitles(components.value))

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -126,8 +126,9 @@ onMounted(async () => {
 
 // Tab management
 const components = computed(() => {
-  const baseComponents = [IdentityTab, DeclarationSummary, HistoryTab]
+  const baseComponents = [DeclarationSummary, HistoryTab]
   if (canInstruct.value) baseComponents.push(VisaValidationTab)
+  baseComponents.push(IdentityTab)
   return baseComponents
 })
 const titles = computed(() => tabTitles(components.value))


### PR DESCRIPTION
Closes #721 

## Scope

Cette PR introduit les changements suivants (spécifiés dans #721) :
- Mettre en premier la section "Entreprise" avant la section "Déclarant ou déclarante"
- Changement d'ordre de l'onglet (pour le mettre tout à la fin)
- Ajout de l'adresse dans la fiche produit au dessus de la section « pièces jointes »

## Captures d'écran

![image](https://github.com/user-attachments/assets/68764528-7da7-4fab-a26d-53937294919c)

![image](https://github.com/user-attachments/assets/6d83ba70-4399-4693-b1c0-7ff5f63aceb3)
