### PR TITLE
Permet de lire et modifier une déclaration d'un ou une collègue

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -92,10 +92,11 @@ class CanAccessIndividualDeclaration(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):  # obj: Declaration
         is_author = IsDeclarationAuthor().has_object_permission(request, view, obj)
+        is_from_same_company = obj.company in request.user.declarable_companies.all()
         is_instructor = IsInstructor().has_permission(request, view)
         is_declarant = IsDeclarant().has_object_permission(request, view, obj)
         is_draft = obj.status == Declaration.DeclarationStatus.DRAFT
         if request.method in permissions.SAFE_METHODS:
-            return is_author or (is_instructor and not is_draft)
+            return is_author or is_from_same_company or (is_instructor and not is_draft)
 
-        return is_author and is_declarant
+        return (is_author or is_from_same_company) and is_declarant

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -660,6 +660,23 @@ class TestDeclarationApi(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @authenticate
+    def test_retrieve_company_declaration(self):
+        """
+        Un user peut récupérer les informations complètes d'une déclaration de sa
+        compagnie
+        """
+        declarant_role = DeclarantRoleFactory(user=authenticate.user)
+        company = declarant_role.company
+        company_declaration = DeclarationFactory(company=company)
+        other_declaration = DeclarationFactory()
+
+        response = self.client.get(reverse("api:retrieve_update_declaration", kwargs={"pk": company_declaration.id}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.get(reverse("api:retrieve_update_declaration", kwargs={"pk": other_declaration.id}))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
     def test_private_notes(self):
         """
         Seulement les roles Instruction et Visa peuvent voir les notes privées


### PR DESCRIPTION
Closes #1066 
Lié à #1068 

## Contexte

La lecture et modification d'une déclaration pouvait se faire exclusivement par l'auteur ou autrice.

## Scope

Une personne de la même compagnie peut : 
- Ouvrir et voir les infos d'une déclaration
- Modifier la déclaration

#### Out of scope 
- S'assigner le déclaration (à faire dans le contexte de #1068)

## Démo

[Screencast from 27-09-24 12:14:50.webm](https://github.com/user-attachments/assets/0465afdf-9a24-41b2-be0d-1b668a9615e8)

