### PR TITLE
Identification des nouveaux ingrédients dans le _DeclarationSummary_

### DIFF
--- a/frontend/src/components/DeclarationSummary/SummaryElementItem.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementItem.vue
@@ -1,6 +1,11 @@
 <template>
-  <li>
-    <div class="capitalize">{{ getElementName(model).toLowerCase() }}</div>
+  <li class="border-l-2 border-b pl-4 py-2">
+    <p class="capitalize font-bold mb-0">
+      {{ getElementName(model).toLowerCase() }}
+      <span v-if="model.new" class="self-center ml-2">
+        <DsfrBadge label="Nouvel ingrédient" type="info" small />
+      </span>
+    </p>
     <div class="mt-1">
       {{ elementInfo }}
     </div>

--- a/frontend/src/components/DeclarationSummary/SummaryElementList.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementList.vue
@@ -7,7 +7,7 @@
       <p class="m-0 font-bold capitalize self-center">{{ getTypeInFrench(objectType) }}s</p>
     </div>
 
-    <ul>
+    <ul class="list-none">
       <SummaryElementItem
         class="mb-2 last:mb-0"
         v-for="(element, index) in elements"

--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -30,26 +30,24 @@
     <SummaryElementList objectType="microorganism" :elements="payload.declaredMicroorganisms" />
     <SummaryElementList
       objectType="form_of_supply"
-      :elements="payload.declaredIngredients.filter((obj) => obj.element.objectType == 'form_of_supply')"
+      :elements="getObjectSubTypeList(payload.declaredIngredients, 'form_of_supply')"
     />
-    <SummaryElementList
-      objectType="aroma"
-      :elements="payload.declaredIngredients.filter((obj) => obj.element.objectType == 'aroma')"
-    />
+    <SummaryElementList objectType="aroma" :elements="getObjectSubTypeList(payload.declaredIngredients, 'aroma')" />
     <SummaryElementList
       objectType="additive"
-      :elements="payload.declaredIngredients.filter((obj) => obj.element.objectType == 'additive')"
+      :elements="getObjectSubTypeList(payload.declaredIngredients, 'additive')"
     />
     <SummaryElementList
       objectType="active_ingredient"
-      :elements="payload.declaredIngredients.filter((obj) => obj.element.objectType == 'active_ingredient')"
+      :elements="getObjectSubTypeList(payload.declaredIngredients, 'active_ingredient')"
     />
     <SummaryElementList
       objectType="non_active_ingredient"
-      :elements="payload.declaredIngredients.filter((obj) => obj.element.objectType == 'non_active_ingredient')"
+      :elements="getObjectSubTypeList(payload.declaredIngredients, 'non_active_ingredient')"
     />
     <SummaryElementList objectType="substance" :elements="payload.declaredSubstances" />
 
+    <p class="font-bold mt-8">Substances contenues dans la composition :</p>
     <SubstancesTable v-model="payload" readonly />
 
     <h3 class="fr-h6 !mt-8">
@@ -79,6 +77,7 @@ export default { name: "DeclarationSummary" }
 </script>
 
 <script setup>
+import { getObjectSubTypeList } from "@/utils/elements"
 import { computed } from "vue"
 import AddressLine from "@/components/AddressLine"
 import SummaryInfoSegment from "./SummaryInfoSegment"

--- a/frontend/src/utils/elements.js
+++ b/frontend/src/utils/elements.js
@@ -1,1 +1,7 @@
 export const getElementName = (e) => e.element?.name || e.newName || `${e.newGenre} ${e.newSpecies}`
+
+export const getObjectSubTypeList = (objectList, subType = null) => {
+  return subType
+    ? objectList.filter((obj) => obj.element?.objectType == subType || obj.newType == subType)
+    : objectList.filter((obj) => !obj.element?.objectType && !obj.newType)
+}

--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -73,6 +73,7 @@
 import { computed } from "vue"
 import { useFetch } from "@vueuse/core"
 import { getApiType, getActivityByType } from "@/utils/mappings"
+import { getObjectSubTypeList } from "@/utils/elements"
 import ElementAutocomplete from "@/components/ElementAutocomplete.vue"
 import ElementList from "./ElementList.vue"
 import SubstancesTable from "@/components/SubstancesTable.vue"
@@ -110,12 +111,6 @@ const hasActiveSubstances = computed(() =>
     (x) => x.active && !x.new && (x.element?.substances?.length || containers.value.substance.indexOf(x) > -1)
   )
 )
-
-const getObjectSubTypeList = (objectList, subType = null) => {
-  return subType
-    ? objectList.filter((obj) => obj.element?.objectType == subType || obj.newType == subType)
-    : objectList.filter((obj) => !obj.element?.objectType && !obj.newType)
-}
 
 const selectOption = async (result) => {
   const item = await fetchElement(getApiType(result.objectType), result.objectType, result.id)


### PR DESCRIPTION
Closes #806 

Cette PR vise à signaler dans le composant `DeclarationSummary` les ingrédients ajoutés manuellement par l'utilisateur. Ce composant est utilisé par les producteurs (avant de soumettre afin de vérifier les infos), mais aussi par les instructrices et viseuses.

Au passage, j'ai corrigé un bug qui arrivait suite au fait qu'on n'utilisait pas la nouvelle fonction `getObjectSubTypeList` dans le DeclarationSummary.

## Capture d'écran
![image](https://github.com/user-attachments/assets/f93783b1-d247-4ca9-932b-bf611cc60928)
