### PR TITLE
Ajout des validations concernant la composition

### DIFF
--- a/api/views/declaration/declaration_flow_validations.py
+++ b/api/views/declaration/declaration_flow_validations.py
@@ -33,7 +33,35 @@ def validate_mandatory_fields(declaration) -> tuple[list, list]:
     has_label = declaration.attachments.filter(type=Attachment.AttachmentType.LABEL).exists()
     if not has_label:
         field_errors.append({"attachments": "La demande doit contenir au moins une pièce jointe de l'étiquetage"})
+
+    for declared_plant in declaration.declared_plants.all():
+        if not declared_plant_is_complete(declared_plant):
+            non_field_errors += ["Merci de renseigner les informations manquantes des plantes ajoutées"]
+
+    for declared_microorganism in declaration.declared_microorganisms.all():
+        if not declared_microorganism_is_complete(declared_microorganism):
+            non_field_errors += ["Merci de renseigner les informations manquantes des micro-organismes ajoutées"]
+
+    for computed_substance in declaration.computed_substances.all():
+        if not computed_substance_is_complete(computed_substance):
+            non_field_errors += ["Merci de renseigner les informations manquantes dans le tableau des substances"]
     return (field_errors, non_field_errors)
+
+
+def declared_plant_is_complete(plant):
+    if not plant.active:
+        return True
+    return plant.used_part and plant.quantity and plant.unit and plant.preparation
+
+
+def declared_microorganism_is_complete(mo):
+    if not mo.active:
+        return True
+    return mo.strain and (not mo.activated or mo.quantity)
+
+
+def computed_substance_is_complete(substance):
+    return substance.quantity
 
 
 def validate_number_of_elements(declaration) -> tuple[list, list]:

