### PR TITLE
Envoi automatique d'emails de rappel cinque jours avant l'expiration

### DIFF
--- a/api/views/declaration/declaration_flow.py
+++ b/api/views/declaration/declaration_flow.py
@@ -79,6 +79,8 @@ class DeclarationFlow:
 
     @status.transition(source=Status.OBSERVATION, target=Status.ABANDONED)
     def abandon(self):
+        # Il n'est pas possible d'effectuer un abandon depuis l'API. Pour le FSM qui le prend
+        # en charge, regarder tasks.py.
         self.error()
 
     def ensure_validators(self, validators):

--- a/config/tests/test_expiration_reminder.py
+++ b/config/tests/test_expiration_reminder.py
@@ -1,9 +1,122 @@
+from datetime import timedelta
+from unittest import mock
+
 from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import timezone
+
+from config.tasks import send_expiration_reminder
+from data.factories import ObservationDeclarationFactory, SnapshotFactory
+from data.models import Declaration
 
 
 class TestExpirationReminder(TestCase):
-    def test_send_reminders_before_expiration(self):
+    @override_settings(ANYMAIL={"SENDINBLUE_API_KEY": "fake-api-key"})
+    @override_settings(CONTACT_EMAIL="contact@example.com")
+    @mock.patch("config.email.send_sib_template")
+    def test_send_reminders_before_expiration(self, mocked_brevo):
         """
         Un rappel doit être envoyé à l'auteur·ice d'une déclaration avant son expiration
         """
-        pass
+        template_number = 10
+        today = timezone.now()
+        declaration = ObservationDeclarationFactory()
+        snapshot = SnapshotFactory(
+            declaration=declaration,
+            status=Declaration.DeclarationStatus.OBSERVATION,
+            expiration_days=10,
+        )
+        # Le snapshot a été créé il y a 5 jours. Vu que la date d'expiration
+        # est de 10 jours, on devrait envoyer l'email
+        snapshot.creation_date = today - timedelta(days=5, minutes=1)
+        snapshot.save()
+
+        send_expiration_reminder()
+
+        mocked_brevo.assert_called_once_with(
+            template_number,
+            {**declaration.brevo_parameters, **{"REMAINING_DAYS": 5}},
+            declaration.author.email,
+            declaration.author.get_full_name(),
+        )
+
+    @override_settings(ANYMAIL={"SENDINBLUE_API_KEY": "fake-api-key"})
+    @override_settings(CONTACT_EMAIL="contact@example.com")
+    @mock.patch("config.email.send_sib_template")
+    def test_multiple_snapshots(self, mocked_brevo):
+        """
+        Seulement le dernier snapshot « observation » ou « objection » sera pris en compte
+        """
+        template_number = 10
+        today = timezone.now()
+        declaration = ObservationDeclarationFactory()
+        snapshot = SnapshotFactory(
+            declaration=declaration,
+            status=Declaration.DeclarationStatus.OBSERVATION,
+            expiration_days=10,
+        )
+
+        snapshot_old = SnapshotFactory(
+            declaration=declaration,
+            status=Declaration.DeclarationStatus.OBSERVATION,
+            expiration_days=15,
+        )
+        # Le dernier snapshot a été créé il y a 5 jours. Vu que la date d'expiration
+        # est de 10 jours, on devrait envoyer l'email
+        snapshot.creation_date = today - timedelta(days=5, minutes=1)
+        snapshot_old.creation_date = today - timedelta(days=25, minutes=1)
+        snapshot.save()
+        snapshot_old.save()
+
+        send_expiration_reminder()
+
+        mocked_brevo.assert_called_once_with(
+            template_number,
+            {**declaration.brevo_parameters, **{"REMAINING_DAYS": 5}},
+            declaration.author.email,
+            declaration.author.get_full_name(),
+        )
+
+    @override_settings(ANYMAIL={"SENDINBLUE_API_KEY": "fake-api-key"})
+    @override_settings(CONTACT_EMAIL="contact@example.com")
+    @mock.patch("config.email.send_sib_template")
+    def test_do_not_send_early_reminders(self, mocked_brevo):
+        """
+        Un rappel ne doit pas être envoyé trop tôt
+        """
+        today = timezone.now()
+        declaration = ObservationDeclarationFactory()
+        snapshot = SnapshotFactory(
+            declaration=declaration,
+            status=Declaration.DeclarationStatus.OBSERVATION,
+            expiration_days=10,
+        )
+        # Le snapshot a été créé il y a 4 jours. Vu que la date d'expiration
+        # est de 10 jours, on a encore 6 jours devant nous. Donc pas d'envoi
+        snapshot.creation_date = today - timedelta(days=4, minutes=1)
+        snapshot.save()
+
+        send_expiration_reminder()
+        mocked_brevo.assert_not_called()
+
+    @override_settings(ANYMAIL={"SENDINBLUE_API_KEY": "fake-api-key"})
+    @override_settings(CONTACT_EMAIL="contact@example.com")
+    @mock.patch("config.email.send_sib_template")
+    def test_do_not_send_late_reminders(self, mocked_brevo):
+        """
+        Un rappel ne doit pas être envoyé trop tard
+        """
+        today = timezone.now()
+        declaration = ObservationDeclarationFactory()
+        snapshot = SnapshotFactory(
+            declaration=declaration,
+            status=Declaration.DeclarationStatus.OBSERVATION,
+            expiration_days=10,
+        )
+        # Le snapshot a été créé il y a 6 jours. Vu que la date d'expiration
+        # est de 10 jours, on n'a que 4 jours devant nous. Donc pas d'envoi
+        snapshot.creation_date = today - timedelta(days=6, minutes=1)
+        snapshot.save()
+
+        send_expiration_reminder()
+        mocked_brevo.assert_not_called()

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 
 from django.conf import settings
 from django.db import models
