### PR TITLE
Support pour des paramètres additionnels dans les pages auth

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -125,6 +125,7 @@ const routes = [
     component: LoginPage,
     meta: {
       title: "Se connecter",
+      omitIfLoggedIn: true,
     },
   },
   {
@@ -133,6 +134,7 @@ const routes = [
     component: SignupPage,
     meta: {
       title: "S'enregistrer",
+      omitIfLoggedIn: true,
     },
   },
   {
@@ -333,6 +335,10 @@ const chooseAuthorisedRoute = async (to, from, next, store) => {
     // 2) vérifie les règles de redirection
     if (to.meta.home) {
       next({ name: store.loggedUser ? "DashboardPage" : "LandingPage" })
+      return
+    }
+    if (to.meta.omitIfLoggedIn && store.loggedUser) {
+      next(to.query.next || { name: "DashboardPage" })
       return
     }
     const authenticationCheck = !to.meta.authenticationRequired || store.loggedUser

--- a/frontend/src/views/LoginPage.vue
+++ b/frontend/src/views/LoginPage.vue
@@ -4,10 +4,15 @@
     <FormWrapper :externalResults="$externalResults">
       <SendNewSignupVerificationEmail v-if="showSendNewConfirmationMail" :userId="userIdForNewConfirmationMail" />
       <DsfrInputGroup :error-message="firstErrorMsg(v$, 'username')">
-        <DsfrInput v-model="state.username" label="Identifiant" labelVisible />
+        <DsfrInput v-model="state.username" label="Identifiant" labelVisible @keyup.enter="submit" />
       </DsfrInputGroup>
       <DsfrInputGroup :error-message="firstErrorMsg(v$, 'password')">
-        <DsfrInput :type="showPassword ? 'text' : 'password'" v-model="state.password" labelVisible>
+        <DsfrInput
+          :type="showPassword ? 'text' : 'password'"
+          v-model="state.password"
+          labelVisible
+          @keyup.enter="submit"
+        >
           <template #label>
             <div class="flex items-center justify-between">
               <div>Mot de passe</div>

--- a/frontend/src/views/LoginPage.vue
+++ b/frontend/src/views/LoginPage.vue
@@ -35,7 +35,7 @@ import { headers } from "@/utils/data-fetching"
 import { errorRequiredField, firstErrorMsg } from "@/utils/forms"
 import useToaster from "@/composables/use-toaster"
 import { handleError } from "@/utils/error-handling"
-import { useRouter } from "vue-router"
+import { useRouter, useRoute } from "vue-router"
 import { useRootStore } from "@/stores/root"
 import FormWrapper from "@/components/FormWrapper"
 import SingleItemWrapper from "@/components/SingleItemWrapper"
@@ -43,6 +43,7 @@ import SendNewSignupVerificationEmail from "@/components/SendNewSignupVerificati
 import PasswordDisplayToggle from "@/components/PasswordDisplayToggle"
 
 const router = useRouter()
+const route = useRoute()
 const rootStore = useRootStore()
 
 const showPassword = ref(false)
@@ -100,7 +101,7 @@ const submit = async () => {
         title: "Vous êtes connecté",
         description: "Vous êtes connecté à la plateforme Compl'Alim.",
       })
-      router.push({ name: "DashboardPage" })
+      router.push(route.query.next || { name: "DashboardPage" })
     }
   }
 }

--- a/frontend/src/views/SignupPage.vue
+++ b/frontend/src/views/SignupPage.vue
@@ -84,13 +84,14 @@ import PasswordDisplayToggle from "@/components/PasswordDisplayToggle"
 import { useRoute, useRouter } from "vue-router"
 
 const router = useRouter()
+const route = useRoute()
 const showPassword = ref(false)
 
 // Form state & rules
 const state = ref({
-  lastName: "",
-  firstName: "",
-  email: useRoute().query.email || "",
+  lastName: route.query.firstName || "",
+  firstName: route.query.lastName || "",
+  email: route.query.email || "",
   username: "",
   password: "",
 })

--- a/web/auth-urls.py
+++ b/web/auth-urls.py
@@ -1,8 +1,6 @@
 from django.contrib.auth import views as auth_views
 from django.urls import path
 
-from web.views import RegisterUserView
-
 urlpatterns = [
     path(
         "s-identifier",
@@ -68,5 +66,4 @@ urlpatterns = [
         ),
         name="password_reset_complete",
     ),
-    path("creer-mon-compte", RegisterUserView.as_view(), name="register"),
 ]


### PR DESCRIPTION
Closes #803 

### 1. Possibilité de pré-remplir le prénom, nom et adresse email dans la page de création de compte

Ceci nous permettra de créer des URLs de création de compte personnalisés lors de la campagne mailing pour les utilisateur·ices de téléiCare - surtout pour s'assurer qu'iels ne créent pas de compte avec d'autres adresses email

![image](https://github.com/user-attachments/assets/98f792d7-e89c-4b1d-98bb-54fa6e5b0b7d)

### 2. Support du paramètre _next_

Pour d'autres campagnes mail on peut utiliser des URLs où - si l'utilisateur·ice est connecté·e la page ciblé s'affiche, sinon la page _s'identifier_ s'affiche, et une fois la personne identifiée on montre directement la page souhaitée (et non nécessairement le dashboard).

Par exemple, si on envoie une campagne mailing pour la création d'entreprise aux personnes ayant un compte mais n'ayant pas encore renseigné une compagnie, on peut inclure l'URL : _https://compl-alim.../connexion/?next=/nouvelle-entreprise_. Si la personne est déjà identifiée elle ira directement à _/nouvelle-entreprise_, sinon, elle le fera après la connexion automatiquement.

[Screencast from 06-08-24 16:21:03.webm](https://github.com/user-attachments/assets/abde397a-2123-417e-9c69-ecb6d401ca42)

### Autres
Au passage, j'ai fait en sorte que sur la page de connexion, si on tape la touche "Enter", on lance la requête de connexion.
