### PR TITLE
Ajout d'un hint pour spécifier de mettre des majuscules

### DIFF
--- a/frontend/src/views/CompanyFormPage/Identification.vue
+++ b/frontend/src/views/CompanyFormPage/Identification.vue
@@ -4,6 +4,7 @@
       <DsfrInputGroup :error-message="firstErrorMsg(v$, 'identifier')">
         <DsfrInput
           :label="`Numéro de ${company.identifierType.toUpperCase()}`"
+          :hint="company.identifierType.toUpperCase() !== 'SIRET' ? 'Merci d\'utiliser des majuscules' : ''"
           v-model="identifier"
           required
           labelVisible


### PR DESCRIPTION
Suite à un email d'une utilisatrice sur le numéro TVA, ce hint explique qu'il faut utiliser des majuscules.

Par la suite on pourra rendre en majuscules le payload avant l'envoyer au backend.

![image](https://github.com/user-attachments/assets/bf017802-4ab8-4e5c-9dd2-c23f2d6af875)
