### PR TITLE
Rend obligatoire une pièce jointe pour l'étiquetage

### DIFF
--- a/api/views/declaration/declaration_flow_validations.py
+++ b/api/views/declaration/declaration_flow_validations.py
@@ -1,4 +1,4 @@
-from data.models import Declaration
+from data.models import Attachment, Declaration
 
 # Les validateurs dans ce fichier retournent une tuple avec les `field_errors` et les
 # `non_field_errors` pour une déclaration.
@@ -30,6 +30,9 @@ def validate_mandatory_fields(declaration) -> tuple[list, list]:
         {field: f"« {Declaration._meta.get_field(field).verbose_name} » ne peut pas être vide"}
         for field in missing_product_fields
     ]
+    has_label = declaration.attachments.filter(type=Attachment.AttachmentType.LABEL).exists()
+    if not has_label:
+        field_errors.append({"attachments": "La demande doit contenir au moins une pièce jointe de l'étiquetage"})
     return (field_errors, non_field_errors)
 
 

--- a/data/factories/declaration.py
+++ b/data/factories/declaration.py
@@ -1,6 +1,13 @@
 import factory
 
-from data.models import Declaration, DeclaredIngredient, DeclaredMicroorganism, DeclaredPlant, DeclaredSubstance
+from data.models import (
+    Attachment,
+    Declaration,
+    DeclaredIngredient,
+    DeclaredMicroorganism,
+    DeclaredPlant,
+    DeclaredSubstance,
+)
 
 from .company import CompanyFactory
 from .condition import ConditionFactory
@@ -64,6 +71,14 @@ class DeclaredSubstanceFactory(factory.django.DjangoModelFactory):
     active = factory.Faker("boolean")
 
 
+class AttachmentFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Attachment
+
+    type = Attachment.AttachmentType.LABEL
+    file = factory.django.ImageField()
+
+
 class CompleteDeclarationFactory(DeclarationFactory):
     class Meta:
         model = Declaration
@@ -77,6 +92,15 @@ class CompleteDeclarationFactory(DeclarationFactory):
     postal_code = factory.Faker("postcode", locale="FR")
     city = factory.Faker("city", locale="FR")
     country = "FR"
+
+    @factory.post_generation
+    def attachments(self, create, extracted, **kwargs):
+        if not create:
+            return
+        if extracted or isinstance(extracted, list):
+            self.attachments.set(extracted)
+        else:
+            self.attachments.set([AttachmentFactory(declaration=self)])
 
     @factory.post_generation
     def conditions_not_recommended(self, create, extracted, **kwargs):


### PR DESCRIPTION
Closes #627

## Scope

Le cœur du sujet se trouve dans [ces lignes](https://github.com/betagouv/complements-alimentaires/compare/627-mandatory-attachment?expand=1#diff-a2481f90f095a22af26f8e914e36b2ff2241437978b74c47d2d86a11becc68ccR33) à l'intérieur de la fonction qui est déjà appelée pour valider les autres champs. Il suffit donc d'ajouter la validation des pièces jointes dedans.

## Démo
[Screencast from 31-07-24 13:43:30.webm](https://github.com/user-attachments/assets/d2716848-8b3b-4e8c-b0d7-c6646f02baa3)

