### PR TITLE
Remplacement automatique du séparateur décimal

### DIFF
--- a/frontend/src/components/NumberField.vue
+++ b/frontend/src/components/NumberField.vue
@@ -1,0 +1,13 @@
+<template>
+  <DsfrInput v-model="model" />
+</template>
+
+<script setup>
+const [model] = defineModel({
+  set(value) {
+    const parseableNumber = value.indexOf(",") > -1 ? value.replace(",", ".") : value
+    const parsedResult = parseFloat(parseableNumber)
+    return isNaN(parsedResult) ? value : parsedResult
+  },
+})
+</script>

--- a/frontend/src/components/SubstancesTable.vue
+++ b/frontend/src/components/SubstancesTable.vue
@@ -42,7 +42,7 @@
           </div>
           <div v-if="props.readonly">{{ payload.computedSubstances[rowIndex].quantity }}</div>
           <DsfrInputGroup v-else-if="askForQuantity(payload.computedSubstances[rowIndex].substance)">
-            <DsfrInput
+            <NumberField
               v-model="payload.computedSubstances[rowIndex].quantity"
               label="Quantité par DJR"
               :required="true"
@@ -64,6 +64,7 @@
 
 import { computed, watch } from "vue"
 import ElementCommentModal from "@/components/ElementCommentModal"
+import NumberField from "@/components/NumberField"
 
 const payload = defineModel()
 const props = defineProps({ readonly: Boolean, hidePrivateComments: Boolean })

--- a/frontend/src/views/ProducerFormPage/ElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/ElementCard.vue
@@ -44,7 +44,7 @@
           />
         </DsfrInputGroup>
         <DsfrInputGroup class="max-w-28">
-          <DsfrInput label="Qté par DJR" v-model="model.quantity" label-visible :required="true" />
+          <NumberField label="Qté par DJR" v-model="model.quantity" label-visible :required="true" />
         </DsfrInputGroup>
         <DsfrInputGroup class="min-w-20 max-w-24">
           <DsfrSelect
@@ -78,13 +78,13 @@
         </div>
         <div v-if="model.activated">
           <DsfrInputGroup>
-            <DsfrInput label-visible v-model="model.quantity" label="Qté par DJR (en UFC)" :required="true" />
+            <NumberField label-visible v-model="model.quantity" label="Qté par DJR (en UFC)" :required="true" />
           </DsfrInputGroup>
         </div>
       </div>
       <div v-else-if="objectType === 'form_of_supply' || objectType === 'active_ingredient'" class="ml-12 flex gap-4">
         <DsfrInputGroup>
-          <DsfrInput label-visible v-model="model.quantity" label="Qté par DJR" :required="true" />
+          <NumberField label-visible v-model="model.quantity" label="Qté par DJR" :required="true" />
         </DsfrInputGroup>
         <DsfrInputGroup class="min-w-20 max-w-24">
           <DsfrSelect
@@ -101,6 +101,7 @@
 </template>
 
 <script setup>
+import NumberField from "@/components/NumberField"
 import { useRootStore } from "@/stores/root"
 import { computed } from "vue"
 import { getElementName } from "@/utils/elements"

--- a/frontend/src/views/ProducerFormPage/ProductTab.vue
+++ b/frontend/src/views/ProducerFormPage/ProductTab.vue
@@ -90,7 +90,7 @@
         <DsfrFieldset legend="Poids ou volume d'une unité de consommation" legendClass="fr-label !pb-0">
           <div class="flex">
             <div class="max-w-64">
-              <DsfrInput
+              <NumberField
                 label="Quantité"
                 label-visible
                 v-model="payload.unitQuantity"
@@ -253,6 +253,7 @@ import { pushOtherChoiceFieldAtTheEnd, getAllIndexesOfRegex } from "@/utils/form
 import CountryField from "@/components/fields/CountryField.vue"
 import OtherChoiceField from "@/components/fields/OtherChoiceField"
 import SectionTitle from "@/components/SectionTitle"
+import NumberField from "@/components/NumberField"
 
 const payload = defineModel()
 const props = defineProps(["externalResults"])


### PR DESCRIPTION
## Problème

Lors que les personnes rentrent un numéro utilisant la virgule comme séparateur décimal, une erreur invisible se produit.

## Solution

La problématique sur quel séparateur décimal utiliser est complexe et dépendant de l'implémentation des locales de chaque browser.

Cette PR implémente une solution rapide qui consiste à remplacer la virgule par le point décimal automatiquement. L'inconvénient étant qu'en France on utilise la virgule - et donc idéalement on montrait la virgule et non pas le point. Mais cette solution au moins permet de rentrer un numéro utilisant n'importe quel séparateur.

## Démo

[Screencast from 24-09-24 17:46:54.webm](https://github.com/user-attachments/assets/7c141fc5-ffad-432d-b479-f1ae3b1cb406)

## Comment ça marche

Tout se passe dans _NumberField.vue_.

L'unique élément de la racine du template est un `DsfrInput` - et donc c'est lui qui hérite automatiquement les attributs qui sont passés au composant. Plus d'info sur l'héritage des attributs sur [cette doc de Vue](https://vuejs.org/guide/components/attrs).

De plus, on défini un setter du modèle qui remplace la virgule par le point et - si le résultat parsé est une chiffre - on la retourne directement. Sinon on retourne la valeur originale. C'est comme ça aussi que marche le modifier natif `.number` ([décrit ici](https://stackoverflow.com/questions/42111991/validating-input-with-vue-js-what-does-v-model-number-really-mean)).
