### PR TITLE
Améliore la performance en enlevant l'historique des ingrédients du serializer 

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -396,12 +396,12 @@ class DeclarationSerializer(serializers.ModelSerializer):
         )
 
         queryset = queryset.prefetch_related(
-            "declared_plants__plant__substances__unit",
-            "declared_plants__plant__plant_parts",
-            "declared_microorganisms__microorganism__substances__unit",
-            "declared_ingredients__ingredient__substances__unit",
-            "declared_substances__substance__unit",
-            "computed_substances__substance__unit",
+            "declared_plants__plant__substances",
+            "declared_plants__plant",
+            "declared_microorganisms__microorganism__substances",
+            "declared_ingredients__ingredient__substances",
+            "declared_substances__substance",
+            "computed_substances__substance",
             "attachments",
         )
         return queryset

--- a/api/serializers/ingredient.py
+++ b/api/serializers/ingredient.py
@@ -5,7 +5,7 @@ from data.models import Ingredient, IngredientStatus, IngredientSynonym
 
 from .historical_record import HistoricalRecordField
 from .substance import SubstanceShortSerializer
-from .utils import PrivateCommentSerializer
+from .utils import HistoricalModelSerializer, PrivateCommentSerializer
 
 
 class IngredientSynonymSerializer(serializers.ModelSerializer):
@@ -18,7 +18,7 @@ class IngredientSynonymSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class IngredientSerializer(PrivateCommentSerializer):
+class IngredientSerializer(HistoricalModelSerializer, PrivateCommentSerializer):
     synonyms = IngredientSynonymSerializer(many=True, read_only=True, source="ingredientsynonym_set")
     substances = SubstanceShortSerializer(many=True, read_only=True)
     status = GoodReprChoiceField(choices=IngredientStatus.choices, read_only=True)

--- a/api/serializers/microorganism.py
+++ b/api/serializers/microorganism.py
@@ -5,7 +5,7 @@ from data.models import IngredientStatus, Microorganism, MicroorganismSynonym
 
 from .historical_record import HistoricalRecordField
 from .substance import SubstanceShortSerializer
-from .utils import PrivateCommentSerializer
+from .utils import HistoricalModelSerializer, PrivateCommentSerializer
 
 
 class MicroorganismSynonymSerializer(serializers.ModelSerializer):
@@ -18,7 +18,7 @@ class MicroorganismSynonymSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class MicroorganismSerializer(PrivateCommentSerializer):
+class MicroorganismSerializer(HistoricalModelSerializer, PrivateCommentSerializer):
     synonyms = MicroorganismSynonymSerializer(many=True, read_only=True, source="microorganismsynonym_set")
     substances = SubstanceShortSerializer(many=True, read_only=True)
     status = GoodReprChoiceField(choices=IngredientStatus.choices, read_only=True)

--- a/api/serializers/plant.py
+++ b/api/serializers/plant.py
@@ -5,7 +5,7 @@ from data.models import IngredientStatus, Part, Plant, PlantFamily, PlantPart, P
 
 from .historical_record import HistoricalRecordField
 from .substance import SubstanceShortSerializer
-from .utils import PrivateCommentSerializer
+from .utils import HistoricalModelSerializer, PrivateCommentSerializer
 
 
 class PlantFamilySerializer(serializers.ModelSerializer):
@@ -50,7 +50,7 @@ class PlantSynonymSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class PlantSerializer(PrivateCommentSerializer):
+class PlantSerializer(HistoricalModelSerializer, PrivateCommentSerializer):
     family = PlantFamilySerializer(read_only=True)
     plant_parts = PartRelationSerializer(source="part_set", many=True, read_only=True)
     synonyms = PlantSynonymSerializer(many=True, read_only=True, source="plantsynonym_set")

--- a/api/serializers/substance.py
+++ b/api/serializers/substance.py
@@ -4,7 +4,7 @@ from api.utils.choice_field import GoodReprChoiceField
 from data.models import IngredientStatus, Substance, SubstanceSynonym
 
 from .historical_record import HistoricalRecordField
-from .utils import PrivateCommentSerializer
+from .utils import HistoricalModelSerializer, PrivateCommentSerializer
 
 
 class SubstanceSynonymSerializer(serializers.ModelSerializer):
@@ -17,7 +17,7 @@ class SubstanceSynonymSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class SubstanceSerializer(PrivateCommentSerializer):
+class SubstanceSerializer(HistoricalModelSerializer, PrivateCommentSerializer):
     synonyms = SubstanceSynonymSerializer(many=True, read_only=True, source="substancesynonym_set")
     unit = serializers.CharField(read_only=True, source="unit.name")
     unit_id = serializers.IntegerField(read_only=True, source="unit.id")

