### PR TITLE
Empêche l'ajout de doublons dans la composition

### DIFF
--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -81,6 +81,7 @@ import SubstancesTable from "@/components/SubstancesTable.vue"
 import NewElementModal from "./NewElementModal.vue"
 import { handleError } from "@/utils/error-handling"
 import SectionTitle from "@/components/SectionTitle"
+import useToaster from "@/composables/use-toaster"
 
 const payload = defineModel()
 const containers = computed(() => ({
@@ -125,6 +126,11 @@ const removeElement = (element) => {
   })
 }
 const addElement = (item, objectType, newlyAdded = false) => {
+  const itemExists = item.id && allElements.value.find((x) => x.element?.id === item.id)
+  if (itemExists) {
+    useToaster().addSuccessMessage("L'ingrédient est déjà présent dans votre composition.")
+    return
+  }
   const toAdd = newlyAdded
     ? {
         ...item,


### PR DESCRIPTION
Closes #942 

Cette PR ajoute une petite validation pour s'assurer que des doublons ne sont pas ajoutés dans la composition.

Elle n'effectue pas de check pour les ingrédients nouvellement ajoutés.

## Démo

[Screencast from 09-09-24 12:12:06.webm](https://github.com/user-attachments/assets/6a65e0c1-1288-4c9b-88e2-371753883eed)