--- a/data/factories/declaration.py
+++ b/data/factories/declaration.py
@@ -2,6 +2,7 @@ import factory
 
 from data.models import (
     Attachment,
+    ComputedSubstance,
     Declaration,
     DeclaredIngredient,
     DeclaredMicroorganism,
@@ -16,7 +17,7 @@ from .galenic_formulation import GalenicFormulationFactory
 from .global_roles import InstructionRoleFactory, VisaRoleFactory
 from .ingredient import IngredientFactory
 from .microorganism import MicroorganismFactory
-from .plant import PlantFactory
+from .plant import PlantFactory, PlantPartFactory
 from .population import PopulationFactory
 from .substance import SubstanceFactory
 from .unit import SubstanceUnitFactory
@@ -44,6 +45,8 @@ class DeclaredPlantFactory(factory.django.DjangoModelFactory):
     plant = factory.SubFactory(PlantFactory)
     quantity = factory.Faker("pyfloat")
     unit = factory.SubFactory(SubstanceUnitFactory)
+    preparation = factory.Faker("text")
+    used_part = factory.SubFactory(PlantPartFactory)
 
 
 class DeclaredMicroorganismFactory(factory.django.DjangoModelFactory):
@@ -53,6 +56,7 @@ class DeclaredMicroorganismFactory(factory.django.DjangoModelFactory):
     microorganism = factory.SubFactory(MicroorganismFactory)
     active = factory.Faker("boolean")
     quantity = factory.Faker("pyfloat")
+    strain = factory.Faker("text")
 
 
 class DeclaredIngredientFactory(factory.django.DjangoModelFactory):
@@ -69,6 +73,15 @@ class DeclaredSubstanceFactory(factory.django.DjangoModelFactory):
 
     substance = factory.SubFactory(SubstanceFactory)
     active = factory.Faker("boolean")
+
+
+class ComputedSubstanceFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ComputedSubstance
+
+    substance = factory.SubFactory(SubstanceFactory)
+    quantity = factory.Faker("pyfloat")
+    unit = factory.SubFactory(SubstanceUnitFactory)
 
 
 class AttachmentFactory(factory.django.DjangoModelFactory):

--- a/data/tests/test_declaration.py
+++ b/data/tests/test_declaration.py
@@ -32,8 +32,7 @@ class DeclarationTestCase(TestCase):
                 self.assertEqual(json_declared_plant["element"]["name"], declared_plant.plant.name)
                 self.assertEqual(json_declared_plant["element"]["id"], declared_plant.plant.id)
             if declared_plant.used_part:
-                self.assertEqual(json_declared_plant["usedPart"]["name"], declared_plant.used_part.name)
-                self.assertEqual(json_declared_plant["usedPart"]["id"], declared_plant.used_part.id)
+                self.assertEqual(json_declared_plant["usedPart"], declared_plant.used_part.id)
             if declared_plant.unit:
                 self.assertEqual(json_declared_plant["unit"], declared_plant.unit.id)
             self.assertEqual(json_declared_plant["quantity"], declared_plant.quantity)

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -14,9 +14,13 @@
     <div v-else>
       <DsfrAlert
         class="mb-4"
-        v-if="isAwaitingInstruction && !declaration.instructor"
+        v-if="isAwaitingInstruction && declaration.instructor.id !== loggedUser.id"
         type="info"
-        title="Cette déclaration n'est pas encore assignée"
+        :title="
+          declaration.instructor && declaration.instructor.firstName
+            ? `Cette déclaration est assignée à ${declaration.instructor.firstName} ${declaration.instructor.lastName}`
+            : 'Cette déclaration n\'est pas encore assignée'
+        "
       >
         <p>Vous pouvez vous assigner cette déclaration pour instruction</p>
         <DsfrButton class="mt-2" label="Instruire" tertiary @click="instructDeclaration" />
@@ -48,6 +52,7 @@
           </DsfrTabContent>
         </DsfrTabs>
         <TabStepper
+          v-if="!isAwaitingInstruction"
           :titles="titles"
           :selectedTabIndex="selectedTabIndex"
           @back="selectTab(selectedTabIndex - 1)"

--- a/frontend/src/views/ProducerFormPage/StatusChangeErrorDisplay.vue
+++ b/frontend/src/views/ProducerFormPage/StatusChangeErrorDisplay.vue
@@ -51,14 +51,20 @@ const shownErrors = computed(() => {
   // ------
   // L'erreur levée lors qu'il n'y a aucun ingrédient n'est pas lié à un champ
   // spécifique. Ici on l'ajout manuellement au tab « Composition »
-  const emptyCompositionError = "Le complément doit comporter au moins un ingrédient"
-  if (nonFieldErrors && nonFieldErrors.indexOf(emptyCompositionError) > -1)
-    errorObject.find((x) => x.tab === "Composition")?.errors?.push(emptyCompositionError)
+  const compositionErrors = [
+    "Le complément doit comporter au moins un ingrédient",
+    "Merci de renseigner les informations manquantes des plantes ajoutées",
+    "Merci de renseigner les informations manquantes des micro-organismes ajoutées",
+    "Merci de renseigner les informations manquantes dans le tableau des substances",
+  ]
+  for (let i = 0; i < compositionErrors.length; i++)
+    if (nonFieldErrors && nonFieldErrors.indexOf(compositionErrors[i]) > -1)
+      errorObject.find((x) => x.tab === "Composition")?.errors?.push(compositionErrors[i])
 
   // Les autres erreurs non-liées à des champs vont dans l'apparté « Autres »
   errorObject
     .find((x) => x.tab === "Autres")
-    ?.errors?.push(...nonFieldErrors.filter((x) => x !== emptyCompositionError))
+    ?.errors?.push(...nonFieldErrors.filter((x) => compositionErrors.indexOf(x) === -1))
 
   // On montre seulement les appartés qui ont au moins une erreur
   return errorObject.filter((x) => x.errors.length > 0)

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -55,6 +55,7 @@
         </DsfrTabContent>
       </DsfrTabs>
       <TabStepper
+        v-if="payload"
         :titles="titles"
         :selectedTabIndex="selectedTabIndex"
         @back="selectTab(selectedTabIndex - 1)"

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -48,6 +48,7 @@
           </DsfrTabContent>
         </DsfrTabs>
         <TabStepper
+          v-if="!isAwaitingVisa"
           :titles="titles"
           :selectedTabIndex="selectedTabIndex"
           @back="selectTab(selectedTabIndex - 1)"


### PR DESCRIPTION
Lié au #626 et #749 car faisant partie de la validation.

À partir de cette PR, des validations concernant des informations sur les éléments ajoutés sont aussi calculées depuis le backend.

### Pour les plantes actives
- Partie utilisée
- Qté par DJR
- Unité
- Préparation
![image](https://github.com/user-attachments/assets/2592d859-e78a-44b3-963b-f8878a33ddeb)

### Pour les micro-organismes
- Souche
- Qté par DJR (si l'organisme est actif)
![image](https://github.com/user-attachments/assets/fc794bd0-df1d-40bd-a2b9-9d69a0ef67e4)

### Pour les substances calculées
- La quantité
![image](https://github.com/user-attachments/assets/1136f5c3-3b38-47d7-860a-eb44306207ee)

### Erreur affichée
En cas de souci avec une de ces informations, on affiche l'erreur sous l’aparté « composition » 

![image](https://github.com/user-attachments/assets/f2fb3a1e-d389-4314-b170-01adb3c26743)
