### PR TITLE
Ajouts d'aides pour mieux comprendre la situation bloquée de la bdd de demo

### DIFF
--- a/data/admin/__init__.py
+++ b/data/admin/__init__.py
@@ -9,6 +9,7 @@ from .substance import SubstanceAdmin
 from .plant import PlantAdmin
 from .microorganism import MicroorganismAdmin
 from .population import Population
+from .preparation import Preparation
 from .condition import Condition
 from .effect import Effect
 from .galenic_formulation import GalenicFormulation

--- a/data/admin/preparation.py
+++ b/data/admin/preparation.py
@@ -1,0 +1,35 @@
+from django import forms
+from django.contrib import admin
+
+from data.models import Preparation
+
+
+class PreparationForm(forms.ModelForm):
+    class Meta:
+        widgets = {
+            "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
+        }
+
+
+@admin.register(Preparation)
+class PreparationAdmin(admin.ModelAdmin):
+    form = PreparationForm
+    fields = [
+        "name",
+        "ca_name",
+        "is_obsolete",
+        "ca_is_obsolete",
+        "creation_date",
+        "modification_date",
+    ]
+    readonly_fields = [
+        "name",
+        "is_obsolete",
+        "creation_date",
+        "modification_date",
+    ]
+    list_display = [
+        "name",
+        "modification_date",
+    ]
+    list_filter = ("is_obsolete",)

--- a/data/migrations/0092_populate_new_preparation_field.py
+++ b/data/migrations/0092_populate_new_preparation_field.py
@@ -8,8 +8,11 @@ def replace_textfield_by_foreign_key(apps, schema_editor):
     Preparation = apps.get_model('data', 'Preparation')
     DeclaredPlant = apps.get_model('data', 'DeclaredPlant')
     for dPlant in DeclaredPlant.objects.all():
-        preparation = Preparation.objects.get(name=dPlant.preparation_old)
-        dPlant.preparation = preparation
+        if dPlant.preparation_old:
+            preparation = Preparation.objects.get(name=dPlant.preparation_old)
+            dPlant.preparation = preparation
+        else:
+            dPlant.preparation = None
         dPlant.save()
 
 

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -384,6 +384,12 @@ class DeclaredPlant(Historisable, Addable):
         Preparation, null=True, blank=True, verbose_name="préparation", on_delete=models.RESTRICT
     )
 
+    def __str__(self):
+        if self.new_name:
+            return f"-NEW- {self.new_name}"
+        else:
+            return self.plant.name
+
 
 class DeclaredMicroorganism(Historisable, Addable):
     declaration = models.ForeignKey(


### PR DESCRIPTION
Une migration est modifiée :
- sur `demo` elle n'avait pas encore été appliquée dont aucun problème
- sur `staging` elle avait été appliqué, mais j'ai reverse puis réappliqué avec le modif.


C'est une tentative pour ne pas avoir à reset la bdd comme proposé ici https://stackoverflow.com/questions/42613536/django-programming-error-column-does-not-exist-even-after-running-migrations