@@ -209,6 +210,18 @@ class Declaration(Historisable, TimeStampable):
             "DECLARATION_ID": self.id,
             "EXPIRATION_DAYS": expiration_days,
         }
+
+    @property
+    def expiration_date(self):
+        expirable_statuses = [Declaration.DeclarationStatus.OBJECTION, Declaration.DeclarationStatus.OBSERVATION]
+        if self.status not in expirable_statuses:
+            return None
+        try:
+            latest_snapshot = self.snapshots.latest("creation_date")
+            expiration_date = latest_snapshot.creation_date + timedelta(days=latest_snapshot.expiration_days)
+            return expiration_date
+        except Exception as _:
+            return None
 
     def __str__(self):
         return f"Déclaration « {self.name} »"

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -213,11 +213,20 @@ class Declaration(Historisable, TimeStampable):
 
     @property
     def expiration_date(self):
-        expirable_statuses = [Declaration.DeclarationStatus.OBJECTION, Declaration.DeclarationStatus.OBSERVATION]
+        expirable_statuses = [
+            Declaration.DeclarationStatus.OBJECTION,
+            Declaration.DeclarationStatus.OBSERVATION,
+            Declaration.DeclarationStatus.ABANDONED,
+        ]
         if self.status not in expirable_statuses:
             return None
         try:
-            latest_snapshot = self.snapshots.latest("creation_date")
+            latest_snapshot = self.snapshots.filter(
+                status__in=[
+                    Declaration.DeclarationStatus.OBJECTION,
+                    Declaration.DeclarationStatus.OBSERVATION,
+                ]
+            ).latest("creation_date")
             expiration_date = latest_snapshot.creation_date + timedelta(days=latest_snapshot.expiration_days)
             return expiration_date
         except Exception as _:


### PR DESCRIPTION
Closes #828 

## Contexte

Cinq jours avant la date d'expiration d'une déclaration en observation ou objection, un email de rappel doit être envoyé. 

## Algorithme

La tâche sera exécutée à une 10h (pour éviter d'allumer les notifs email des personnes à minuit). Il faut qu'au moment de l'envoie, la date d'expiration soit au minimum à 5 jours de distance. 

La tâche qu'effectue l'expiration des déclarations se lance à minuit tous les jours. Il faut donc prendre ce moment pour faire la calcul. D'où la ligne

```python
end_of_expiration_day = timezone.make_aware(datetime.combine(declaration.expiration_date, time.max))
```
À partir de ce moment là, si nous nous trouvons entre _5_ et _6_ jours de la fin de la journée d'expiration, on envoie l'email.

Vu que cette tâche ne s'effectue qu'une fois par jour, le lendemain on n'aura plus le message car le jour ne sera pas entre 5 et 6 jours de distance, mais 4.
