### PR TITLE
:lady_beetle:  Ensures the file validator handles null cases

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -259,6 +259,9 @@ class AttachmentSerializer(IdPassthrough, serializers.ModelSerializer):
         read_only_fields = ("file",)
 
     def validate_file(self, file):
+        if not file:
+            return None
+
         size_limit = 1048576 * 2
         if file.size > size_limit:
             raise ProjectAPIException(


### PR DESCRIPTION
Closes #1080

## Problème

Nous avons un `Unhandled 'NoneType' object has no attribute 'size'` sur la fonction de validation du fichier d'une pièce jointe.

## Solution

Aujourd'hui la propriété `file` des pièces jointes est nullable. De plus, en utilisant des Patch il se peut que cette propriété ne soit pas envoyée au backend.

Nous devons donc vérifier que le paramètre reçu dans la fonction ne soit pas `None` avant d'essayer d’accéder ses propriétés :

```python
if not file:
    return None
``` 