--- a/api/serializers/utils.py
+++ b/api/serializers/utils.py
@@ -20,3 +20,17 @@ class PrivateCommentSerializer(serializers.ModelSerializer):
         if not can_see_private_comments:
             repr.pop("private_comments", None)
         return repr
+
+
+class HistoricalModelSerializer(serializers.ModelSerializer):
+    """
+    Si le serializer contient un champ "history", ce champ sera conditionné à
+    `context.history`. Ceci permet de ne pas requeter la table de simple-history
+    à moins que ça soit explicitement requis par la view.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not self.context.get("history", None):
+            self.fields.pop("history", None)

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -26,6 +26,18 @@ class TestElementsApi(APITestCase):
         self.assertEqual(plant.name, body["name"])
         self.assertEqual(plant.id, body["id"])
 
+    def test_get_single_plant_history(self):
+        plant = PlantFactory.create()
+        response = self.client.get(f"{reverse('api:single_plant', kwargs={'pk': plant.id})}?history=true")
+        body = response.json()
+
+        self.assertIn("history", body)
+
+        response = self.client.get(reverse("api:single_plant", kwargs={"pk": plant.id}))
+        body = response.json()
+
+        self.assertNotIn("history", body)
+
     @authenticate
     def test_plant_private_comments(self):
         plant = PlantFactory.create(private_comments="Private")
@@ -71,6 +83,18 @@ class TestElementsApi(APITestCase):
         self.assertEqual(ingredient.name, body["name"])
         self.assertEqual(ingredient.id, body["id"])
 
+    def test_get_single_ingredient_history(self):
+        ingredient = IngredientFactory.create()
+        response = self.client.get(f"{reverse('api:single_ingredient', kwargs={'pk': ingredient.id})}?history=true")
+        body = response.json()
+
+        self.assertIn("history", body)
+
+        response = self.client.get(reverse("api:single_ingredient", kwargs={"pk": ingredient.id}))
+        body = response.json()
+
+        self.assertNotIn("history", body)
+
     def test_get_single_ingredient_with_right_type(self):
         """
         Le modèle (table) ingrédient à un champ `ingredient_type`.
@@ -104,6 +128,20 @@ class TestElementsApi(APITestCase):
         self.assertEqual(microorganism.name, body["name"])
         self.assertEqual(microorganism.id, body["id"])
 
+    def test_get_single_microorganism_history(self):
+        microorganism = MicroorganismFactory.create()
+        response = self.client.get(
+            f"{reverse('api:single_microorganism', kwargs={'pk': microorganism.id})}?history=true"
+        )
+        body = response.json()
+
+        self.assertIn("history", body)
+
+        response = self.client.get(reverse("api:single_microorganism", kwargs={"pk": microorganism.id}))
+        body = response.json()
+
+        self.assertNotIn("history", body)
+
     @authenticate
     def test_microorganism_private_comments(self):
         microorganism = MicroorganismFactory.create(private_comments="private")
@@ -128,6 +166,18 @@ class TestElementsApi(APITestCase):
 
         self.assertEqual(substance.name, body["name"])
         self.assertEqual(substance.id, body["id"])
+
+    def test_get_single_substance_history(self):
+        substance = SubstanceFactory.create()
+        response = self.client.get(f"{reverse('api:single_substance', kwargs={'pk': substance.id})}?history=true")
+        body = response.json()
+
+        self.assertIn("history", body)
+
+        response = self.client.get(reverse("api:single_substance", kwargs={"pk": substance.id}))
+        body = response.json()
+
+        self.assertNotIn("history", body)
 
     @authenticate
     def test_substance_private_comments(self):

--- a/api/views/ingredient.py
+++ b/api/views/ingredient.py
@@ -1,10 +1,10 @@
-from rest_framework.generics import RetrieveAPIView
-
-from data.models import Ingredient
 from api.serializers import IngredientSerializer
+from data.models import Ingredient
+
+from .utils import IngredientRetrieveView
 
 
-class IngredientRetrieveView(RetrieveAPIView):
+class IngredientRetrieveView(IngredientRetrieveView):
     model = Ingredient
     queryset = Ingredient.objects.filter(missing_import_data=False)
     serializer_class = IngredientSerializer

--- a/api/views/microorganism.py
+++ b/api/views/microorganism.py
@@ -1,9 +1,10 @@
-from rest_framework.generics import RetrieveAPIView
-from data.models import Microorganism
 from api.serializers import MicroorganismSerializer
