### PR TITLE
Ajout de l'ID et compagnie dans les tables / regroupement des filtres instruction

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -251,7 +251,7 @@ const routes = [
       authenticationRequired: true,
       defaultQueryParams: {
         page: 1,
-        status: "AWAITING_INSTRUCTION,ONGOING_INSTRUCTION,AWAITING_VISA,ONGOING_VISA,OBJECTION,OBSERVATION",
+        status: "INSTRUCTION,OBJECTION,OBSERVATION,ABANDONED,AUTHORIZED,WITHDRAWN",
       },
     },
   },

--- a/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
@@ -17,15 +17,17 @@ import { getStatusTagForCell } from "@/utils/components"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 
-const headers = ["Nom du produit", "Auteur", "État", "Date de création", "Date de modification"]
+const headers = ["ID", "Nom du produit", "Entreprise", "Auteur", "État", "Date de création", "Date de modification"]
 const rows = computed(() =>
   props.data?.results?.map((x) => ({
     rowData: [
+      x.id,
       {
         component: "router-link",
         text: x.name,
         to: { name: "DeclarationPage", params: { id: x.id } }, // TODO Change to a more enteprisey view
       },
+      x.company.socialName,
       `${x.author.firstName} ${x.author.lastName}`,
       getStatusTagForCell(x.status),
       timeAgo(x.creationDate),

--- a/frontend/src/views/CompanyDeclarationsPage/index.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/index.vue
@@ -13,6 +13,7 @@
         class="max-w-2xl"
         @updateFilter="updateStatusFilter"
         v-model="filteredStatus"
+        :groupInstruction="true"
       />
     </div>
     <div v-if="isFetching" class="flex justify-center my-10">

--- a/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
+++ b/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
@@ -15,6 +15,8 @@ import { computed, ref } from "vue"
 import { timeAgo } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
 import { useResizeObserver, useDebounceFn } from "@vueuse/core"
+import { useRootStore } from "@/stores/root"
+import { storeToRefs } from "pinia"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 const emit = defineEmits("open")
@@ -22,8 +24,13 @@ const emit = defineEmits("open")
 // Les données pour la table
 const headers = computed(() => {
   if (useShortTable.value) return ["Nom", "État"]
-  return ["Nom du produit", "Marque", "État", "Date de modification"]
+  return ["ID", "Nom du produit", "Entreprise", "État", "Date de modification"]
 })
+
+const store = useRootStore()
+const { loggedUser } = storeToRefs(store)
+const getCompanyWithId = (id) => loggedUser.value.companies?.find((x) => x.id === id)?.socialName
+
 const rows = computed(() => {
   // Les dates ISO sont sortables par text
   if (!props.data?.results) return []
@@ -36,12 +43,13 @@ const rows = computed(() => {
 
   return props.data.results.map((d) => ({
     rowData: [
+      d.id,
       {
         component: "router-link",
         text: d.name,
         to: { name: "DeclarationPage", params: { id: d.id } },
       },
-      d.brand || "—",
+      getCompanyWithId(d.company) || "Inconnue",
       getStatusTagForCell(d.status, true),
       timeAgo(d.modificationDate),
     ],

--- a/frontend/src/views/InstructionDeclarationsPage/InstructionDeclarationsTable.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/InstructionDeclarationsTable.vue
@@ -22,12 +22,13 @@ const { loggedUser } = storeToRefs(useRootStore())
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 
-const headers = ["", "Nom du produit", "Entreprise", "État", "Date limite de réponse", "Instruit par", "Article"]
+const headers = ["", "ID", "Nom du produit", "Entreprise", "État", "Date limite de réponse", "Instruit par", "Article"]
 const rows = computed(() =>
   props.data?.results?.map((x) => ({
     rowAttrs: { class: needsAttention(x) ? "font-bold" : "" },
     rowData: [
       needsAttention(x) ? { component: "div", class: "h-3 w-3 rounded-full bg-orange-400" } : "",
+      x.id,
       {
         component: "router-link",
         text: x.name,

--- a/frontend/src/views/VisaDeclarationsPage/VisaDeclarationsTable.vue
+++ b/frontend/src/views/VisaDeclarationsPage/VisaDeclarationsTable.vue
@@ -19,6 +19,7 @@ import { articleOptions } from "@/utils/mappings"
 const props = defineProps({ data: { type: Object, default: () => {} } })
 
 const headers = [
+  "ID",
   "Nom du produit",
   "Entreprise",
   "État",
@@ -30,6 +31,7 @@ const headers = [
 const rows = computed(() =>
   props.data?.results?.map((x) => ({
     rowData: [
+      x.id,
       {
         component: "router-link",
         text: x.name,


### PR DESCRIPTION
Linked to #926 
Closes #995 

## Scope

- Ajout de l'ID et la compagnie dans les tables de déclaration
- Regroupement des filtres « instruction » dans la table « les déclarations de mon entreprise »

![image](https://github.com/user-attachments/assets/266101d7-d6ad-42db-8ad7-60f2a19f571f)

![image](https://github.com/user-attachments/assets/bdd8e5f3-1cc0-4b2d-9b1d-23e874e7faa0)
