### PR TITLE
Displays expiration date in declaration page

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -351,6 +351,7 @@ class DeclarationSerializer(serializers.ModelSerializer):
             "post_validation_expiration_days",
             "private_notes",
             "blocking_reasons",
+            "expiration_date",
         )
         read_only_fields = (
             "id",

--- a/frontend/src/components/DeclarationAlert.vue
+++ b/frontend/src/components/DeclarationAlert.vue
@@ -1,6 +1,10 @@
 <template>
   <DsfrAlert v-if="displayData" :type="displayData.type" :title="displayData.title">
     <p v-if="displayData.body">{{ displayData.body }}</p>
+    <p v-if="displayData.expirationDate">
+      <v-icon name="ri-error-warning-line"></v-icon>
+      Sans retour de votre part, ce dossier expirera le {{ isoToPrettyDate(displayData.expirationDate) }}.
+    </p>
     <DsfrButton v-if="displayData.canDownloadCertificate" icon="ri-file-text-line" class="mt-2" secondary>
       <a :href="`/declarations/${declaration.id}/certificate`" target="_blank" rel="noopener noreferrer">
         {{ displayData.downloadButtonText || "Télécharger l'attestation" }}
@@ -11,6 +15,7 @@
 
 <script setup>
 import { computed } from "vue"
+import { isoToPrettyDate } from "@/utils/date"
 const props = defineProps({ declaration: Object, role: { type: String, default: "declarant" } })
 
 const displayData = computed(() => {
@@ -63,6 +68,7 @@ const declarantDisplayData = computed(() => {
       return {
         type: "warning",
         title: "Une objection a été emise sur cette déclaration",
+        expirationDate: props.declaration?.expirationDate,
         body: blockingReasons.value,
         canDownloadCertificate: false,
       }
@@ -70,6 +76,7 @@ const declarantDisplayData = computed(() => {
       return {
         type: "warning",
         title: "Une observation a été emise sur cette déclaration",
+        expirationDate: props.declaration?.expirationDate,
         body: blockingReasons.value,
         canDownloadCertificate: false,
       }


### PR DESCRIPTION
Closes #842 

## Contexte

Depuis #720 les dossiers en inactivité partent automatiquement en abandon. Par contre, l'information sur la date à laquelle ce passage est fait n'est affiché nulle part dans la UI des producteurs.

Cette PR affiche la date d'expiration dans l'Alert qui montre aussi le statut de la déclaration

## Capture d'écran
![image](https://github.com/user-attachments/assets/eae4f511-a2f5-4c2c-8585-82a86905f656)
