### PR TITLE
Clarification de la table « computed substances »

### DIFF
--- a/frontend/src/components/SubstancesTable.vue
+++ b/frontend/src/components/SubstancesTable.vue
@@ -36,11 +36,11 @@
         </div>
 
         <!-- Cells des inputs (communes à toutes les substances) -->
-        <div class="sm:table-cell ca-cell">
+        <div class="sm:table-cell ca-cell sm:max-w-16">
           <div class="sm:hidden ca-xs-title">
             Quantité par DJR (en {{ payload.computedSubstances[rowIndex].substance.unit }})
           </div>
-          <DsfrInputGroup class="max-w-28" v-if="!props.readonly">
+          <DsfrInputGroup v-if="!props.readonly">
             <DsfrInput
               v-model="payload.computedSubstances[rowIndex].quantity"
               label="Quantité par DJR"
@@ -66,14 +66,9 @@ import ElementCommentModal from "@/components/ElementCommentModal"
 const payload = defineModel()
 const props = defineProps({ readonly: Boolean, hidePrivateComments: Boolean })
 
-const headers = ["", "Nom", "Num CAS", "Num EINEC", "Ingrédient(s) source", "Qté par DJR", "Unité"]
+const headers = ["", "Nom", "Ingrédient(s) source", "Qté totale par DJR", "Unité"]
 const rows = computed(() =>
-  payload.value.computedSubstances.map((x) => [
-    x.substance.name.toLowerCase(),
-    x.substance.casNumber || "-",
-    x.substance.einecNumber || "-",
-    sourceElements(x.substance),
-  ])
+  payload.value.computedSubstances.map((x) => [x.substance.name.toLowerCase(), sourceElements(x.substance)])
 )
 
 const elements = computed(() =>

--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -62,8 +62,8 @@
     <div v-show="hasActiveSubstances">
       <hr class="mt-4" />
       <DsfrCallout
-        title="Dosage totale des substances actives"
-        content="Les substances contenues dans les ingrédients actifs renseignés sont affichées ci-dessous. Veuillez compléter leur dosage total."
+        title="Dosage total des substances actives"
+        content="Ce tableau présente les substances actives identifiées dans les ingrédients que vous avez sélectionnés. Une même substance pouvant être introduite par plusieurs sources, nous vous demandons de renseigner pour chaque substance la quantité totale par dose journalière recommandée (DJR)."
       />
       <SubstancesTable :hidePrivateComments="true" v-model="payload" />
     </div>

--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -60,11 +60,10 @@
     </div>
 
     <div v-show="hasActiveSubstances">
-      <h3 class="fr-h6 !mb-4 !mt-6">Substances</h3>
-      <p>
-        Les substances contenues dans les ingrédients actifs renseignés sont affichées ci-dessous. Veuillez compléter
-        leur dosage total.
-      </p>
+      <hr class="mt-4" />
+      <h3 class="fr-h6 !mb-4 !mt-6">Dosage totale des substances actives</h3>
+      <p class="mb-2">Les substances contenues dans les ingrédients actifs renseignés sont affichées ci-dessous.</p>
+      <p>Veuillez compléter leur dosage total.</p>
       <SubstancesTable :hidePrivateComments="true" v-model="payload" />
     </div>
   </div>

--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -61,9 +61,10 @@
 
     <div v-show="hasActiveSubstances">
       <hr class="mt-4" />
-      <h3 class="fr-h6 !mb-4 !mt-6">Dosage totale des substances actives</h3>
-      <p class="mb-2">Les substances contenues dans les ingrédients actifs renseignés sont affichées ci-dessous.</p>
-      <p>Veuillez compléter leur dosage total.</p>
+      <DsfrCallout
+        title="Dosage totale des substances actives"
+        content="Les substances contenues dans les ingrédients actifs renseignés sont affichées ci-dessous. Veuillez compléter leur dosage total."
+      />
       <SubstancesTable :hidePrivateComments="true" v-model="payload" />
     </div>
   </div>


### PR DESCRIPTION
Closes #997 

Cette PR fait deux choses :
- Enlève les colonnes « CAS » et « EINEC », très peu utilisées et gênantes pour la lecture de la ligne
- Le titre est passé de « Substances » à « Dosage totale des substances actives »
- ~~Le texte a été divisé en deux lignes pour faciliter la lecture, laissant dans une linge toute seule l'instruction « Veuillez compléter leur dosage total. »~~ Le texte a été changé
- Le composant _Callout_ a été utilisé (vu avec @Fantine-py)

![image](https://github.com/user-attachments/assets/9a241468-1b09-49b2-85ff-a5adb4c49f22)