### PR TITLE
Add tab stepper at the bottom of tab components

### DIFF
--- a/frontend/src/components/TabStepper.vue
+++ b/frontend/src/components/TabStepper.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="border p-4 bg-gray-100 text-right">
+    <DsfrButton
+      secondary
+      v-if="selectedTabIndex > 0"
+      @click="emit('back')"
+      :label="`Revenir à l'onglet « ${titles[selectedTabIndex - 1].title} »`"
+    />
+    <DsfrButton
+      class="ml-4"
+      v-if="selectedTabIndex < titles.length - 1"
+      @click="emit('forward')"
+      :label="`Passer à l'onglet « ${titles[selectedTabIndex + 1].title} »`"
+    />
+  </div>
+</template>
+
+<script setup>
+defineProps(["titles", "selectedTabIndex"])
+const emit = defineEmits(["back", "forward"])
+</script>

--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -130,7 +130,7 @@ export const tabTitles = (components, useSubmission = false) => {
       panelId: `tab-content-${idx("IdentityTab")}`,
     },
     DeclarationSummary: {
-      title: "Le produit",
+      title: "Produit",
       icon: "ri-flask-line",
       tabId: `tab-${idx("DeclarationSummary")}`,
       panelId: `tab-content-${idx("DeclarationSummary")}`,
@@ -154,7 +154,7 @@ export const tabTitles = (components, useSubmission = false) => {
       panelId: `tab-content-${idx("SummaryTab")}`,
     },
     ProductTab: {
-      title: "Le produit",
+      title: "Produit",
       icon: "ri-capsule-fill",
       tabId: `tab-${idx("ProductTab")}`,
       panelId: `tab-content-${idx("ProductTab")}`,

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -47,12 +47,19 @@
             ></component>
           </DsfrTabContent>
         </DsfrTabs>
+        <TabStepper
+          :titles="titles"
+          :selectedTabIndex="selectedTabIndex"
+          @back="selectTab(selectedTabIndex - 1)"
+          @forward="selectTab(selectedTabIndex + 1)"
+        />
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
+import TabStepper from "@/components/TabStepper"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import { onMounted, computed, ref } from "vue"
@@ -135,8 +142,10 @@ const titles = computed(() => tabTitles(components.value))
 const selectedTabIndex = ref(0)
 const asc = ref(true) // Je n'aime pas le nommage mais ça vient de ce paramètre : https://vue-dsfr.netlify.app/?path=/docs/composants-dsfrtabs--docs
 const selectTab = (index) => {
+  if (index === selectedTabIndex.value) return
   asc.value = selectedTabIndex.value < index
   selectedTabIndex.value = index
+  tabs.value?.selectIndex?.(selectedTabIndex.value)
 }
 
 const instructDeclaration = async () => {

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -53,11 +53,18 @@
           </FormWrapper>
         </DsfrTabContent>
       </DsfrTabs>
+      <TabStepper
+        :titles="titles"
+        :selectedTabIndex="selectedTabIndex"
+        @back="selectTab(selectedTabIndex - 1)"
+        @forward="selectTab(selectedTabIndex + 1)"
+      />
     </div>
   </div>
 </template>
 <script setup>
 import ProgressSpinner from "@/components/ProgressSpinner"
+import TabStepper from "@/components/TabStepper"
 import { useRootStore } from "@/stores/root"
 import { ref, computed, watch } from "vue"
 import ProductTab from "./ProductTab"

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -47,12 +47,19 @@
             ></component>
           </DsfrTabContent>
         </DsfrTabs>
+        <TabStepper
+          :titles="titles"
+          :selectedTabIndex="selectedTabIndex"
+          @back="selectTab(selectedTabIndex - 1)"
+          @forward="selectTab(selectedTabIndex + 1)"
+        />
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
+import TabStepper from "@/components/TabStepper"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import { onMounted, computed, ref } from "vue"
@@ -135,8 +142,10 @@ const titles = computed(() => tabTitles(components.value))
 const selectedTabIndex = ref(0)
 const asc = ref(true) // Je n'aime pas le nommage mais ça vient de ce paramètre : https://vue-dsfr.netlify.app/?path=/docs/composants-dsfrtabs--docs
 const selectTab = (index) => {
+  if (index === selectedTabIndex.value) return
   asc.value = selectedTabIndex.value < index
   selectedTabIndex.value = index
+  tabs.value?.selectIndex?.(selectedTabIndex.value)
 }
 
 const takeDeclaration = async () => {


### PR DESCRIPTION
## Contexte

Comme spécifié dans [ce commentaire](https://github.com/betagouv/complements-alimentaires/issues/626#issuecomment-2250461270) de l'issue #626, on aimerait avoir une façon de passer à l'onglet suivant en bas de page de chaque onglet.

## Scope

Cette PR crée le composant `TabStepper` qui permet de changer d'onglet en bas de l'écran afin d'éviter le scroll vers le haut. 

## Captures d'écran

![image](https://github.com/user-attachments/assets/6c7155dd-c58f-4082-98fd-a0acefe7bcbb)
![image](https://github.com/user-attachments/assets/895d4a28-f71f-431c-9491-8858e33fa5dc)
