### PR TITLE
:fire_extinguisher: add try catch for migration

### DIFF
--- a/data/migrations/0092_populate_new_preparation_field.py
+++ b/data/migrations/0092_populate_new_preparation_field.py
@@ -9,8 +9,11 @@ def replace_textfield_by_foreign_key(apps, schema_editor):
     DeclaredPlant = apps.get_model('data', 'DeclaredPlant')
     for dPlant in DeclaredPlant.objects.all():
         if dPlant.preparation_old:
-            preparation = Preparation.objects.get(name=dPlant.preparation_old)
-            dPlant.preparation = preparation
+            try:
+                preparation = Preparation.objects.get(name=dPlant.preparation_old)
+                dPlant.preparation = preparation
+            except Preparation.DoesNotExist:
+                dPlant.preparation = None
         else:
             dPlant.preparation = None
         dPlant.save()


### PR DESCRIPTION
Pour fixer cette [erreur](https://sentry.incubateur.net/organizations/betagouv/issues/119241/?alert_rule_id=106&alert_timestamp=1725611724160&alert_type=email&environment=production&notification_uuid=fe73fcd6-236c-49b4-b674-f6a76a5eada7&project=146&referrer=alert_email) qui est arrivée en prod lors du deploiement



Fait directement en base sur la `prod` : 

- suppression des colonnes preparation_old et preparation_id de data_declaredplant et data_historicaldeclaredplant + constraint sur prepration_id
- création column preparation TEXT
- suppression de la ligne concernant la migration 0092 dans django_migrations