### PR TITLE
Astérisque pour les champs obligatoires dans l'écran produit

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -23,7 +23,7 @@ urlpatterns = {
     path("populations/", views.PopulationListView.as_view(), name="population_list"),
     path("conditions/", views.ConditionListView.as_view(), name="condition_list"),
     path("effects/", views.EffectListView.as_view(), name="effect_list"),
-    path("galenic-formulation/", views.GalenicFormulationListView.as_view(), name="galenic_formulation_list"),
+    path("galenic-formulations/", views.GalenicFormulationListView.as_view(), name="galenic_formulation_list"),
     path("units/", views.UnitListView.as_view(), name="unit_list"),
     # Authentication
     path("login/", views.LoginView.as_view(), name="login"),

--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -91,7 +91,7 @@ import { useRouter } from "vue-router"
 import SummaryModificationButton from "./SummaryModificationButton"
 
 const router = useRouter()
-const { units, populations, conditions, effects, galenicFormulation } = storeToRefs(useRootStore())
+const { units, populations, conditions, effects, galenicFormulations } = storeToRefs(useRootStore())
 
 const payload = defineModel()
 defineProps({ readonly: Boolean })
@@ -103,11 +103,11 @@ const unitInfo = computed(() => {
 
 const galenicFormulationsNames = computed(() => {
   if (!payload.value.galenicFormulation) return null
-  return galenicFormulation.value?.find((y) => y.id === parseInt(payload.value.galenicFormulation))?.name
+  return galenicFormulations.value?.find((y) => y.id === parseInt(payload.value.galenicFormulation))?.name
 })
 
 const effectsNames = computed(() => {
-  const findName = (id) => effects.value.find((y) => y.id === id)?.name
+  const findName = (id) => effects.value?.find((y) => y.id === id)?.name
   const otherEffects = payload.value.otherEffects
   const allEffects = otherEffects
     ? payload.value.effects.map(findName).concat("Autre (à préciser) : ".concat(otherEffects))
@@ -121,11 +121,11 @@ const effectsNames = computed(() => {
 })
 
 const populationNames = computed(() => {
-  const findName = (id) => populations.value.find((y) => y.id === id)?.name
+  const findName = (id) => populations.value?.find((y) => y.id === id)?.name
   return payload.value.populations.map(findName).join(", ")
 })
 const conditionNames = computed(() => {
-  const findName = (id) => conditions.value.find((y) => y.id === id)?.name
+  const findName = (id) => conditions.value?.find((y) => y.id === id)?.name
   return payload.value.conditionsNotRecommended.map(findName).join(", ")
 })
 

--- a/frontend/src/stores/root.js
+++ b/frontend/src/stores/root.js
@@ -9,7 +9,7 @@ export const useRootStore = defineStore("root", () => {
   const populations = ref(null)
   const conditions = ref(null)
   const effects = ref(null)
-  const galenicFormulation = ref(null)
+  const galenicFormulations = ref(null)
   const plantParts = ref(null)
   const units = ref(null)
 
@@ -48,9 +48,9 @@ export const useRootStore = defineStore("root", () => {
     const { data } = await useFetch("/api/v1/effects/").json()
     effects.value = otherFieldsAtTheEnd(data.value)
   }
-  const fetchGalenicFormulation = async () => {
-    const { data } = await useFetch("/api/v1/galenic-formulation/").json()
-    galenicFormulation.value = otherFieldsAtTheEnd(data.value)
+  const fetchGalenicFormulations = async () => {
+    const { data } = await useFetch("/api/v1/galenic-formulations/").json()
+    galenicFormulations.value = otherFieldsAtTheEnd(data.value)
   }
   const fetchPlantParts = async () => {
     const { data } = await useFetch("/api/v1/plant-parts/").json()
@@ -65,7 +65,7 @@ export const useRootStore = defineStore("root", () => {
     fetchEffects()
     fetchPopulations()
     fetchPlantParts()
-    fetchGalenicFormulation()
+    fetchGalenicFormulations()
     fetchUnits()
   }
   return {
@@ -79,7 +79,7 @@ export const useRootStore = defineStore("root", () => {
     fetchPopulations,
     fetchConditions,
     fetchEffects,
-    fetchGalenicFormulation,
+    fetchGalenicFormulations,
     fetchDeclarationFieldsData,
     fetchPlantParts,
     fetchUnits,
@@ -87,7 +87,7 @@ export const useRootStore = defineStore("root", () => {
     populations,
     conditions,
     effects,
-    galenicFormulation,
+    galenicFormulations,
     units,
   }
 })

--- a/frontend/src/views/ProducerFormPage/ProductTab.vue
+++ b/frontend/src/views/ProducerFormPage/ProductTab.vue
@@ -26,34 +26,37 @@
         <DsfrInputGroup :error-message="firstErrorMsg(v$, 'name')">
           <DsfrInput v-model="payload.name" label-visible label="Nom du produit" :required="true" />
         </DsfrInputGroup>
+      </div>
+      <div class="col-span-2 md:col-span-1 max-w-md">
         <DsfrInputGroup>
           <DsfrInput v-model="payload.brand" label-visible label="Marque" />
         </DsfrInputGroup>
       </div>
       <div class="col-span-2 md:col-span-1 max-w-md">
-        <!-- Useless? -->
         <DsfrInputGroup>
           <DsfrInput v-model="payload.gamme" label-visible label="Gamme" />
         </DsfrInputGroup>
-
-        <!-- Useless? -->
+      </div>
+      <div class="col-span-2 md:col-span-1 max-w-md">
         <DsfrInputGroup>
           <DsfrInput v-model="payload.flavor" label-visible label="Arôme" />
         </DsfrInputGroup>
       </div>
       <DsfrInputGroup class="max-w-2xl mt-6">
-        <DsfrInput is-textarea v-model="payload.description" label-visible label="Description" :required="true" />
+        <DsfrInput is-textarea v-model="payload.description" label-visible label="Description" />
       </DsfrInputGroup>
     </div>
     <SectionTitle title="Format" class="!mt-10" sizeTag="h6" icon="ri-capsule-fill" />
     <div class="grid grid-cols-2 gap-4">
-      <DsfrFieldset legend="Forme galénique" legendClass="fr-label !font-normal !pb-0">
+      <DsfrFieldset legend="Forme galénique" legendClass="fr-label !pb-0">
         <div class="flex">
           <div class="max-w-32">
-            <DsfrSelect :options="formulationStates" v-model="galenicFormulationState" defaultUnselectedText="État" />
+            <DsfrSelect label="État" :options="formulationStates" v-model="galenicFormulationState" />
           </div>
           <div class="max-w-md ml-4">
             <DsfrSelect
+              :required="true"
+              label="Forme"
               v-model="payload.galenicFormulation"
               :options="
                 galenicFormulationList?.map((formulation) => ({
@@ -69,8 +72,8 @@
         <DsfrInput
           v-if="
             payload.galenicFormulation &&
-            galenicFormulation &&
-            getAllIndexesOfRegex(galenicFormulation, /Autre.*(à préciser)/).includes(
+            galenicFormulations &&
+            getAllIndexesOfRegex(galenicFormulations, /Autre.*(à préciser)/).includes(
               parseInt(payload.galenicFormulation)
             )
           "
@@ -83,13 +86,22 @@
 
     <div class="grid grid-cols-2 gap-4">
       <div class="col-span-2 md:col-span-1 max-w-md mt-6">
-        <DsfrFieldset legend="Poids ou volume d'une unité de consommation" legendClass="fr-label !font-normal !pb-0">
+        <DsfrFieldset legend="Poids ou volume d'une unité de consommation" legendClass="fr-label !pb-0">
           <div class="flex">
             <div class="max-w-64">
-              <DsfrInput v-model="payload.unitQuantity" class="max-w-64" :required="true" />
+              <DsfrInput
+                label="Quantité"
+                label-visible
+                v-model="payload.unitQuantity"
+                class="max-w-64"
+                :required="true"
+              />
             </div>
             <div class="max-w-32 ml-4">
               <DsfrSelect
+                label="Unité"
+                label-visible
+                :required="true"
                 :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
                 v-model="payload.unitMeasurement"
                 defaultUnselectedText="Unité"
@@ -98,7 +110,7 @@
           </div>
         </DsfrFieldset>
       </div>
-      <div class="col-span-2 md:col-span-1 max-w-md">
+      <div class="col-span-2 md:col-span-1 max-w-md pt-0 sm:pt-8">
         <DsfrInputGroup>
           <DsfrInput v-model="payload.conditioning" label-visible label="Conditionnement" />
         </DsfrInputGroup>
@@ -178,7 +190,7 @@
       </div>
     </DsfrFieldset>
 
-    <DsfrInputGroup class="max-w-2xl mt-6" v-if="payload.effects && payload.effects.indexOf(otherEffectsId) > -1">
+    <DsfrInputGroup class="max-w-2xl mt-6 pt-8" v-if="payload.effects && payload.effects.indexOf(otherEffectsId) > -1">
       <DsfrInput
         v-model="payload.otherEffects"
         label-visible
@@ -246,15 +258,25 @@ const v$ = useVuelidate(rules, payload, { $externalResults })
 watch($externalResults, () => v$.value.$touch())
 
 const store = useRootStore()
-const { populations, conditions, effects, galenicFormulation, loggedUser } = storeToRefs(store)
+const { populations, conditions, effects, galenicFormulations, loggedUser } = storeToRefs(store)
+
 const galenicFormulationState = ref(null)
+// Peupler la variable du state si la forme galénique est présente déjà dans le payload
+const populateGalenicFormulationState = () => {
+  if (payload.value.galenicFormulation) {
+    const formulation = galenicFormulations.value?.find((x) => x.id === payload.value.galenicFormulation)
+    if (formulation) galenicFormulationState.value = formulation.isLiquid ? "liquid" : "solid"
+  }
+}
+watch(galenicFormulations, populateGalenicFormulationState, { immediate: true })
+
 const otherEffectsId = computed(() => effects.value?.find((effect) => effect.name === "Autre (à préciser)")?.id)
 const galenicFormulationList = computed(() => {
-  if (!galenicFormulationState.value) return galenicFormulation.value
+  if (!galenicFormulationState.value) return galenicFormulations.value
   else {
     const isLiquid = galenicFormulationState.value === "liquid"
     return otherFieldsAtTheEnd(
-      galenicFormulation.value
+      galenicFormulations.value
         ?.filter((formulation) => formulation.isLiquid === isLiquid) // le filter perd l'ordre alphabétique d'origine
         .sort((a, b) => a.name.localeCompare(b.name))
     )

--- a/frontend/src/views/ProducerFormPage/ProductTab.vue
+++ b/frontend/src/views/ProducerFormPage/ProductTab.vue
@@ -68,7 +68,7 @@
           </div>
         </div>
       </DsfrFieldset>
-      <div class="max-w-2xl">
+      <div class="max-w-2xl pt-0 sm:pt-6">
         <DsfrInput
           v-if="
             payload.galenicFormulation &&


### PR DESCRIPTION
Closes #702 

## Contexte

Le DSFR suggère d'ajouter un astérisque pour les champs obligatoires dans les formulaires ([lien](https://www.systeme-de-design.gouv.fr/composants-et-modeles/champ-de-saisie)). Cette PR vise à s'assurer que cette règle est bien respectée.

Au passage certains fixes ont été aussi réalisés dans la page du producteur.

## Scope

- Ajout de l'astérisque pour les champs « forme galénique » et « poids ou volume d'une unité de consommation »
- Enlèvement de l'astérisque pour le champ « description »
- Le select pour l'état de la forme galénique n'était pas rempli automatiquement lors qu'on ouvrait une déclaration existante. Cette PR fixe ce petit souci
- Le tableau de formes galéniques provenant de l'API s'appelle maintenant `galenicFormulations` (en pluriel) un peu partout dans l'appli, pour clarté et cohérence avec les autres ressources (effects, conditions, etc)
- Ajout de certaines conditionnels `?` pour éviter des situations de compétition qui levaient des erreurs (par ex `effects.value?.find`)

## Capture d'écran
![image](https://github.com/user-attachments/assets/af46b069-30d3-4b3d-aa74-dca9c6209363)

