### PR TITLE
Updates Django 5.1 static files and storage settings

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -186,7 +186,7 @@ default_file_storage = env("DEFAULT_FILE_STORAGE")
 
 STORAGES = {
     "default": {
-        "BACKEND": env("DEFAULT_FILE_STORAGE"),
+        "BACKEND": default_file_storage,
     },
     "staticfiles": {
         "BACKEND": env("STATICFILES_STORAGE"),

--- a/config/settings.py
+++ b/config/settings.py
@@ -181,9 +181,19 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static/")
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Media and file storage
-DEFAULT_FILE_STORAGE = env("DEFAULT_FILE_STORAGE")
 
-if DEFAULT_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
+default_file_storage = env("DEFAULT_FILE_STORAGE")
+
+STORAGES = {
+    "default": {
+        "BACKEND": env("DEFAULT_FILE_STORAGE"),
+    },
+    "staticfiles": {
+        "BACKEND": env("STATICFILES_STORAGE"),
+    },
+}
+
+if default_file_storage == "storages.backends.s3.S3Storage":
     AWS_ACCESS_KEY_ID = env("CELLAR_KEY")
     AWS_SECRET_ACCESS_KEY = env("CELLAR_SECRET")
     AWS_S3_ENDPOINT_URL = env("CELLAR_HOST")
@@ -194,7 +204,6 @@ if DEFAULT_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
 MEDIA_ROOT = env("MEDIA_ROOT", default=os.path.join(BASE_DIR, "media"))
 MEDIA_URL = "/media/"
 
-STATICFILES_STORAGE = env("STATICFILES_STORAGE")
 SESSION_COOKIE_AGE = 31536000
 SESSION_COOKIE_SECURE = env("SECURE", cast=bool)
 SESSION_COOKIE_HTTPONLY = True
@@ -279,7 +288,7 @@ customColorPalette = [
     {"color": "hsl(207, 90%, 54%)", "label": "Blue"},
 ]
 
-if DEFAULT_FILE_STORAGE == "storages.backends.s3.S3Storage":
+if default_file_storage == "storages.backends.s3.S3Storage":
     CKEDITOR_5_FILE_STORAGE = "data.storage.FileUploadS3Storage"
 else:
     CKEDITOR_5_FILE_STORAGE = "data.storage.FileUploadFileSystemStorage"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ click-plugins==1.1.1 ; python_version >= "3.11.dev0" and python_version < "3.12.
 click-repl==0.3.0 ; python_version >= "3.11.dev0" and python_version < "3.12.dev0"
 click==8.1.7 ; python_version >= "3.11.dev0" and python_version < "3.12.dev0"
 colorama==0.4.6 ; python_version >= "3.11" and python_version < "3.12.dev0" and sys_platform == "win32" or python_version < "3.12.dev0" and platform_system == "Windows" and python_version >= "3.11.dev0"
-cryptography==43.0.0 ; python_version >= "3.11.dev0" and python_version < "3.12.dev0"
+cryptography==43.0.1 ; python_version >= "3.11.dev0" and python_version < "3.12.dev0"
 cssselect2==0.7.0 ; python_version >= "3.11.dev0" and python_version < "3.12.dev0"
 decorator==5.1.1 ; python_version >= "3.11" and python_version < "3.12.dev0"
 distlib==0.3.8 ; python_version >= "3.11.dev0" and python_version < "3.12.dev0"


### PR DESCRIPTION
Closes #952 

## Contexte

Depuis Django 4.2, les settings `STATICFILES_STORAGE` et `DEFAULT_FILE_STORAGE` sont dépréciés ([release notes de la version 4.2](https://docs.djangoproject.com/en/5.1/releases/4.2/#custom-file-storages))

Django 5.1 a carrément enlevé ces deux settings ([release notes de la version 5.1](https://docs.djangoproject.com/en/5.1/releases/5.1/#features-removed-in-5-1)).

## Fix

On utilise deux variables d'environnement différentes pour ces deux settings :
- **DEFAULT_FILE_STORAGE** utilise `env("DEFAULT_FILE_STORAGE")` et concerne les fichiers dans les différents `FileField` de nos modèles.
- **STATICFILES_STORAGE** utilise `env("STATICFILES_STORAGE")` et concerne les fichiers statiques (ceux qui résultent de la commande `collectstatic`)

Désormais, les deux sont spécifiés dans le même setting :
```python
STORAGES = {
    "default": {
        "BACKEND": env("DEFAULT_FILE_STORAGE"),
    },
    "staticfiles": {
        "BACKEND": env("STATICFILES_STORAGE"),
    },
}
```

## django-storages

La valeur à mettre dans la variable d'environnement `DEFAULT_FILE_STORAGE` en prod/staging/demo a changé :

##### ~~`storages.backends.s3boto3.S3Boto3Storage`~~ -> `storages.backends.s3.S3Storage`

Ces valeurs sont à changer directement sur Clevercloud dans les plateformes où ce commit aurait été deployé. 


