### PR TITLE
Affichage de la raison du refus dans la vue visa

### DIFF
--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -481,6 +481,7 @@ class VisaRequestFlowView(DeclarationFlowView):
             user=request.user,
             action=self.get_snapshot_action(request, declaration),
             post_validation_status=self.post_validation_status,
+            blocking_reasons=request.data.get("reasons"),
         )
 
     def on_transition_success(self, request, declaration):

--- a/frontend/src/utils/declaration.js
+++ b/frontend/src/utils/declaration.js
@@ -1,4 +1,0 @@
-export const shouldShowReasons = (declaration) => {
-  const concernedStatus = ["OBSERVATION", "OBJECTION", "REJECTED"]
-  return concernedStatus.indexOf(declaration?.status) > -1 && declaration?.blockingReasons
-}

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -82,7 +82,6 @@ import { useRoute, useRouter } from "vue-router"
 import { handleError } from "@/utils/error-handling"
 import FormWrapper from "@/components/FormWrapper"
 import { headers } from "@/utils/data-fetching"
-import { shouldShowReasons } from "@/utils/declaration"
 import useToaster from "@/composables/use-toaster"
 import { statusProps, tabTitles } from "@/utils/mappings"
 
@@ -229,5 +228,8 @@ watch(
   (tab) => selectTab(parseInt(tab))
 )
 
-const showReasons = computed(() => shouldShowReasons(data.value))
+const showReasons = computed(() => {
+  const concernedStatus = ["OBSERVATION", "OBJECTION", "REJECTED"]
+  return concernedStatus.indexOf(data.value?.status) > -1 && data.value?.blockingReasons
+})
 </script>

--- a/frontend/src/views/VisaPage/VisaValidationTab.vue
+++ b/frontend/src/views/VisaPage/VisaValidationTab.vue
@@ -16,10 +16,10 @@
           :text="declaration.postValidationExpirationDays || '< non spécifié >'"
         />
         <VisaInfoLine
-          v-if="showReasons"
+          v-if="declaration.blockingReasons?.length"
           title="Raisons de la décision"
           icon="ri-edit-line"
-          :text="declaration.blockingReasons.join(', ') || '< non spécifié >'"
+          :text="declaration.blockingReasons.join(',\n') || '< non spécifié >'"
         />
       </div>
     </div>
@@ -58,7 +58,6 @@ import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import useToaster from "@/composables/use-toaster"
 import VisaInfoLine from "./VisaInfoLine.vue"
-import { shouldShowReasons } from "@/utils/declaration"
 
 const $externalResults = ref({})
 const emit = defineEmits(["decision-done"])
@@ -110,6 +109,4 @@ const decisionCategories = computed(() => {
     },
   ]
 })
-
-const showReasons = computed(() => shouldShowReasons(declaration.value))
 </script>


### PR DESCRIPTION
Closes #793 

# Description du fix

On avait deux soucis qui empêchaient les raisons `blockingReasons` de s'afficher dans l'écran de visa/signature :

1- Lors du changement de statut vers `awaiting_visa`, on ne sauvegardait pas les raisons dans l'objet snapshot. J'ai ajouté aussi un test pour s'assurer qu'on a cette information

2- J'ai factorisé la fonction qui détermine si les raisons sont affichées ou pas. Ceci n'était pas une bonne idée car cette logique change en dépendant de notre rôle. Pour un.e déclarant.e les raisons s'affichent si la déclaration est refusée ou en état d'observation ou objection. Par contre pour une viseuse les raisons doivent toujours s'afficher.

![image](https://github.com/user-attachments/assets/bfda7cf6-6fd2-4350-9795-9dc0670ec463)
