### PR TITLE
Redirects to correct URL after login

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -347,7 +347,7 @@ const chooseAuthorisedRoute = async (to, from, next, store) => {
       store.companies?.some((c) => c.roles?.some((x) => x.name === to.meta.requiredRole)) ||
       store.loggedUser?.globalRoles?.some((x) => x.name === to.meta.requiredRole)
 
-    authenticationCheck && roleCheck ? next() : next({ name: "LoginPage" })
+    authenticationCheck && roleCheck ? next() : next({ name: "LoginPage", query: { next: to.path } })
   }
 }
 

--- a/frontend/src/stores/root.js
+++ b/frontend/src/stores/root.js
@@ -28,7 +28,7 @@ export const useRootStore = defineStore("root", () => {
     // TODO: add error handling here, but weird bug with await and response
   }
 
-  const companies = computed(() => loggedUser.value.companies)
+  const companies = computed(() => loggedUser.value?.companies)
 
   const resetInitialData = () => {
     loggedUser.value = null


### PR DESCRIPTION
Closes #846 

Cette petite PR permet aux utilisateurs d'être redirectionnés vers la page adéquate après login.

Par exemple, si dans un e-mail transactionnel Brevo j'ai un lien vers la gestion de mon entreprise, mais que je ne suis pas identifié, je tomberai sur la page login et après m'être identifié la page gestion sera affiché - non pas la page d'accueil.

Exemple : 

[Screencast from 15-08-24 10:23:13.webm](https://github.com/user-attachments/assets/619dd889-3455-4167-bd60-e12599acaf3a)
