### PR TITLE
Bug fix : Les micro-organismes ajoutés manuellement sont actifs

### DIFF
--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -80,7 +80,7 @@ Pour tous les autres, l'activitée est fournie par le backend */
 export const getActivityByType = (type) => {
   switch (type) {
     case "plant":
-    case "micro-organisme":
+    case "microorganism":
     case "active_ingredient":
     case "form_of_supply":
     case "substance":


### PR DESCRIPTION
Closes #783 

Suite à une comparaison de texte erronée, les micro-organismes ajoutés manuellement n'était pas actifs (#783).

Cette PR répare cette comparaison de sorte que `getActivityByType` retourne bien `true` pour les micro-organismes.