### PR TITLE
Ajout de la raison “Demande en article 17 attendue”

### DIFF
--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -155,13 +155,14 @@ const rejectReasons = [
   },
   {
     title: "Le produit répond à la définition du médicament",
-    items: ["Par fonction", "Par présentation", "Sevrage tabagique"],
+    items: ["Médicament par fonction", "Médicament par présentation", "Sevrage tabagique"],
   },
   {
     title: "Les procédures ne sont pas respectées",
     items: [
       "Présence d'un Novel Food",
       "Présence d'une forme d'apport en nutriments non autorisée",
+      "Demande en article 17 attendue",
       "Demande en article 18 attendue",
     ],
   },


### PR DESCRIPTION
Closes #790 

Cette PR fait deux choses : 
1- Ajout de _Demande en article 17 attendue_ dans les raisons, et
2- Re-wording des raisons _Médicament par fonction_ et _Médicament par présentation_. Avant c'était seulement _Par fonction_ et _Par présentation_, et lors qu'on montrait ces raisons le contexte écrit manquait.

![image](https://github.com/user-attachments/assets/83cc83fc-874c-407d-b9d6-7cdb616a599d)