+from data.models import Microorganism
+
+from .utils import IngredientRetrieveView
 
 
-class MicroorganismRetrieveView(RetrieveAPIView):
+class MicroorganismRetrieveView(IngredientRetrieveView):
     model = Microorganism
     queryset = Microorganism.objects.filter(missing_import_data=False)
     serializer_class = MicroorganismSerializer

--- a/api/views/plant.py
+++ b/api/views/plant.py
@@ -1,9 +1,12 @@
-from rest_framework.generics import RetrieveAPIView, ListAPIView
+from rest_framework.generics import ListAPIView
+
+from api.serializers import PlantPartSerializer, PlantSerializer
 from data.models import Plant, PlantPart
-from api.serializers import PlantSerializer, PlantPartSerializer
+
+from .utils import IngredientRetrieveView
 
 
-class PlantRetrieveView(RetrieveAPIView):
+class PlantRetrieveView(IngredientRetrieveView):
     model = Plant
     queryset = Plant.objects.filter(missing_import_data=False)
     serializer_class = PlantSerializer

--- a/api/views/substance.py
+++ b/api/views/substance.py
@@ -1,9 +1,10 @@
-from rest_framework.generics import RetrieveAPIView
-from data.models import Substance
 from api.serializers import SubstanceSerializer
+from data.models import Substance
+
+from .utils import IngredientRetrieveView
 
 
-class SubstanceRetrieveView(RetrieveAPIView):
+class SubstanceRetrieveView(IngredientRetrieveView):
     model = Substance
     queryset = Substance.objects.filter(missing_import_data=False)
     serializer_class = SubstanceSerializer

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -1,0 +1,9 @@
+from rest_framework.generics import RetrieveAPIView
+
+
+class IngredientRetrieveView(RetrieveAPIView):
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        if self.request.query_params.get("history", None):
+            context["history"] = True
+        return context

--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -168,7 +168,7 @@ const historyDataDedup = computed(() => Array.from(new Set(historyData.value.map
 
 // TODO: remove background
 // TODO: affichage du change reason dans l'admin
-const url = computed(() => `/api/v1/${getApiType(type.value)}s/${elementId.value}`)
+const url = computed(() => `/api/v1/${getApiType(type.value)}s/${elementId.value}?history=true`)
 const { data: element, response, execute } = useFetch(url, { immediate: false }).get().json()
 
 const getElementFromApi = async () => {


### PR DESCRIPTION
## Contexte

Sur les erreurs Sentry « _N+1 Query_ » on peut voir des appels innécessaires aux tables historiques (par exemple _data_historialsubstance_).

## Solution

Ces appels viennent des serializers des ingrédients. Ils incluent explicitement l'historique, par exemple, sur `PlantSerializer` :

```python
class PlantSerializer(PrivateCommentSerializer):
    ...
    history = HistoricalRecordField(read_only=True)

    fields = (
        ...
        "history",
    )
```

Cette PR fait en sorte que l'historique soit seulement inclut si l'URL contient le query param `?history=true`.

#### Côté view

La view cherche le query param, et si elle le trouve, elle ajoute au contexte du serializer la propriété `history`. Ceci est fait dans la classe `IngredientRetrieveView` : 

```python
# api/views/utils.py

class IngredientRetrieveView(RetrieveAPIView):
    def get_serializer_context(self):
        context = super().get_serializer_context()
        if self.request.query_params.get("history", None):
            context["history"] = True
        return context
```

#### Côté serializer

Lors de l'initialization du serializer, le champ "history" est gardé seulement si le contexte contient la propriété "history". Ceci se passe dans `HistoricalModelSerializer` : 

```python
# api/serializers/utils.py

class HistoricalModelSerializer(serializers.ModelSerializer):

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)

        if not self.context.get("history", None):
            self.fields.pop("history", None)
```

#### Côté UI

La view des résultats de la recherche utilise l'historique, donc elle doit seulement ajouter le queryparam pour continuer de l'obtenir : 

```javascript
const url = computed(() => `/api/v1/${getApiType(type.value)}s/${elementId.value}?history=true`)
```

## Amélioration

Le nombre de requêtes diminue de peu, mais s'agissant d'une jointure on gagne quand même pas mal de ms par sauvegarde de la déclaration.

Pour une déclaration en local contenant 4 plantes, 2 additifs, 3 ingrédients actifs, 2 substances et 12 computed-substances, on passe de 463 requêtes à 436.