### PR TITLE
Changements sur les permissions et les filtres des listes de déclarations

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -16,10 +16,22 @@ class CanAccessUser(permissions.BasePermission):
 
 class CanAccessUserDeclatarions(permissions.BasePermission):
     """
-    Un.e utilisateur.ice peut seulement avoir accès à ces propres déclarations. Cette
-    permission vérifie que le paramètre dans l'URL `user_pk` corresponde à l'objet
-    `user` de la requête.
+    Un.e utilisateur.ice peut avoir accès aux :
+    - déclarations créées par iel même
+    - déclarations d'une des compagnies pour lesquelles iel a droit de déclaration
+    - déclarations d'une des compagnies pour lesquelles iel a droit de supervision
     """
+
+    def has_object_permission(self, request, view, obj):  # obj est une déclaration
+        created_by_user = obj.author == request.user
+        if created_by_user:  # Pour éviter les requêtes successives si on n'a pas besoin
+            return True
+
+        user_has_company_roles = (
+            obj.company in request.user.declarable_companies.all()
+            or obj.company in request.user.supervisable_companies.all()
+        )
+        return user_has_company_roles
 
     def has_permission(self, request, view):
         return view.kwargs["user_pk"] == request.user.id

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -4,6 +4,7 @@ from .user import (
     CollaboratorSerializer,
     CreateUserSerializer,
     ChangePasswordSerializer,
+    SimpleUserSerializer,
 )
 from .global_roles import SimpleInstructorSerializer, SimpleVisorSerializer
 from .webinar import WebinarSerializer

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -448,6 +448,9 @@ class DeclarationSerializer(serializers.ModelSerializer):
 
 
 class DeclarationShortSerializer(serializers.ModelSerializer):
+    author = SimpleUserSerializer(read_only=True)
+    company = SimpleCompanySerializer(read_only=True)
+
     class Meta:
         model = Declaration
         fields = (

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -604,13 +604,14 @@ class TestDeclarationApi(APITestCase):
     @authenticate
     def test_retrieve_update_declaration_list(self):
         """
-        Un user peut récupérer ses propres déclarations
+        Un user peut récupérer ses propres déclarations et celles des entreprises pour lesquelles
+        iel a des droits.
         """
 
         declarant_role = DeclarantRoleFactory(user=authenticate.user)
         company = declarant_role.company
         user_declaration_1 = DeclarationFactory.create(author=authenticate.user, company=company)
-        user_declaration_2 = DeclarationFactory.create(author=authenticate.user, company=company)
+        company_declaration_1 = DeclarationFactory.create(company=company)
 
         other_declaration = DeclarationFactory.create()
 
@@ -621,7 +622,7 @@ class TestDeclarationApi(APITestCase):
         self.assertEqual(len(declarations), 2)
         ids = map(lambda x: x["id"], declarations)
         self.assertIn(user_declaration_1.id, ids)
-        self.assertIn(user_declaration_2.id, ids)
+        self.assertIn(company_declaration_1.id, ids)
         self.assertNotIn(other_declaration.id, ids)
 
     @authenticate

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -215,6 +215,8 @@ const routes = [
       defaultQueryParams: {
         page: 1,
         status: "DRAFT,OBSERVATION,OBJECTION,INSTRUCTION",
+        company: "",
+        author: "",
       },
     },
   },
@@ -252,6 +254,8 @@ const routes = [
       defaultQueryParams: {
         page: 1,
         status: "INSTRUCTION,OBJECTION,OBSERVATION,ABANDONED,AUTHORIZED,WITHDRAWN",
+        company: "",
+        author: "",
       },
     },
   },

--- a/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
@@ -29,7 +29,7 @@ const rows = computed(() =>
       },
       x.company.socialName,
       `${x.author.firstName} ${x.author.lastName}`,
-      getStatusTagForCell(x.status),
+      getStatusTagForCell(x.status, true),
       timeAgo(x.creationDate),
       timeAgo(x.modificationDate),
     ],

--- a/frontend/src/views/CompanyDeclarationsPage/index.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/index.vue
@@ -4,13 +4,41 @@
       class="mb-8"
       :links="[
         { to: { name: 'DashboardPage' }, text: 'Tableau de bord' },
-        { text: `Les déclarations de l'entreprise ${company.socialName}` },
+        { text: 'Les déclarations de mon entreprise' },
       ]"
     />
     <div class="border px-4 pt-4 pb-0 mb-2 sm:flex gap-8 items-baseline filters">
