### PR TITLE
modify query to make distinct list for user and admin

### DIFF
--- a/stats/teleicare_users_extraction.sql
+++ b/stats/teleicare_users_extraction.sql
@@ -148,8 +148,15 @@ GO
 SELECT COUNT(*) FROM V_UsersForExport
 /* 14020 usagers et administrateurs avec Email non null */
 
-/*Extract via PowerShell des utilisateurs ayant eu une activité ces 2 dernières années */
-SELECT Nom, Prenom, Email, EtabRaisonSociale, EtabEnseigne, EtabSiret, EtabNumeroTvaIntra, Fonction, RoleAsp FROM [TELEICARE].[dbo].[V_UsersForExport] where LASTACTIVITYDATE > '2022-08-01'
+/*Extract via PowerShell :
+- des gestionnaires depuis le début de téléicare */
+SELECT Nom, Prenom, Email, EtabRaisonSociale, EtabEnseigne, EtabSiret, EtabNumeroTvaIntra, Fonction, RoleAsp FROM [TELEICARE].[dbo].[V_UsersForExport] where RoleAsp = 'Administrateur'
+
+/* - des utilisateurs non gestionnaires ayant eu une activité ces 2 dernières années */
+SELECT Nom, Prenom, Email, EtabRaisonSociale, EtabEnseigne, EtabSiret, EtabNumeroTvaIntra, Fonction, RoleAsp FROM [TELEICARE].[dbo].[V_UsersForExport] where RoleAsp = 'Usager' and LASTACTIVITYDATE > '2022-08-01'
+
+-- deux listes distinctes car certains gestionnaires sont aussi utilisateurs
+-- 10355 total
 
 
 /* Reste à creuser */


### PR DESCRIPTION
relève de #730 mais ne la ferme pas car il faudra à nouveau faire un extract avec le dump du 09/09

L'ancienne liste Brevo qui regroupait :
* administrateurs ayant eu une action depuis moins de 2 ans (pour satisfaire aux critères d'import de Brevo)
* usagers ayant eu une action depuis moins de 2 ans
est supprimée.

2 nouvelles listes sont crées : 
* tous les administrateurs
* usagers ayant eu une action depuis moins de 2 ans

Certains admin sont aussi usagers.

Comme ça quand tu voudra shooter aux gestionnaires + usagers, il suffira de sélectionner les 2 listes et Brevo gère la déduplication de lui-même.