### PR TITLE
Ajout la possibilité de filtrer sur les décla "non assignée"

### DIFF
--- a/frontend/src/views/InstructionDeclarationsPage/index.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/index.vue
@@ -83,7 +83,8 @@ const limit = 10
 const pages = computed(() => getPagesForPagination(data.value?.count, limit, route.path))
 const allInstructors = computed(() => data.value?.instructors)
 const instructorSelectOptions = computed(() => {
-  const availableInstructors = allInstructors.value?.map((x) => ({ value: x.id, text: x.name })) || []
+  const availableInstructors = allInstructors.value?.map((x) => ({ value: "" + x.id, text: x.name })) || []
+  availableInstructors.unshift({ value: "None", text: "Déclarations non assignées" })
   availableInstructors.unshift({ value: "", text: "Toutes les déclarations" })
   return availableInstructors
 })
@@ -93,9 +94,7 @@ const page = computed(() => parseInt(route.query.page))
 const filteredStatus = computed(() => route.query.status)
 const companyNameStart = computed(() => route.query.entrepriseDe)
 const companyNameEnd = computed(() => route.query.entrepriseA)
-const assignedInstructor = computed(() =>
-  route.query.personneAssignée === "" ? "" : parseInt(route.query.personneAssignée)
-)
+const assignedInstructor = computed(() => route.query.personneAssignée)
 
 const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...newQuery } })
 


### PR DESCRIPTION
Closes #826 

## Contexte

Aujourd'hui les instructrices peuvent filtrer la liste de déclarations par personne assignée. Il faut aussi qu'elles puissent le faire par déclaration non-assignée.

## Détails techniques

Aujourd'hui django-filter ne prévoit pas l'option d'ajouter un filtrage par absence de model Foreign Key ([documentation qui l'explique](https://django-filter.readthedocs.io/en/stable/guide/tips.html#filter-and-lookup-expression-mismatch-in-range-isnull)) et je ne voulais pas devoir créer un filtre additionnel. J'ai donc utilisé un `CharFilter` custom où je traite manuellement les cas `None` et les autres.

À noter que le frontend utilise seulement une valeur à la fois, mais techniquement on pourrait filtrer par plus d'une instructrice.

## Démo
[Screencast from 13-08-24 09:49:31.webm](https://github.com/user-attachments/assets/deabc9bd-c5c8-432f-83af-66a193e36eb1)

