### PR TITLE
Renomme "Ingrédient" en "Autre ingrédient" pour éviter la confusion

### DIFF
--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -18,8 +18,8 @@ export const typesMapping = {
   form_of_supply: "Forme d'apport", // nutrient: "Nutriment"
   aroma: "Arôme",
   additive: "Additif",
-  active_ingredient: "Ingredient actif",
-  non_active_ingredient: "Ingredient non actif", // TODO : merger ces 2 types en 1 et n'utiliser que le label "actif"/"inactif"
+  active_ingredient: "Autre ingredient actif",
+  non_active_ingredient: "Autre ingredient non actif", // TODO : merger ces 2 types en 1 et n'utiliser que le label "actif"/"inactif"
   substance: "Substance",
   // TODO: déprecier après l'import de données extraites en mai 2024
   // qui contient les types plus précis


### PR DESCRIPTION
Closes #1017 
C'est notamment utile lors de la création d'un nouvel ingrédient pour que les pros puissent choisir au mieux la catégorie d'ingrédient qu'ils veulent créer.

![image](https://github.com/user-attachments/assets/a69f99ef-96be-4d3b-a16b-41df6dbefe28)
