### PR TITLE
Fix du bug des radio-buttons dans l'onglet « Nouveaux éléments »

### DIFF
--- a/frontend/src/views/ProducerFormPage/NewElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementCard.vue
@@ -8,7 +8,7 @@
     <hr class="mt-4 pb-1" />
     <DsfrInputGroup>
       <DsfrRadioButton
-        name="authorizationMode"
+        :name="`authorizationMode-${uid}`"
         hint="Cet ingrédient est autorisé ou utilisable en France"
         v-model="model.authorizationMode"
         value="FR"
@@ -22,7 +22,7 @@
       </DsfrRadioButton>
 
       <DsfrRadioButton
-        name="authorizationMode"
+        :name="`authorizationMode-${uid}`"
         hint="Cet ingrédient n'est pas autorisée en France mais l'est dans un autre pays de l'UE ou EEE (déclaré au titre de l'article 16 du décret 2006-352)"
         v-model="model.authorizationMode"
         value="EU"
@@ -41,7 +41,7 @@
         <DsfrInputGroup>
           <DsfrRadioButtonSet
             v-model="model.frReason"
-            name="frReason"
+            :name="`frReason-${uid}`"
             legend="Raison de l'ajout manuel"
             :options="additionReasons"
           ></DsfrRadioButtonSet>
@@ -97,8 +97,11 @@
 <script setup>
 import CountryField from "@/components/fields/CountryField"
 import { getElementName } from "@/utils/elements"
+import { getCurrentInstance } from "vue"
 
 const model = defineModel()
+const { uid } = getCurrentInstance()
+
 const additionReasons = [
   {
     label: "Usage établi",


### PR DESCRIPTION
Closes #936 

## Contexte

Lors qu'on a plus d'un nouvel élément, dans l'onglet « Nouveaux éléments » les différents groupes des radio-buttons ne sont pas indépendants, donc en sélectionnant un d'une carte, ceux de l'autre carte perdent leur sélection. 

## Fix

Pour rendre chaque groupe de radio-buttons indépendant, il faut leur donner un `name` unique. On prend le `uid` du composant et on l'inclut dans le `name` :

![image](https://github.com/user-attachments/assets/92a01be2-68ae-4f14-adac-0e40d9145876)

## Démo
[Screencast from 10-09-24 10:20:16.webm](https://github.com/user-attachments/assets/d4d616c2-8f76-4239-b5bf-a5401c0b3392)

