### PR TITLE
Enlève référence à un URL non-existant

### DIFF
--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -56,7 +56,6 @@
             </div>
         </div>
     </form>
-    <a href="{% url 'register' %}">Créer mon compte</a>
     <hr aria-hidden="true" style="margin-top: 22px;" />
     <p style="font-size: 0.85em; margin-top: 20px;"><a href="{% url 'password_reset' %}">J'ai perdu mon mot de passe</a></p>
 {% endblock %}


### PR DESCRIPTION
Closes #894 

## Contexte

Cette PR adresse l'issue [116561](https://sentry.incubateur.net/organizations/betagouv/issues/116561/) de Sentry.

## Explication

Nous avons encore les views auth de Django qu'on utilisait au début. À terme elles pourraient disparaître, mais ça c'est hors le scope de cette PR.

Un de ces templates avait une référence à une view qui n'existe plus : celle de la création de compte. 

La référence a été enlevée et la page est à nouveau fonctionnelle.