### PR TITLE
Affichage de la date limite d'instruction dans les tables Visa et Instruction

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -277,6 +277,7 @@ class SimpleDeclarationSerializer(serializers.ModelSerializer):
             "creation_date",
             "instructor",
             "visor",
+            "response_limit_date",
         )
         read_only_fields = fields
 

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -239,6 +239,14 @@ class Declaration(Historisable, TimeStampable):
         La date limite d'instruction est fixée à deux mois à partir du dernier statut
         "en attente d'instruction"
         """
+        concerned_statuses = [
+            Declaration.DeclarationStatus.AWAITING_INSTRUCTION,
+            Declaration.DeclarationStatus.ONGOING_INSTRUCTION,
+            Declaration.DeclarationStatus.AWAITING_VISA,
+            Declaration.DeclarationStatus.ONGOING_VISA,
+        ]
+        if self.status not in concerned_statuses:
+            return None
         status = Declaration.DeclarationStatus.AWAITING_INSTRUCTION
         try:
             latest_snapshot = self.snapshots.filter(status=status).latest("creation_date")

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.db import models
 
+from dateutil.relativedelta import relativedelta
 from djangorestframework_camel_case.render import CamelCaseJSONRenderer
 
 from data.behaviours import Historisable, TimeStampable
@@ -229,6 +230,20 @@ class Declaration(Historisable, TimeStampable):
             ).latest("creation_date")
             expiration_date = latest_snapshot.creation_date + timedelta(days=latest_snapshot.expiration_days)
             return expiration_date
+        except Exception as _:
+            return None
+
+    @property
+    def response_limit_date(self):
+        """
+        La date limite d'instruction est fixée à deux mois à partir du dernier statut
+        "en attente d'instruction"
+        """
+        status = Declaration.DeclarationStatus.AWAITING_INSTRUCTION
+        try:
+            latest_snapshot = self.snapshots.filter(status=status).latest("creation_date")
+            response_limit = latest_snapshot.creation_date + relativedelta(months=2)
+            return response_limit
         except Exception as _:
             return None
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -291,6 +291,7 @@ const routes = [
         status: "AWAITING_VISA,ONGOING_VISA",
         entrepriseDe: "",
         entrepriseA: "",
+        triage: "-modificationDate",
       },
     },
   },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -263,6 +263,7 @@ const routes = [
         entrepriseDe: "",
         entrepriseA: "",
         personneAssignée: "",
+        triage: "-modificationDate",
       },
     },
   },

--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -212,3 +212,12 @@ export const tabTitles = (components, useSubmission = false) => {
   }
   return components.map((x) => titleMap[x.__name || x.name])
 }
+
+export const orderingOptions = [
+  { value: "modificationDate", text: "Date de modification" },
+  { value: "-modificationDate", text: "Date de modification (descendant)" },
+  { value: "name", text: "Nom du produit" },
+  { value: "-name", text: "Nom du produit (descendant)" },
+  { value: "responseLimitDate", text: "Date limite de réponse" },
+  { value: "-responseLimitDate", text: "Date limite de réponse (descendant)" },
+]

--- a/frontend/src/views/InstructionDeclarationsPage/InstructionDeclarationsTable.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/InstructionDeclarationsTable.vue
@@ -12,7 +12,7 @@
 
 <script setup>
 import { computed } from "vue"
-import { timeAgo } from "@/utils/date"
+import { isoToPrettyDate } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
@@ -21,7 +21,7 @@ const { loggedUser } = storeToRefs(useRootStore())
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 
-const headers = ["", "Nom du produit", "Entreprise", "État", "Date de modification", "Instruit par"]
+const headers = ["", "Nom du produit", "Entreprise", "État", "Date limite de réponse", "Instruit par"]
 const rows = computed(() =>
   props.data?.results?.map((x) => ({
     rowAttrs: { class: needsAttention(x) ? "font-bold" : "" },
@@ -34,7 +34,7 @@ const rows = computed(() =>
       },
       x.company.socialName,
       getStatusTagForCell(x.status),
-      timeAgo(x.modificationDate),
+      x.responseLimitDate && isoToPrettyDate(x.responseLimitDate),
       x.instructor
         ? `${x.instructor.firstName} ${x.instructor.lastName}`
         : { component: "span", text: "Non-assigné", class: "italic" },

--- a/frontend/src/views/InstructionDeclarationsPage/index.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/index.vue
@@ -82,6 +82,7 @@ import { useRoute, useRouter } from "vue-router"
 import { getPagesForPagination } from "@/utils/components"
 import { DsfrInput } from "@gouvminint/vue-dsfr"
 import StatusFilter from "@/components/StatusFilter.vue"
+import { orderingOptions } from "@/utils/mappings"
 
 const router = useRouter()
 const route = useRoute()
@@ -99,15 +100,6 @@ const instructorSelectOptions = computed(() => {
   availableInstructors.unshift({ value: "", text: "Toutes les déclarations" })
   return availableInstructors
 })
-
-const orderingOptions = [
-  { value: "modificationDate", text: "Date de modification" },
-  { value: "-modificationDate", text: "Date de modification (descendant)" },
-  { value: "name", text: "Nom du produit" },
-  { value: "-name", text: "Nom du produit (descendant)" },
-  { value: "responseLimitDate", text: "Date limite de réponse" },
-  { value: "-responseLimitDate", text: "Date limite de réponse (descendant)" },
-]
 
 // Valeurs obtenus du queryparams
 const page = computed(() => parseInt(route.query.page))

--- a/frontend/src/views/InstructionDeclarationsPage/index.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/index.vue
@@ -43,6 +43,17 @@
         </DsfrFieldset>
       </div>
       <StatusFilter :exclude="['DRAFT']" @update:modelValue="updateStatusFilter" v-model="filteredStatus" />
+      <div class="md:border-l md:px-8">
+        <DsfrInputGroup class="max-w-sm">
+          <DsfrSelect
+            label="Trier par :"
+            defaultUnselectedText=""
+            :modelValue="ordering"
+            @update:modelValue="updateOrdering"
+            :options="orderingOptions"
+          />
+        </DsfrInputGroup>
+      </div>
     </div>
     <div v-if="isFetching" class="flex justify-center my-10">
       <ProgressSpinner />
@@ -89,12 +100,22 @@ const instructorSelectOptions = computed(() => {
   return availableInstructors
 })
 
+const orderingOptions = [
+  { value: "modificationDate", text: "Date de modification" },
+  { value: "-modificationDate", text: "Date de modification (descendant)" },
+  { value: "name", text: "Nom du produit" },
+  { value: "-name", text: "Nom du produit (descendant)" },
+  { value: "responseLimitDate", text: "Date limite de réponse" },
+  { value: "-responseLimitDate", text: "Date limite de réponse (descendant)" },
+]
+
 // Valeurs obtenus du queryparams
 const page = computed(() => parseInt(route.query.page))
 const filteredStatus = computed(() => route.query.status)
 const companyNameStart = computed(() => route.query.entrepriseDe)
 const companyNameEnd = computed(() => route.query.entrepriseA)
 const assignedInstructor = computed(() => route.query.personneAssignée)
+const ordering = computed(() => route.query.triage)
 
 const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...newQuery } })
 
@@ -103,11 +124,12 @@ const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
 const updateCompanyNameStartFilter = (newValue) => updateQuery({ entrepriseDe: newValue })
 const updateCompanyNameEndFilter = (newValue) => updateQuery({ entrepriseA: newValue })
 const updateInstructorFilter = (newValue) => updateQuery({ personneAssignée: newValue })
+const updateOrdering = (newValue) => updateQuery({ triage: newValue })
 
 // Obtention de la donnée via API
 const url = computed(
   () =>
-    `/api/v1/declarations/?limit=${limit}&offset=${offset.value}&status=${filteredStatus.value || ""}&company_name_start=${companyNameStart.value}&company_name_end=${companyNameEnd.value}&ordering=-modificationDate&instructor=${assignedInstructor.value}`
+    `/api/v1/declarations/?limit=${limit}&offset=${offset.value}&status=${filteredStatus.value || ""}&company_name_start=${companyNameStart.value}&company_name_end=${companyNameEnd.value}&ordering=${ordering.value}&instructor=${assignedInstructor.value}`
 )
 const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
@@ -115,7 +137,7 @@ const fetchSearchResults = async () => {
   await handleError(response)
 }
 
-watch([page, filteredStatus, companyNameStart, companyNameEnd, assignedInstructor], fetchSearchResults)
+watch([page, filteredStatus, companyNameStart, companyNameEnd, assignedInstructor, ordering], fetchSearchResults)
 </script>
 
 <style scoped>

--- a/frontend/src/views/VisaDeclarationsPage/VisaDeclarationsTable.vue
+++ b/frontend/src/views/VisaDeclarationsPage/VisaDeclarationsTable.vue
@@ -12,12 +12,12 @@
 
 <script setup>
 import { computed } from "vue"
-import { timeAgo } from "@/utils/date"
+import { isoToPrettyDate } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 
-const headers = ["Nom du produit", "Entreprise", "État", "Date de modification", "Instruit par", "Visé par"]
+const headers = ["Nom du produit", "Entreprise", "État", "Date limite de réponse", "Instruit par", "Visé par"]
 const rows = computed(() =>
   props.data?.results?.map((x) => ({
     rowData: [
@@ -28,7 +28,7 @@ const rows = computed(() =>
       },
       x.company.socialName,
       getStatusTagForCell(x.status),
-      timeAgo(x.modificationDate),
+      x.responseLimitDate && isoToPrettyDate(x.responseLimitDate),
       x.instructor
         ? `${x.instructor.firstName} ${x.instructor.lastName}`
         : { component: "span", text: "Non-assigné", class: "italic" },

--- a/frontend/src/views/VisaDeclarationsPage/index.vue
+++ b/frontend/src/views/VisaDeclarationsPage/index.vue
@@ -11,7 +11,20 @@
         @update:modelValue="updateStatusFilter"
         v-model="filteredStatus"
       />
+
+      <div class="md:border-l md:px-8">
+        <DsfrInputGroup class="max-w-sm">
+          <DsfrSelect
+            label="Trier par :"
+            defaultUnselectedText=""
+            :modelValue="ordering"
+            @update:modelValue="updateOrdering"
+            :options="orderingOptions"
+          />
+        </DsfrInputGroup>
+      </div>
     </div>
+
     <div v-if="isFetching" class="flex justify-center my-10">
       <ProgressSpinner />
     </div>
@@ -38,6 +51,7 @@ import VisaDeclarationsTable from "./VisaDeclarationsTable"
 import { useRoute, useRouter } from "vue-router"
 import { getPagesForPagination } from "@/utils/components"
 import StatusFilter from "@/components/StatusFilter.vue"
+import { orderingOptions } from "@/utils/mappings"
 
 const router = useRouter()
 const route = useRoute()
@@ -52,16 +66,18 @@ const pages = computed(() => getPagesForPagination(data.value.count, limit, rout
 // Valeurs obtenus du queryparams
 const page = computed(() => parseInt(route.query.page))
 const filteredStatus = computed(() => route.query.status)
+const ordering = computed(() => route.query.triage)
 
 const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...newQuery } })
 
 const updateStatusFilter = (status) => updateQuery({ status })
 const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
+const updateOrdering = (newValue) => updateQuery({ triage: newValue })
 
 // Obtention de la donnée via API
 const url = computed(
   () =>
-    `/api/v1/declarations/?limit=${limit}&offset=${offset.value}&status=${filteredStatus.value || ""}&ordering=-modificationDate`
+    `/api/v1/declarations/?limit=${limit}&offset=${offset.value}&status=${filteredStatus.value || ""}&ordering=${ordering.value}`
 )
 const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
@@ -69,7 +85,7 @@ const fetchSearchResults = async () => {
   await handleError(response)
 }
 
-watch([page, filteredStatus], fetchSearchResults)
+watch([page, filteredStatus, ordering], fetchSearchResults)
 </script>
 
 <style scoped>


### PR DESCRIPTION
Closes #795 

## Contexte

Sur téléicare, les instructrices et viseuses peuvent déjà voir la date limite de réponse des dossiers depuis la table. Cette fonctionnalité manquait sur Compl'Alim.

## Fonctionnement

La date limite d'instruction est définie comme deux mois après la dernière soumission de la part du pro (par exemple lors d'un retour d'observation ou objection). Pour l'obtenir on se base donc sur les snapshots pour trouver quand une déclaration a été pour la dernière fois mise en statut « _en attente d'instruction_ » et on ajoute deux mois.

## Captures d'écran

[Screencast from 16-08-24 16:11:30.webm](https://github.com/user-attachments/assets/81080029-46c3-4654-9fa9-b944dfe50dbf)

