### PR TITLE
Correction du problème lors que la validation ne retourne que des erreurs sans champ

### DIFF
--- a/frontend/src/views/ProducerFormPage/StatusChangeErrorDisplay.vue
+++ b/frontend/src/views/ProducerFormPage/StatusChangeErrorDisplay.vue
@@ -41,9 +41,9 @@ const shownErrors = computed(() => {
   const errorObject = Object.keys(tabSections).map((key) => {
     return {
       tab: key,
-      errors: fieldErrors
-        .filter((x) => tabSections[key]?.indexOf(Object.keys(x)[0]) > -1)
-        .map((x) => Object.values(x)?.[0]),
+      errors: fieldErrors.filter
+        ? fieldErrors.filter((x) => tabSections[key]?.indexOf(Object.keys(x)[0]) > -1).map((x) => Object.values(x)?.[0])
+        : [],
     }
   })
 
@@ -62,9 +62,10 @@ const shownErrors = computed(() => {
       errorObject.find((x) => x.tab === "Composition")?.errors?.push(compositionErrors[i])
 
   // Les autres erreurs non-liées à des champs vont dans l'apparté « Autres »
-  errorObject
-    .find((x) => x.tab === "Autres")
-    ?.errors?.push(...nonFieldErrors.filter((x) => compositionErrors.indexOf(x) === -1))
+  if (nonFieldErrors && nonFieldErrors.length)
+    errorObject
+      .find((x) => x.tab === "Autres")
+      ?.errors?.push(...nonFieldErrors.filter((x) => compositionErrors.indexOf(x) === -1))
 
   // On montre seulement les appartés qui ont au moins une erreur
   return errorObject.filter((x) => x.errors.length > 0)


### PR DESCRIPTION
Petite correction d'un bug qui arrive lors que le backend retourne simplement des `nonFieldError`s. 

Dans ce cas, le `fieldErrors` est un objet, non pas un tableau, et donc n'a pas la fonction `filter`. Ceci provoque un crash UI.

Avant d'utiliser les fonctions d'`Array`, on vérifie que l'objet en soit bien un.