### PR TITLE
Bug fixes

### DIFF
--- a/api/serializers/substance.py
+++ b/api/serializers/substance.py
@@ -42,6 +42,7 @@ class SubstanceSerializer(PrivateCommentSerializer):
             "activity",
             "status",
             "history",
+            "object_type",
         )
         read_only_fields = fields
 

--- a/api/views/declaration/declaration_flow_validations.py
+++ b/api/views/declaration/declaration_flow_validations.py
@@ -61,7 +61,7 @@ def declared_microorganism_is_complete(mo):
 
 
 def computed_substance_is_complete(substance):
-    return substance.quantity
+    return substance.quantity is not None
 
 
 def validate_number_of_elements(declaration) -> tuple[list, list]:


### PR DESCRIPTION
Fix #924 -> Les déclarants peuvent maintenant indiquer "0" dans les quantité de substances pour lesquelles ils n'étaient pas obligés de renseigner la quantité dans TeleIcare. 0 n'est plus une valeur refusée.

Fix bug des substances déclarées qui n'étaient pas conservées dans la table des substances après passage au back