### PR TITLE
Ajout du formulaire de contact

### DIFF
--- a/api/tests/test_contact.py
+++ b/api/tests/test_contact.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+@override_settings(ANYMAIL={"SENDINBLUE_API_KEY": "fake-api-key"})
+@override_settings(CONTACT_EMAIL="contact@example.com")
+@override_settings(DEFAULT_FROM_EMAIL="from@example.com")
+@mock.patch("api.views.contact.EmailMessage", autospec=True)
+class TestContactView(APITestCase):
+    def test_submit_contact_form(self, mocked_email):
+        payload = {"name": "Anne Yversaire", "email": "anne@example.com", "message": "Hello world!"}
+
+        self.client.post(reverse("api:contact"), payload, format="json")
+
+        mocked_email.assert_called_once_with(
+            subject="Demande de support de Anne Yversaire",
+            body="Nom/Prénom\nAnne Yversaire\n------\n\nAdresse email\nanne@example.com\n------\n\nMessage\n« Hello world! »\n------",
+            from_email="from@example.com",
+            to=["contact@example.com"],
+            reply_to=["anne@example.com"],
+        )
+
+    def test_missing_info(self, mocked_email):
+        payload = {"name": "", "email": "anne@example.com", "message": "Hello world!"}
+
+        response = self.client.post(reverse("api:contact"), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mocked_email.assert_not_called()

--- a/api/urls.py
+++ b/api/urls.py
@@ -171,6 +171,8 @@ urlpatterns = {
         views.DeclarationWithdrawView.as_view(),
         name="withdraw",
     ),
+    # Contact
+    path("contact/", views.ContactView.as_view(), name="contact"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -64,3 +64,4 @@ from .solicitation import (
 )
 from .snapshot import DeclarationSnapshotListView
 from .grouped_views import DeclarationFieldsGroupedView
+from .contact import ContactView

--- a/api/views/contact.py
+++ b/api/views/contact.py
@@ -1,0 +1,46 @@
+import logging
+
+from django.conf import settings
+from django.core.mail import EmailMessage
+
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.exceptions import ProjectAPIException
+
+logger = logging.getLogger(__name__)
+
+
+class ContactView(APIView):
+    def post(self, request, *args, **kwargs):
+        try:
+            email = request.data.get("email", "").strip()
+            name = request.data.get("name")
+            message = request.data.get("message")
+
+            if not email or not name or not message:
+                logger.error(f"Missing field from contact view. Name: {name}, email: {email}, message: {message}.")
+                raise ProjectAPIException(non_field_errors=["Merci de remplir tous les champs obligatoires."])
+
+            subject = f"Demande de support de {name}"
+
+            body = f"Nom/Prénom\n{name}\n------"
+            body += f"\n\nAdresse email\n{email}\n------"
+            body += f"\n\nMessage\n« {message} »\n------"
+
+            email = EmailMessage(
+                subject=subject,
+                body=body,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                to=[settings.CONTACT_EMAIL],
+                reply_to=[email],
+            )
+            email.send()
+            return Response()
+        except Exception as e:
+            logger.exception(f"Exception ocurred while handling contact request. {e}")
+            raise ProjectAPIException(
+                non_field_errors=[
+                    "Une erreur est survenu lors de l'envoi de votre message. Merci de réessayer ultérieurement."
+                ]
+            )

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -30,6 +30,7 @@ import VisaDeclarationsPage from "@/views/VisaDeclarationsPage"
 import VisaPage from "@/views/VisaPage"
 import CompanyDeclarationsPage from "@/views/CompanyDeclarationsPage"
 import A11yPage from "@/views/A11yPage.vue"
+import ContactForm from "@/views/ContactForm"
 import { ref } from "vue"
 
 const routes = [
@@ -49,6 +50,11 @@ const routes = [
     path: "/entreprises",
     name: "ProducerHomePage",
     component: ProducerHomePage,
+  },
+  {
+    path: "/contactez-nous",
+    name: "ContactForm",
+    component: ContactForm,
   },
   {
     path: "/blog",

--- a/frontend/src/views/ContactForm.vue
+++ b/frontend/src/views/ContactForm.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="fr-container pb-10">
+    <DsfrBreadcrumb :links="[{ to: '/', text: 'Accueil' }, { text: 'Contactez-nous' }]" />
+    <h1>Contactez-nous</h1>
+    <FormWrapper :externalResults="$externalResults">
+      <DsfrInputGroup :error-message="firstErrorMsg(v$, 'name')">
+        <DsfrInput class="max-w-md" v-model="state.name" label="Votre nom et prénom" required label-visible />
+      </DsfrInputGroup>
+      <DsfrInputGroup :error-message="firstErrorMsg(v$, 'email')">
+        <DsfrInput class="max-w-md" v-model="state.email" label="Votre adresse email" required label-visible />
+      </DsfrInputGroup>
+      <DsfrInputGroup :error-message="firstErrorMsg(v$, 'message')">
+        <DsfrInput class="max-w-2xl" isTextarea v-model="state.message" label="Message" required label-visible />
+      </DsfrInputGroup>
+      <div class="">
+        <DsfrButton size="lg" label="Envoyer" icon="ri-mail-send-line" @click="sendEmail" />
+      </div>
+    </FormWrapper>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from "vue"
+import { useFetch } from "@vueuse/core"
+import useToaster from "@/composables/use-toaster"
+import { useRootStore } from "@/stores/root"
+import { storeToRefs } from "pinia"
+import { useVuelidate } from "@vuelidate/core"
+import FormWrapper from "@/components/FormWrapper"
+import { firstErrorMsg } from "@/utils/forms"
+import { errorRequiredField, errorRequiredEmail } from "@/utils/forms"
+import { handleError } from "@/utils/error-handling"
+import { headers } from "@/utils/data-fetching"
+import { useRouter } from "vue-router"
+
+const { loggedUser } = storeToRefs(useRootStore())
+const router = useRouter()
+
+const state = ref({
+  name: "",
+  email: "",
+  message: "",
+})
+
+onMounted(() => {
+  if (!loggedUser) return
+  state.value.name = `${loggedUser.value.firstName} ${loggedUser.value.lastName}`
+  state.value.email = loggedUser.value.email
+})
+
+const rules = {
+  name: errorRequiredField,
+  email: errorRequiredEmail,
+  message: errorRequiredField,
+}
+const $externalResults = ref({})
+const v$ = useVuelidate(rules, state, $externalResults)
+
+const sendEmail = async () => {
+  v$.value.$reset()
+  v$.value.$validate()
+  if (v$.value.$error) {
+    return
+  }
+  const { response } = await useFetch("/api/v1/contact/", { headers: headers() }).post(state.value).json()
+  $externalResults.value = await handleError(response)
+
+  if (response.value.ok) {
+    useToaster().addSuccessMessage("Le message a été envoyé et sera traité par notre équipe dans les plus brefs")
+    router.push({ name: "Root" })
+  }
+}
+</script>

--- a/frontend/src/views/DashboardPage/index.vue
+++ b/frontend/src/views/DashboardPage/index.vue
@@ -117,6 +117,7 @@ const onboardingActions = [
   {
     title: "Contactez notre équipe",
     description: "Une question ? Contactez-nous",
+    link: { name: "ContactForm" },
   },
 ]
 
@@ -130,6 +131,11 @@ const userActions = [
     title: "Nouvelle entreprise",
     description: "Créez ou rejoignez une nouvelle entreprise",
     link: { name: "CompanyFormPage" },
+  },
+  {
+    title: "Contactez notre équipe",
+    description: "Une question ? Contactez-nous",
+    link: { name: "ContactForm" },
   },
 ]
 </script>


### PR DESCRIPTION
Closes #928 

## Contexte 

On a une carte _Contactez-nous_ qui n'a pas de vue derrière et n'est donc pas cliquable.

## Scope

Même si ça aurait été plus simple d'ajouter un `<a href="mailto:..."`, ce n'est [pas une bonne idée](https://www.callonjo.com.au/why-you-should-keep-your-website-secure-by-not-including-email-addresses/) d'ajouter des adresses email au frontend si on veut éviter du spam, phishing, et autres choses désagréables. 

J'ai donc créé un formulaire frontend qui appelle une vue simple dans le backend exposé via API. C'est cette vue qui se charge d'envoyer l'email à notre équipe avec le message spécifié par l'utilisateur·ice.

Le formulaire remplit automatiquement les champs _nom_ et _email_ si la personne est authentifiée :

![image](https://github.com/user-attachments/assets/be4917da-3866-4ad0-8d4e-09177dc1aa48)


Le message envoyé a cette forme : 

```
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 8bit
Subject: Demande de support de Alejandro M Guillén
From: from@example.com
To: contact@example.com
Reply-To: alemangui@example.com
Date: Mon, 02 Sep 2024 15:41:41 -0000
Message-ID: 
 <172529170129.800074.3144353888107616482@ubu....>

Nom/Prénom
Alejandro M Guillén
------

Adresse email
alemangui@example.com
------

Message
« Hello world! »
------
```