+      <DsfrFieldset class="!mb-0">
+        <div class="md:pl-4">
+          <DsfrInputGroup>
+            <DsfrSelect
+              label="Entreprise"
+              :modelValue="company"
+              @update:modelValue="updateCompany"
+              defaultUnselectedText="Toutes"
+              :options="companiesOptions"
+              class="!text-sm"
+            />
+          </DsfrInputGroup>
+        </div>
+      </DsfrFieldset>
+      <DsfrFieldset class="!mb-0">
+        <div class="md:border-x md:px-4">
+          <DsfrInputGroup>
+            <DsfrSelect
+              label="Personne assignée"
+              :modelValue="author"
+              @update:modelValue="updateAuthor"
+              defaultUnselectedText="Toutes"
+              :options="authorOptions"
+              class="!text-sm"
+            />
+          </DsfrInputGroup>
+        </div>
+      </DsfrFieldset>
       <StatusFilter
         :exclude="['DRAFT']"
-        class="max-w-2xl"
+        class="max-w-xl"
         @updateFilter="updateStatusFilter"
         v-model="filteredStatus"
         :groupInstruction="true"
@@ -47,8 +75,20 @@ import StatusFilter from "@/components/StatusFilter.vue"
 const route = useRoute()
 const store = useRootStore()
 const router = useRouter()
-const { companies } = storeToRefs(store)
-const company = computed(() => companies.value?.find((c) => +c.id === +route.params.id))
+const { companies, loggedUser } = storeToRefs(store)
+
+const authorOptions = computed(() => {
+  const allAuthors = data.value?.authors.map((x) => ({ value: x.id, text: `${x.firstName} ${x.lastName}` })) || []
+  const emptyOption = { value: "", text: "Toutes" }
+  allAuthors.unshift(emptyOption)
+  return allAuthors
+})
+const companiesOptions = computed(() => {
+  const allCompanies = companies.value?.map((x) => ({ value: x.id, text: x.socialName })) || []
+  const emptyOption = { value: "", text: "Toutes" }
+  allCompanies.unshift(emptyOption)
+  return allCompanies
+})
 
 const limit = 10
 const hasDeclarations = computed(() => data.value?.count > 0)
@@ -58,20 +98,26 @@ const offset = computed(() => (page.value - 1) * limit)
 // Valeurs obtenus du queryparams
 const page = computed(() => parseInt(route.query.page))
 const filteredStatus = computed(() => route.query.status)
+const company = computed(() => (route.query.company ? parseInt(route.query.company) : ""))
+const author = computed(() => (route.query.author ? parseInt(route.query.author) : ""))
 
 const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...newQuery } })
 const updateStatusFilter = (status) => updateQuery({ status })
 const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
+const updateCompany = (newValue) => updateQuery({ company: newValue })
+const updateAuthor = (newValue) => updateQuery({ author: newValue })
 
-const url = computed(
-  () =>
-    `/api/v1/companies/${company.value?.id}/declarations/?&limit=${limit}&offset=${offset.value}&status=${filteredStatus.value || ""}`
-)
+const url = computed(() => {
+  let statusQuery = filteredStatus.value
+  if (filteredStatus.value?.indexOf("INSTRUCTION") > -1)
+    statusQuery += `${statusQuery.length ? "," : ""}AWAITING_INSTRUCTION,ONGOING_INSTRUCTION,AWAITING_VISA,ONGOING_VISA`
+  return `/api/v1/users/${loggedUser.value.id}/declarations/?limit=${limit}&offset=${offset.value}&status=${statusQuery || ""}&ordering=-modificationDate&company=${company.value}&author=${author.value}`
+})
 const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
   await execute()
   await handleError(response)
 }
 
-watch([page, filteredStatus], fetchSearchResults)
+watch([page, filteredStatus, company, author], fetchSearchResults)
 </script>

