### PR TITLE
Appel groupé pour les infos liées aux champs de la déclaration

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -26,6 +26,7 @@ urlpatterns = {
     path("galenic-formulations/", views.GalenicFormulationListView.as_view(), name="galenic_formulation_list"),
     path("preparations/", views.PreparationListView.as_view(), name="preparation_list"),
     path("units/", views.UnitListView.as_view(), name="unit_list"),
+    path("declarationFieldData/", views.DeclarationFieldsGroupedView.as_view(), name="declaration_field_data"),
     # Authentication
     path("login/", views.LoginView.as_view(), name="login"),
     path("logout/", views.LogoutView.as_view(), name="logout"),

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -62,3 +62,4 @@ from .solicitation import (
     AddNewCollaboratorView,
 )
 from .snapshot import DeclarationSnapshotListView
+from .grouped_views import DeclarationFieldsGroupedView

--- a/api/views/grouped_views.py
+++ b/api/views/grouped_views.py
@@ -1,0 +1,38 @@
+import json
+
+from django.http import JsonResponse
+
+from djangorestframework_camel_case.render import CamelCaseJSONRenderer
+from rest_framework import status
+from rest_framework.views import APIView
+
+from api.views import (
+    ConditionListView,
+    EffectListView,
+    GalenicFormulationListView,
+    PlantPartListView,
+    PopulationListView,
+    PreparationListView,
+    UnitListView,
+)
+
+
+class DeclarationFieldsGroupedView(APIView):
+    """
+    Cette view permet de grouper les éléments nécessaires pour afficher toutes les
+    dépendances d'une déclaration. Elle existe pour éviter de faire plusieurs appels API
+    pour les récuperer individuellement.
+    """
+
+    def get(self, request, *args, **kwargs):
+        json_content = {
+            "populations": PopulationListView.as_view()(request._request).data,
+            "conditions": ConditionListView.as_view()(request._request).data,
+            "effects": EffectListView.as_view()(request._request).data,
+            "galenicFormulations": GalenicFormulationListView.as_view()(request._request).data,
+            "preparations": PreparationListView.as_view()(request._request).data,
+            "plantParts": PlantPartListView.as_view()(request._request).data,
+            "units": UnitListView.as_view()(request._request).data,
+        }
+        payload = json.loads(CamelCaseJSONRenderer().render(json_content))
+        return JsonResponse(payload, status=status.HTTP_200_OK)

--- a/frontend/src/stores/root.js
+++ b/frontend/src/stores/root.js
@@ -65,14 +65,16 @@ export const useRootStore = defineStore("root", () => {
     const { data } = await useFetch("/api/v1/units/").json()
     units.value = data.value
   }
-  const fetchDeclarationFieldsData = () => {
-    fetchConditions()
-    fetchEffects()
-    fetchPopulations()
-    fetchPlantParts()
-    fetchGalenicFormulations()
-    fetchPreparations()
-    fetchUnits()
+  // Appel groupé des fieldDdata
+  const fetchDeclarationFieldsData = async () => {
+    const { data } = await useFetch("/api/v1/declarationFieldData/").json()
+    populations.value = data.value.populations
+    conditions.value = pushOtherChoiceFieldAtTheEnd(data.value.conditions)
+    effects.value = pushOtherChoiceFieldAtTheEnd(data.value.effects)
+    galenicFormulations.value = pushOtherChoiceFieldAtTheEnd(data.value.galenicFormulations)
+    preparations.value = data.value.preparations
+    plantParts.value = data.value.plantParts
+    units.value = data.value.units
   }
   return {
     loggedUser,


### PR DESCRIPTION
Closes #915 

## Contexte

Sur plusieurs views du frontend on a besoin des informations liées aux différents champs de la déclaration. Notamment : 
- `populations`
- `conditions`
- `effects`
- `galenicFormulations`
- `preparations`
- `plantParts`
- `units`

Ces appels sont faits aujourd'hui un par un, ce qui ralentit le chargement de plusieurs pages et place une charge plus élevée dans notre serveur :

![image](https://github.com/user-attachments/assets/2732c5a4-0111-45a4-826d-57c5b0a0c499)

## Fix

Cette PR fait une view groupée simple pour n'avoir qu'un seul appel qui contient toutes les infos à l'intérieur :

![image](https://github.com/user-attachments/assets/fc1d8763-dc52-4faf-8414-cabcb12dbbb0)

Note : les autres endpoints restent actifs en cas de besoin.
