### PR TITLE
Permet d'ajouter des ancres aux blog post

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -355,7 +355,7 @@ CKEDITOR_5_CONFIGS = {
                 {"model": "heading3", "view": "h3", "title": "Heading 3", "class": "ck-heading_heading3"},
             ]
         },
-        "htmlSupport": {"allow": [{"name": "/.*/", "attributes": True, "classes": True, "styles": True}]},
+        "htmlSupport": {"allow": [{"name": "/.*/", "attributes": {"id": True}}]},
     },
     "list": {
         "properties": {

--- a/config/settings.py
+++ b/config/settings.py
@@ -355,6 +355,7 @@ CKEDITOR_5_CONFIGS = {
                 {"model": "heading3", "view": "h3", "title": "Heading 3", "class": "ck-heading_heading3"},
             ]
         },
+        "htmlSupport": {"allow": [{"name": "/.*/", "attributes": True, "classes": True, "styles": True}]},
     },
     "list": {
         "properties": {


### PR DESCRIPTION
@Fantine-py souhaitait pouvoir rendre la navigation plus fluide sur la FAQ.

Les ancres ne fonctionnaient pas car les attributs `id` n'étaient pas sauvegardés lorsqu'ajoutés au code source dans l'interface d'admin django.

## Avant
![image](https://github.com/user-attachments/assets/c20d919a-403f-48f1-9386-3f04e977ba5e)


## Après 
![image](https://github.com/user-attachments/assets/51390747-b4b1-4dba-b0ba-50b6909a1307)

Le plugin [GeneralHtmlSupport](https://ckeditor.com/docs/ckeditor5/latest/features/html/general-html-support.html) est supporté par défaut par la lib django-ckeditor5, il suffit de le spécifier dans la config ckeditor du fichier settings.py

