### PR TITLE
Ne plus demander la quantité pour les substances qui n'en nécessitent pas

### DIFF
--- a/api/serializers/substance.py
+++ b/api/serializers/substance.py
@@ -62,5 +62,6 @@ class SubstanceShortSerializer(PrivateCommentSerializer):
             "max_quantity",
             "public_comments",
             "private_comments",  # Caché si l'utilisateur.ice ne fait pas partie de l'administration
+            "must_specify_quantity",
         )
         read_only_fields = fields

--- a/api/views/declaration/declaration_flow_validations.py
+++ b/api/views/declaration/declaration_flow_validations.py
@@ -60,8 +60,8 @@ def declared_microorganism_is_complete(mo):
     return mo.strain and (not mo.activated or mo.quantity)
 
 
-def computed_substance_is_complete(substance):
-    return substance.quantity is not None
+def computed_substance_is_complete(computed_substance):
+    return computed_substance.quantity is not None if computed_substance.substance.must_specify_quantity else True
 
 
 def validate_number_of_elements(declaration) -> tuple[list, list]:

--- a/frontend/src/components/SubstancesTable.vue
+++ b/frontend/src/components/SubstancesTable.vue
@@ -40,7 +40,7 @@
           <div class="sm:hidden ca-xs-title">
             Quantité par DJR (en {{ payload.computedSubstances[rowIndex].substance.unit }})
           </div>
-          <DsfrInputGroup v-if="!props.readonly">
+          <DsfrInputGroup v-if="askForQuantity(payload.computedSubstances[rowIndex].substance)">
             <DsfrInput
               v-model="payload.computedSubstances[rowIndex].quantity"
               label="Quantité par DJR"
@@ -50,7 +50,9 @@
           <div v-else>{{ payload.computedSubstances[rowIndex].quantity }}</div>
         </div>
         <div class="hidden sm:table-cell fr-text-alt ca-cell font-italic">
-          {{ payload.computedSubstances[rowIndex].substance.unit }}
+          <span v-if="askForQuantity(payload.computedSubstances[rowIndex].substance)">
+            {{ payload.computedSubstances[rowIndex].substance.unit }}
+          </span>
         </div>
       </div>
     </div>
@@ -70,6 +72,11 @@ const headers = ["", "Nom", "Ingrédient(s) source", "Qté totale par DJR", "Uni
 const rows = computed(() =>
   payload.value.computedSubstances.map((x) => [x.substance.name.toLowerCase(), sourceElements(x.substance)])
 )
+
+const askForQuantity = (substance) => {
+  if (props.readonly) return false
+  return substance.mustSpecifyQuantity
+}
 
 const elements = computed(() =>
   [].concat(

--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -63,7 +63,7 @@
       <hr class="mt-4" />
       <DsfrCallout
         title="Dosage total des substances actives"
-        content="Ce tableau présente les substances actives identifiées dans les ingrédients que vous avez sélectionnés. Une même substance pouvant être introduite par plusieurs sources, nous vous demandons de renseigner pour chaque substance la quantité totale par dose journalière recommandée (DJR)."
+        content="Ce tableau présente les substances actives identifiées dans les ingrédients que vous avez sélectionnés. Une même substance pouvant être introduite par plusieurs sources, la quantité totale par dose journalière recommandée (DJR) est demandée pour certaines substances faisant l'objet d'une règlementation spécifique ou impliquant un risque."
       />
       <SubstancesTable :hidePrivateComments="true" v-model="payload" />
     </div>


### PR DESCRIPTION
Closes #998 

## Scope

- Changement du texte dans l'encart en haut du tableau des « computed substances »
- L'input et l'unité ne s'affichent pas pour les substances n'ayant pas `must_specify_quantity` à `true`
- Côté backend, la validation du flow prend aussi en compte le paramètre `must_specify_quantity`

![image](https://github.com/user-attachments/assets/22c0ab4f-dc62-479d-b456-a509250c17f3)
