### PR TITLE
Anonymise la personne ayant instruit un dossier du point de vue du déclarant·e

### DIFF
--- a/frontend/src/components/SnapshotItem.vue
+++ b/frontend/src/components/SnapshotItem.vue
@@ -13,7 +13,8 @@
       <DeclarationSummary :readonly="true" v-model="snapshot.jsonDeclaration" />
     </DsfrModal>
     <div class="initials rounded-full min-w-12 w-12 h-12 flex items-center justify-center">
-      {{ initials }}
+      <v-icon v-if="hideInstructionDetails && isAdministrativeAction" name="ri-user-fill" aria-hidden />
+      <span v-else>{{ initials }}</span>
     </div>
     <div class="max-w-xl">
       <div :class="`flex ${rightSide ? 'justify-end' : 'justify-start'}`">
@@ -51,7 +52,20 @@ import { statusProps } from "@/utils/mappings"
 import { isoToPrettyDate, isoToPrettyTime } from "@/utils/date"
 import DeclarationSummary from "@/components/DeclarationSummary"
 
-const props = defineProps({ snapshot: Object, rightSide: Boolean })
+const props = defineProps({ snapshot: Object, rightSide: Boolean, hideInstructionDetails: Boolean })
+
+const isAdministrativeAction = computed(() => {
+  const instructionActions = [
+    "TAKE_FOR_INSTRUCTION",
+    "OBSERVE_NO_VISA",
+    "AUTHORIZE_NO_VISA",
+    "REQUEST_VISA",
+    "TAKE_FOR_VISA",
+    "ACCEPT_VISA",
+    "REFUSE_VISA",
+  ]
+  return instructionActions.indexOf(props.snapshot.action) > -1
+})
 
 const initials = computed(() => `${props.snapshot.user.firstName?.[0]}${props.snapshot.user.lastName?.[0]}`)
 const date = computed(
@@ -59,7 +73,10 @@ const date = computed(
 )
 const modalOpened = ref(false)
 const isInValidationState = computed(() => props.snapshot.status === "AWAITING_VISA")
-const fullName = computed(() => `${props.snapshot.user.firstName} ${props.snapshot.user.lastName}`)
+const fullName = computed(() => {
+  if (props.hideInstructionDetails && isAdministrativeAction.value) return "L'administration"
+  return `${props.snapshot.user.firstName} ${props.snapshot.user.lastName}`
+})
 const actionText = computed(() => {
   const mapping = {
     SUBMIT: "a soumis la déclaration pour instruction",

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -40,6 +40,7 @@
               :readonly="readonly"
               :declarationId="id"
               @withdraw="onWithdrawal"
+              :hideInstructionDetails="true"
             ></component>
           </FormWrapper>
         </DsfrTabContent>


### PR DESCRIPTION
Closes #1052
Closes #1053 

## Contexte

L'onglet « historique », lors qu'affiché aux pros, montrent le nom / prénom de la personne ayant instruit le dossier.

## Scope

- Ne pas montrer le nom ni les initiales du côté administration dans l'onglet historique
- Ne pas montrer les détails du processus d'instruction aux pros (çad le moment ou ça passe en visa, etc)

#### Out of scope
- Ces fixes sont seulement côté UI. À voir si à terme on veut les enlever de l'API aussi lors que c'est un pro qui fait l'appel.

## Captures d'écran

Côté instruction / visa on a les infos des noms :
![image](https://github.com/user-attachments/assets/a7684a86-2dee-46dd-a207-67d4045daa64)

Côté déclarant·e on a une vue sans détails de l'instruction : 
![image](https://github.com/user-attachments/assets/4794672a-b904-44f7-b38e-edc3edf99876)
