### PR TITLE
make logo clickable

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -2,9 +2,9 @@
   <DsfrHeader :logo-text="logoText" :quickLinks="quickLinks">
     <template #operator>
       <div class="flex items-center">
-        <a href="/">
+        <router-link :to="{ name: 'LandingPage' }">
           <img :src="require('@/assets/logo.svg')" alt="Logo Compl'Alim" class="h-20" />
-        </a>
+        </router-link>
 
         <DsfrBadge v-if="environment === 'dev'" :label="environment" type="info" />
         <DsfrBadge v-if="environment === 'demo'" :label="environment" type="new" />

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -2,7 +2,10 @@
   <DsfrHeader :logo-text="logoText" :quickLinks="quickLinks">
     <template #operator>
       <div class="flex items-center">
-        <img :src="require('@/assets/logo.svg')" alt="Logo Compl'Alim" class="h-20" />
+        <a href="/">
+          <img :src="require('@/assets/logo.svg')" alt="Logo Compl'Alim" class="h-20" />
+        </a>
+
         <DsfrBadge v-if="environment === 'dev'" :label="environment" type="info" />
         <DsfrBadge v-if="environment === 'demo'" :label="environment" type="new" />
         <DsfrBadge v-if="environment === 'staging'" :label="environment" type="warning" />


### PR DESCRIPTION
Selon la doc https://vue-ds.fr/composants/DsfrHeader
C'est grâce à la propo `serviceTitle` que le lien est crée vers la prop `homeTo` (par défaut = "/").
Notre `serviceTitle` devrait être "Compl'Alim" mais c'est déjà inclu dans notre logo.

Du coup je propose un bête lien <href>.