### PR TITLE
Pré-sélection et groupement des filtres pour le rôle déclarant

### DIFF
--- a/frontend/src/components/StatusFilter.vue
+++ b/frontend/src/components/StatusFilter.vue
@@ -28,13 +28,14 @@
 <script setup>
 import { watch, ref, onMounted } from "vue"
 import { statusProps } from "@/utils/mappings"
+const emit = defineEmits(["updateFilter"])
 const statusString = defineModel()
 const props = defineProps({ exclude: { type: Array, default: Array }, groupInstruction: { type: Boolean } })
 const statuses = ref([])
 const opened = ref(false)
 
 onMounted(() => (statuses.value = statusString.value ? statusString.value.split(",") : []))
-watch(statuses, () => (statusString.value = statuses.value.join(",")))
+watch(statuses, () => emit("updateFilter", statuses.value.join(",")))
 
 const baseFilterOptions = [
   { value: "DRAFT", text: "Brouillon" },

--- a/frontend/src/components/StatusFilter.vue
+++ b/frontend/src/components/StatusFilter.vue
@@ -29,27 +29,37 @@
 import { watch, ref, onMounted } from "vue"
 import { statusProps } from "@/utils/mappings"
 const statusString = defineModel()
-const props = defineProps({ exclude: { type: Array, default: Array } })
+const props = defineProps({ exclude: { type: Array, default: Array }, groupInstruction: { type: Boolean } })
 const statuses = ref([])
 const opened = ref(false)
 
 onMounted(() => (statuses.value = statusString.value ? statusString.value.split(",") : []))
-watch(statuses, () => {
-  statusString.value = statuses.value.join(",")
-})
-const statusFilterOptions = [
+watch(statuses, () => (statusString.value = statuses.value.join(",")))
+
+const baseFilterOptions = [
   { value: "DRAFT", text: "Brouillon" },
-  { value: "AWAITING_INSTRUCTION", text: "En attente d'instruction" },
-  { value: "ONGOING_INSTRUCTION", text: "En cours d'instruction" },
-  { value: "AWAITING_VISA", text: "En attente de visa" },
-  { value: "ONGOING_VISA", text: "Visa en cours" },
   { value: "OBJECTION", text: "Objection" },
   { value: "OBSERVATION", text: "Observation" },
   { value: "ABANDONED", text: "Abandon" },
-  { value: "AUTHORIZED", text: "Autorisée" },
-  { value: "REJECTED", text: "Refusée" },
+  { value: "AUTHORIZED", text: "Déclaration finalisée" },
+  { value: "REJECTED", text: "Refus" },
   { value: "WITHDRAWN", text: "Retiré du marché" },
 ]
+const statusFilterOptions = props.groupInstruction
+  ? baseFilterOptions
+      .slice(0, 1)
+      .concat([{ value: "INSTRUCTION", text: "Instruction" }])
+      .concat(baseFilterOptions.slice(1))
+  : baseFilterOptions
+      .slice(0, 1)
+      .concat([
+        { value: "AWAITING_INSTRUCTION", text: "En attente d'instruction" },
+        { value: "ONGOING_INSTRUCTION", text: "En cours d'instruction" },
+        { value: "AWAITING_VISA", text: "En attente de visa" },
+        { value: "ONGOING_VISA", text: "Visa en cours" },
+      ])
+      .concat(baseFilterOptions.slice(1))
+
 const options = statusFilterOptions
   .filter((x) => props.exclude.indexOf(x.value) === -1)
   .map((x) => ({ label: x.text, name: x.value }))

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -208,7 +208,7 @@ const routes = [
       authenticationRequired: true,
       defaultQueryParams: {
         page: 1,
-        status: "DRAFT,OBSERVATION,OBJECTION",
+        status: "DRAFT,OBSERVATION,OBJECTION,INSTRUCTION",
       },
     },
   },

--- a/frontend/src/utils/components.js
+++ b/frontend/src/utils/components.js
@@ -1,11 +1,15 @@
 import { statusProps } from "@/utils/mappings"
 
-export const getStatusTagForCell = (status) => ({
-  component: "DsfrTag",
-  label: statusProps[status].label,
-  class: status,
-  icon: statusProps[status].icon,
-})
+export const getStatusTagForCell = (status, groupInstruction = false) => {
+  const instructionStatuses = ["AWAITING_INSTRUCTION", "ONGOING_INSTRUCTION", "AWAITING_VISA", "ONGOING_VISA"]
+  const processedStatus = groupInstruction && instructionStatuses.indexOf(status) > -1 ? "INSTRUCTION" : status
+  return {
+    component: "DsfrTag",
+    label: statusProps[processedStatus].label,
+    class: processedStatus,
+    icon: statusProps[processedStatus].icon,
+  }
+}
 
 export const getPagesForPagination = (count, limit, path) => {
   const totalPages = Math.ceil(count / limit)

--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -96,6 +96,10 @@ export const statusProps = {
     icon: "ri-pencil-fill",
     label: "Brouillon",
   },
+  INSTRUCTION: {
+    icon: "ri-time-fill",
+    label: "Instruction",
+  },
   AWAITING_INSTRUCTION: {
     icon: "ri-time-fill",
     label: "En attente d'instruction",
@@ -126,11 +130,11 @@ export const statusProps = {
   },
   AUTHORIZED: {
     icon: "ri-check-fill",
-    label: "Autorisée",
+    label: "Déclaration finalisée",
   },
   REJECTED: {
     icon: "ri-error-warning-fill",
-    label: "Refusée",
+    label: "Refus",
   },
   WITHDRAWN: {
     icon: "ri-close-fill",

--- a/frontend/src/views/CompanyDeclarationsPage/index.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/index.vue
@@ -11,7 +11,7 @@
       <StatusFilter
         :exclude="['DRAFT']"
         class="max-w-2xl"
-        @update:modelValue="updateStatusFilter"
+        @updateFilter="updateStatusFilter"
         v-model="filteredStatus"
       />
     </div>

--- a/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
+++ b/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
@@ -31,7 +31,7 @@ const rows = computed(() => {
   if (useShortTable.value)
     return props.data.results.map((d) => ({
       rowAttrs: { class: "cursor-pointer", onClick: () => emit("open", d.id) },
-      rowData: [d.name, getStatusTagForCell(d.status)],
+      rowData: [d.name, getStatusTagForCell(d.status, true)],
     }))
 
   return props.data.results.map((d) => ({
@@ -42,7 +42,7 @@ const rows = computed(() => {
         to: { name: "DeclarationPage", params: { id: d.id } },
       },
       d.brand || "—",
-      getStatusTagForCell(d.status),
+      getStatusTagForCell(d.status, true),
       timeAgo(d.modificationDate),
     ],
   }))

--- a/frontend/src/views/DeclarationsHomePage/index.vue
+++ b/frontend/src/views/DeclarationsHomePage/index.vue
@@ -16,7 +16,7 @@
     <div class="border px-4 pt-4 mb-2 sm:flex gap-8 items-baseline filters">
       <StatusFilter
         class="max-w-2xl"
-        @update:modelValue="updateStatusFilter"
+        @updateFilter="updateStatusFilter"
         v-model="filteredStatus"
         :groupInstruction="true"
       />

--- a/frontend/src/views/DeclarationsHomePage/index.vue
+++ b/frontend/src/views/DeclarationsHomePage/index.vue
@@ -14,7 +14,12 @@
       />
     </div>
     <div class="border px-4 pt-4 mb-2 sm:flex gap-8 items-baseline filters">
-      <StatusFilter class="max-w-2xl" @update:modelValue="updateStatusFilter" v-model="filteredStatus" />
+      <StatusFilter
+        class="max-w-2xl"
+        @update:modelValue="updateStatusFilter"
+        v-model="filteredStatus"
+        :groupInstruction="true"
+      />
     </div>
     <div v-if="isFetching" class="flex justify-center my-10">
       <ProgressSpinner />
@@ -67,10 +72,12 @@ const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...newQ
 const updateStatusFilter = (status) => updateQuery({ status })
 const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
 
-const url = computed(
-  () =>
-    `/api/v1/users/${loggedUser.value.id}/declarations/?limit=${limit}&offset=${offset.value}&status=${filteredStatus.value || ""}&ordering=-modificationDate`
-)
+const url = computed(() => {
+  let statusQuery = filteredStatus.value
+  if (filteredStatus.value?.indexOf("INSTRUCTION") > -1)
+    statusQuery += `${statusQuery.length ? "," : ""}AWAITING_INSTRUCTION,ONGOING_INSTRUCTION,AWAITING_VISA,ONGOING_VISA`
+  return `/api/v1/users/${loggedUser.value.id}/declarations/?limit=${limit}&offset=${offset.value}&status=${statusQuery || ""}&ordering=-modificationDate`
+})
 const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
   await execute()

--- a/frontend/src/views/InstructionDeclarationsPage/index.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/index.vue
@@ -42,7 +42,7 @@
           </div>
         </DsfrFieldset>
       </div>
-      <StatusFilter :exclude="['DRAFT']" @update:modelValue="updateStatusFilter" v-model="filteredStatus" />
+      <StatusFilter :exclude="['DRAFT']" @updateFilter="updateStatusFilter" v-model="filteredStatus" />
       <div class="md:border-l md:px-8">
         <DsfrInputGroup class="max-w-sm">
           <DsfrSelect

--- a/frontend/src/views/VisaDeclarationsPage/index.vue
+++ b/frontend/src/views/VisaDeclarationsPage/index.vue
@@ -8,7 +8,7 @@
       <StatusFilter
         :exclude="['DRAFT']"
         class="max-w-2xl"
-        @update:modelValue="updateStatusFilter"
+        @updateFilter="updateStatusFilter"
         v-model="filteredStatus"
       />
 


### PR DESCRIPTION
Closes #868 

## Contexte

Aujourd'hui on utilise des filtres de _django_filters_ pour l'API déclarations. Ces filtres se basent sur les propriétés du modèle et donc fonctionnent avec les statuts définis là dessus : DRAFT, AWAITING_INSTRUCTION, etc etc.

## Scope

Pour le ou la déclarant·e, ce serait souhaitable plutôt d'avoir un filtre groupée qui contienne les statuts _AWAITING_INSTRUCTION_, _ONGOING_INSTRUCTION_, _AWAITING_VISA_ et _ONGOING_VISA_ - çad à ses yeux les déclaration en instruction. Iel n'a pas besoin de savoir si la déclaration est en attente de visa, seulement si la déclaration est du côté de l'instruction.

#### Option technique 1 (celle choisie)

L'option choisie est de gérer ce groupement côté UI et laisser les filtres backend inchangés.

Cela impacte principalement le composant `StatusFilter` (qui désormais reçoit une propriété `groupInstruction` pour savoir quels statuts montrer), et la view  `DeclarationsHomePage`, qui doit ajuster la requête API lors que _instruction_ est sélectionné pour ajouter les quatre statuts dans le query.

#### Option technique 2

Une option alternative explorée est de surcharger le fonctionnement par défaut du filtre backend pour recevoir l'option `INSTRUCTION` et répondre avec les quatre statuts pertinents.

Je n'ai pas choisie cette option car on aurait du aussi modifier le serializer pour retourner un statut différent _instruction_ et parce que finalement on parle d'une simplification UI, non pas d'une vraie topologie données/métier.

## Démo

À noter que désormais "Instruction" fait partie des filtres activés par défaut.

[Screencast from 21-08-24 11:48:41.webm](https://github.com/user-attachments/assets/4f244835-8cd1-4860-ae11-0eec94156c52)
