### PR TITLE
Assigner au dossier l'instructeur ayant effectué le dernier changement de statut

### DIFF
--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -336,6 +336,10 @@ class DeclarationObserveView(DeclarationFlowView):
     snapshot_action = Snapshot.SnapshotActions.OBSERVE_NO_VISA
     brevo_template_id = 4
 
+    def on_transition_success(self, request, declaration):
+        declaration.instructor = InstructionRole.objects.get(user=request.user)
+        return super().on_transition_success(request, declaration)
+
 
 class DeclarationAuthorizeView(DeclarationFlowView):
     """
@@ -347,6 +351,10 @@ class DeclarationAuthorizeView(DeclarationFlowView):
     create_snapshot = True
     snapshot_action = Snapshot.SnapshotActions.AUTHORIZE_NO_VISA
     brevo_template_id = 6
+
+    def on_transition_success(self, request, declaration):
+        declaration.instructor = InstructionRole.objects.get(user=request.user)
+        return super().on_transition_success(request, declaration)
 
 
 class DeclarationResubmitView(DeclarationFlowView):
@@ -488,6 +496,7 @@ class VisaRequestFlowView(DeclarationFlowView):
         declaration.post_validation_producer_message = request.data.get("comment", "")
         declaration.post_validation_expiration_days = request.data.get("expiration")
         declaration.private_notes = request.data.get("private_notes", "")
+        declaration.instructor = InstructionRole.objects.get(user=request.user)
 
         if not self.post_validation_status:
             raise Exception("VisaRequestFlowView doit être sous-classée et doit spécifier le post_validation_status")


### PR DESCRIPTION
Complément de #794

### Lors que la déclaration est « en cours d'instruction »

Une autre instructrice peut quand même la reprendre et l’instruire, même si cette personne n'est pas assignée à la déclaration. Démo ci-dessous :

https://github.com/user-attachments/assets/4ff9df6d-864e-45b4-bc64-fbb306d93550

Après cette action, la déclaration sera assignée à la personne ayant effectué le dernier changement de statut