### PR TITLE
Ajout des paramètres pour les emails observation et objection

### DIFF
--- a/api/tests/test_flow_emails.py
+++ b/api/tests/test_flow_emails.py
@@ -30,13 +30,6 @@ from .utils import authenticate
 @override_settings(CONTACT_EMAIL="contact@example.com")
 @mock.patch("config.email.send_sib_template")
 class TestDeclarationFlow(APITestCase):
-    def get_test_brevo_params(self, declaration):
-        return {
-            "PRODUCT_NAME": declaration.name,
-            "COMPANY_NAME": declaration.company.social_name if declaration.company else "",
-            "DECLARATION_LINK": declaration.producer_url,
-        }
-
     @authenticate
     def test_submit_declaration(self, mocked_brevo):
         """
@@ -51,7 +44,7 @@ class TestDeclarationFlow(APITestCase):
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            self.get_test_brevo_params(declaration),
+            declaration.brevo_parameters,
             authenticate.user.email,
             authenticate.user.get_full_name(),
         )
@@ -69,7 +62,7 @@ class TestDeclarationFlow(APITestCase):
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            self.get_test_brevo_params(declaration),
+            declaration.brevo_parameters,
             authenticate.user.email,
             authenticate.user.get_full_name(),
         )
@@ -87,7 +80,7 @@ class TestDeclarationFlow(APITestCase):
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            self.get_test_brevo_params(declaration),
+            declaration.brevo_parameters,
             authenticate.user.email,
             authenticate.user.get_full_name(),
         )
@@ -123,7 +116,7 @@ class TestDeclarationFlow(APITestCase):
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            self.get_test_brevo_params(declaration),
+            declaration.brevo_parameters,
             authenticate.user.email,
             authenticate.user.get_full_name(),
         )
@@ -146,7 +139,7 @@ class TestDeclarationFlow(APITestCase):
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            self.get_test_brevo_params(declaration),
+            declaration.brevo_parameters,
             authenticate.user.email,
             authenticate.user.get_full_name(),
         )
@@ -169,7 +162,7 @@ class TestDeclarationFlow(APITestCase):
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            self.get_test_brevo_params(declaration),
+            declaration.brevo_parameters,
             authenticate.user.email,
             authenticate.user.get_full_name(),
         )
@@ -192,7 +185,7 @@ class TestDeclarationFlow(APITestCase):
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            self.get_test_brevo_params(declaration),
+            declaration.brevo_parameters,
             authenticate.user.email,
             authenticate.user.get_full_name(),
         )
@@ -209,7 +202,7 @@ class TestDeclarationFlow(APITestCase):
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            self.get_test_brevo_params(declaration),
+            declaration.brevo_parameters,
             authenticate.user.email,
             authenticate.user.get_full_name(),
         )
@@ -233,7 +226,7 @@ class TestDeclarationFlow(APITestCase):
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            self.get_test_brevo_params(observed_declaration),
+            observed_declaration.brevo_parameters,
             observed_declaration.author.email,
             observed_declaration.author.get_full_name(),
         )
@@ -257,7 +250,7 @@ class TestDeclarationFlow(APITestCase):
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            self.get_test_brevo_params(objected_declaration),
+            objected_declaration.brevo_parameters,
             objected_declaration.author.email,
             objected_declaration.author.get_full_name(),
         )

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -215,11 +215,7 @@ class DeclarationFlowView(GenericAPIView):
         """
         À surcharger en cas des paramètres spéciaux à envoyer à Brevo
         """
-        return {
-            "PRODUCT_NAME": declaration.name,
-            "COMPANY_NAME": declaration.company.social_name if declaration.company else "",
-            "DECLARATION_LINK": declaration.producer_url,
-        }
+        return declaration.brevo_parameters
 
     def get_transition(self, request, declaration):
         """

--- a/config/tasks.py
+++ b/config/tasks.py
@@ -67,14 +67,6 @@ class ExpirationDeclarationFlow:
             raise EarlyExpirationError()
 
 
-def get_brevo_parameters(declaration):
-    return {
-        "PRODUCT_NAME": declaration.name,
-        "COMPANY_NAME": declaration.company.social_name if declaration.company else "",
-        "DECLARATION_LINK": declaration.producer_url,
-    }
-
-
 @app.task
 def expire_declarations():
     declarations = Declaration.objects.filter(status__in=allowed_statuses)
@@ -86,7 +78,7 @@ def expire_declarations():
             if declaration.author:
                 email.send_sib_template(
                     brevo_template_id,
-                    get_brevo_parameters(declaration),
+                    declaration.brevo_parameters,
                     declaration.author.email,
                     declaration.author.get_full_name(),
                 )

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -206,6 +206,7 @@ class Declaration(Historisable, TimeStampable):
             "PRODUCT_NAME": self.name,
             "COMPANY_NAME": self.company.social_name if self.company else "",
             "DECLARATION_LINK": self.producer_url,
+            "DECLARATION_ID": self.id,
             "EXPIRATION_DAYS": expiration_days,
         }
 

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -14,10 +14,10 @@
     <div v-else>
       <DsfrAlert
         class="mb-4"
-        v-if="isAwaitingInstruction && declaration.instructor.id !== loggedUser.id"
+        v-if="isAwaitingInstruction && declaration.instructor?.id !== loggedUser.id"
         type="info"
         :title="
-          declaration.instructor && declaration.instructor.firstName
+          declaration.instructor?.firstName
             ? `Cette déclaration est assignée à ${declaration.instructor.firstName} ${declaration.instructor.lastName}`
             : 'Cette déclaration n\'est pas encore assignée'
         "


### PR DESCRIPTION
Linked to https://github.com/betagouv/complements-alimentaires/issues/828

Cette PR fait l'ajout des jours d'expiration et de l'ID de la déclaration. 

Je me suis permis d'ajouter un petit fix dans le front-end (frontend/src/views/InstructionPage/index.vue) qui empêchait de prendre un dossier en instruction.

![image](https://github.com/user-attachments/assets/f6191e4b-211b-4a30-81c6-3882be3d59c4)
