### PR TITLE
:lady_beetle: Fix data pour la déduplication des computed substances

### DIFF
--- a/stats/duplicated_computed_substances_bug.sql
+++ b/stats/duplicated_computed_substances_bug.sql
@@ -1,0 +1,42 @@
+-- Extraction des adresses mail des concerné.e.s
+
+select distinct
+    data_user.email,
+    (declaration_id)
+from (
+    select
+        data_computedsubstance.declaration_id,
+        data_computedsubstance.substance_id,
+        count(*) as cnt
+    from data_computedsubstance
+    group by
+        data_computedsubstance.declaration_id,
+        data_computedsubstance.substance_id
+    order by count(*) desc
+) as duplicated_computed_substances
+inner join
+    data_declaration
+    on duplicated_computed_substances.declaration_id = data_declaration.id
+inner join data_user on data_user.id = author_id
+where cnt > 1
+
+
+-- Déduplication
+-- declaration_to_dedup_ids = liste provenant de la requête SQL
+import time
+for declaration_to_dedup in Declaration.objects.filter(id__in=declaration_to_dedup_ids):
+    total = declaration_to_dedup.computed_substances.all().values_list('substance_id', flat=True)
+    nb_total = len(total)
+    substances_id = list(total.distinct())
+    nb_distinct = len(substances_id)
+    print(f'->> déduplication de {declaration_to_dedup} : {nb_total - nb_distinct} sur {nb_total}')
+    # conserver une seule version de chaque substance avec ses autres champs (active, quantity, unit)
+    for subst_id in substances_id:
+        all_objects_ids = list(declaration_to_dedup.computed_substances.filter(substance_id=subst_id).values_list("id", flat=True))
+        nb_initial = len(all_objects_ids)
+        # pop le premier pour le conserver
+        all_objects_ids.pop(0)
+        # supprimer les autres
+        # declaration_to_dedup.computed_substances.filter(id__in=all_objects_ids).delete()
+        print(f'suppression de {len(declaration_to_dedup.computed_substances.filter(id__in=all_objects_ids))} sur {nb_initial} pour la substance {Substance.objects.get(pk=subst_id)}')
+        time.sleep(3)


### PR DESCRIPTION
Closes #1083 

* Query SQL pour récup declaration id et email
* query django pour supprimer les substances dupliquées

C'est un peu crado d'avoir du sql + python dans le même fichier, mais comme c'est du one shot, ça me va. Dis moi si c'est pas ok pour toi @alemangui 


## Metabase
Query pour vérifier si cette situation réapparaît (doublons de computed substances) : [ici](https://compl-alim-metabase.cleverapps.io/question/89-combien-de-declarations-impactees-par-le-bug-des-doublons-de-computed-substances)

## Mail pour les déclarant.e.s impactés
Nous nous sommes aperçu qu'un bug vous a impacté pendant la déclaration n°<déclaration_id> : les ingrédients ajoutés se sont trouvés dupliqués ainsi que les substances associées. 2 actions ont été prises pour résoudre ce problème :

* une modification de la plateforme afin que ce bug n'arrive plus
* une modification de votre déclaration pour n'avoir qu'une seule version de chaque microorganisme, forme d'apport, additif, autre ingrédient actif ou inactif, substance (celle-ci devrait avoir lieu dans les 24h à venir)

En ce qui concerne les plantes dupliqués, nous vous laissons le soin de les dédupliquer vous même en cliquant sur le bouton "Enlever" dans l'onglet de "Composition". Cela n'a pas été fait automatiquement car une même plante peut être ajoutée plusieurs fois via une partie différente.