### PR TITLE
Empêcher la création de nouvel ingrédient de type "Arôme"

### DIFF
--- a/frontend/src/views/ProducerFormPage/NewElementModal.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementModal.vue
@@ -71,7 +71,7 @@ const addableTypes = computed(() =>
   Object.keys(typesMapping)
     // Note : Sur téléicare on ne peux pas ajouter des substances directement
     // Le type "ingredient" est voué à être déprécié, donc on ne permet pas d'en ajouter
-    .filter((key) => !["ingredient", "substance"].includes(key))
+    .filter((key) => !["ingredient", "aroma", "substance"].includes(key))
     .map((key) => ({ text: typesMapping[key], value: key }))
 )
 


### PR DESCRIPTION
Cela prépare que bientôt les arômes ne seront qu'un champ libre.
Car il n'y a pas de suivi réglementaire à faire sur les aromes.
![image](https://github.com/user-attachments/assets/27934ef2-c3ca-47f0-8e41-c75f6711b384)