--- a/frontend/src/views/DashboardPage/index.vue
+++ b/frontend/src/views/DashboardPage/index.vue
@@ -64,7 +64,11 @@ const supervisorActions = computed(() => [
   {
     title: "Les déclarations de mon entreprise",
     description: "Visualisez les déclarations soumises pour le compte de votre entreprise",
-    link: { name: "CompanyDeclarationsPage", params: { id: company.value?.id } },
+    link: {
+      name: "CompanyDeclarationsPage",
+      params: { id: company.value?.id },
+      query: { company: company.value?.id },
+    },
   },
   {
     title: "Les collaborateurs de mon entreprise",
@@ -88,7 +92,7 @@ const declarantActions = [
     title: "Toutes mes déclarations",
     description:
       "Accédez à l'ensemble de vos dossiers (brouillons, dossiers en cours d'instruction, attestations de déclaration)",
-    link: { name: "DeclarationsHomePage" },
+    link: { name: "DeclarationsHomePage", query: { author: loggedUser.value?.id } },
   },
 ]
 

--- a/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
+++ b/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
@@ -15,8 +15,6 @@ import { computed, ref } from "vue"
 import { timeAgo } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
 import { useResizeObserver, useDebounceFn } from "@vueuse/core"
-import { useRootStore } from "@/stores/root"
-import { storeToRefs } from "pinia"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 const emit = defineEmits("open")
@@ -24,12 +22,8 @@ const emit = defineEmits("open")
 // Les données pour la table
 const headers = computed(() => {
   if (useShortTable.value) return ["Nom", "État"]
-  return ["ID", "Nom du produit", "Entreprise", "État", "Date de modification"]
+  return ["ID", "Nom du produit", "Entreprise", "Déclarant·e", "État", "Date de modification"]
 })
-
-const store = useRootStore()
-const { loggedUser } = storeToRefs(store)
-const getCompanyWithId = (id) => loggedUser.value.companies?.find((x) => x.id === id)?.socialName
 
 const rows = computed(() => {
   // Les dates ISO sont sortables par text
@@ -49,7 +43,8 @@ const rows = computed(() => {
         text: d.name,
         to: { name: "DeclarationPage", params: { id: d.id } },
       },
-      getCompanyWithId(d.company) || "Inconnue",
+      d.company?.socialName || "Inconnue",
+      d.author ? `${d.author.firstName} ${d.author.lastName}` : "",
       getStatusTagForCell(d.status, true),
       timeAgo(d.modificationDate),
     ],

--- a/frontend/src/views/DeclarationsHomePage/index.vue
+++ b/frontend/src/views/DeclarationsHomePage/index.vue
@@ -14,8 +14,36 @@
       />
     </div>
     <div class="border px-4 pt-4 mb-2 sm:flex gap-8 items-baseline filters">
+      <DsfrFieldset class="!mb-0">
+        <div class="md:pl-4">
+          <DsfrInputGroup>
+            <DsfrSelect
+              label="Entreprise"
+              :modelValue="company"
+              @update:modelValue="updateCompany"
+              defaultUnselectedText="Toutes"
+              :options="companiesOptions"
+              class="!text-sm"
+            />
+          </DsfrInputGroup>
+        </div>
+      </DsfrFieldset>
+      <DsfrFieldset class="!mb-0">
+        <div class="md:border-x md:px-4">
+          <DsfrInputGroup>
+            <DsfrSelect
+              label="Personne assignée"
+              :modelValue="author"
+              @update:modelValue="updateAuthor"
+              defaultUnselectedText="Toutes"
+              :options="authorOptions"
+              class="!text-sm"
+            />
+          </DsfrInputGroup>
+        </div>
+      </DsfrFieldset>
       <StatusFilter
-        class="max-w-2xl"
+        class="max-w-xl"
         @updateFilter="updateStatusFilter"
         v-model="filteredStatus"
         :groupInstruction="true"
@@ -26,7 +54,7 @@
     </div>
     <DeclarationsTable :data="data" v-else-if="hasDeclarations" />
     <div v-else class="mb-8">
-      <p>Vous n'avez pas encore créé des déclarations.</p>
+      <p>Vous n'avez pas encore des déclarations avec ces filtres.</p>
       <DsfrButton icon="ri-capsule-fill" label="Créer ma première déclaration" @click="createNewDeclaration" />
     </div>
     <DsfrPagination
@@ -55,10 +83,25 @@ const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
 const router = useRouter()
 const route = useRoute()
+const company = computed(() => (route.query.company ? parseInt(route.query.company) : ""))
+const author = computed(() => (route.query.author ? parseInt(route.query.author) : ""))
 
 const hasDeclarations = computed(() => !!data.value?.results?.length)
 const showPagination = computed(() => data.value?.count > data.value?.results?.length)
 const offset = computed(() => (page.value - 1) * limit)
+
+const authorOptions = computed(() => {
+  const allAuthors = data.value?.authors.map((x) => ({ value: x.id, text: `${x.firstName} ${x.lastName}` })) || []
+  const emptyOption = { value: "", text: "Toutes" }
+  allAuthors.unshift(emptyOption)
+  return allAuthors
+})
+const companiesOptions = computed(() => {
+  const companies = loggedUser.value.companies?.map((x) => ({ value: x.id, text: x.socialName })) || []
+  const emptyOption = { value: "", text: "Toutes" }
+  companies.unshift(emptyOption)
+  return companies
+})
 
 const limit = 10
 const pages = computed(() => getPagesForPagination(data.value.count, limit, route.path))
@@ -71,12 +114,14 @@ const createNewDeclaration = () => router.push({ name: "NewDeclaration" })
 const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...newQuery } })
 const updateStatusFilter = (status) => updateQuery({ status })
 const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
+const updateCompany = (newValue) => updateQuery({ company: newValue })
+const updateAuthor = (newValue) => updateQuery({ author: newValue })
 
 const url = computed(() => {
   let statusQuery = filteredStatus.value
   if (filteredStatus.value?.indexOf("INSTRUCTION") > -1)
     statusQuery += `${statusQuery.length ? "," : ""}AWAITING_INSTRUCTION,ONGOING_INSTRUCTION,AWAITING_VISA,ONGOING_VISA`
-  return `/api/v1/users/${loggedUser.value.id}/declarations/?limit=${limit}&offset=${offset.value}&status=${statusQuery || ""}&ordering=-modificationDate`
+  return `/api/v1/users/${loggedUser.value.id}/declarations/?limit=${limit}&offset=${offset.value}&status=${statusQuery || ""}&ordering=-modificationDate&company=${company.value}&author=${author.value}`
 })
 const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
@@ -84,5 +129,5 @@ const fetchSearchResults = async () => {
   await handleError(response)
 }
 
-watch([page, filteredStatus], fetchSearchResults)
+watch([page, filteredStatus, company, author], fetchSearchResults)
 </script>


### PR DESCRIPTION

Closes #926 

## Scope

### Droits de lecture des déclarations (déclarant·e)
#### :arrow_left: Avant
Les déclarant·e·s pouvaient seulement voir les déclarations qu'iels avaient créées.

#### :white_check_mark: Après
Les déclarant·e·s peuvent voir toutes les déclarations des entreprises pour lesquelles iels ont droit de déclaration ou supervision. 

Ceci permettra par la suite de reprendre un dossier d'un collègue.

La carte « Mes déclarations » envoie vers la table de déclarations avec le filtre « Personne assignée » prérempli à la personne identifiée. Ce filtre peut être utilisé pour voir d'autres déclarations faites par des collègues.

![image](https://github.com/user-attachments/assets/4e6b749f-0ad7-409d-b035-dbec1a2bb650)

### Triage par entreprise (déclarant·e)
#### :arrow_left: Avant
La liste des déclarations affichée à un·e déclarant·e contenait les déclarations de toutes les entreprises, sans possibilité de filtrer ni de savoir à quelle entreprise la déclaration était liée.

#### :white_check_mark: Après
Désormais un·e déclarant·e peut voir l'entreprise directement dans la table ainsi que filtrer sur cette donnée.

![image](https://github.com/user-attachments/assets/03a1155c-d652-47dd-abc3-d8d34ac13632)

### Liste des déclarations de mon entreprise (gestionnaire)
#### :arrow_left: Avant
Les déclarations affichées concernaient toutes les entreprises (bug #926).

#### :white_check_mark: Après
Lors qu'on clique sur la carte « Les déclarations de mon entreprise » on arrive à la liste des déclarations de l'entreprise sélectionnée, tout en ayant un filtre pour changer d'entreprise ou pour afficher tout en même temps.

![image](https://github.com/user-attachments/assets/1d8ef2f4-52bc-4610-9abe-6787ee5540ad)

## Notes techniques

Ces changements rendent l'endpoint API `companies/<int:pk>/declarations/` lié à la view `CompanyDeclarationsListView` inutilisé - car via le système de filtres et le nouvelles permissions on peut utiliser plutôt `users/<int:user_pk>/declarations/` lié à `UserDeclarationsListCreateApiView`. J'ai laissé quand même l'endpoint et la view car je veux m'assurer d'abord que ce comportement soit bien celui qu'on veut garder.