### PR TITLE
Changement de l'ordre des actions dans l'onglet décision pour l'instructrice

### DIFF
--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -185,8 +185,8 @@ const proposalOptions = computed(() => {
   if (decisionCategory.value === "approve") return [{ text: "Autorisation", value: "autorisation" }]
 
   return [
-    { text: "Objection", value: "objection" },
     { text: "Observation", value: "observation" },
+    { text: "Objection", value: "objection" },
     { text: "Refus", value: "rejection" },
   ]
 })


### PR DESCRIPTION
Closes #765 

Cette PR change l'ordre des actions dans l'onglet décision pour l'instructrice pour placer _Observation_ au dessus de _Objection_.