### PR TITLE
Champ « délai de réponse » dynamique

### DIFF
--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -55,7 +55,12 @@
             </div>
             <div class="content-end" v-if="decisionCategory != 'approve'">
               <DsfrInputGroup :error-message="firstErrorMsg(v$, 'delayDays')">
-                <DsfrInput v-model="delayDays" label="Délai de réponse (jours)" label-visible />
+                <DsfrInput
+                  :disabled="disableDelayDays"
+                  v-model="delayDays"
+                  label="Délai de réponse (jours)"
+                  label-visible
+                />
               </DsfrInputGroup>
             </div>
           </div>
@@ -104,7 +109,7 @@ const rules = computed(() => {
     comment: errorRequiredField,
     reasons: { required: helpers.withMessage("Au moins une raison doit être selectionnée", required) },
     proposal: errorRequiredField,
-    delayDays: errorRequiredField,
+    delayDays: proposal.value !== "rejection" ? errorRequiredField : {},
   }
 })
 const declaration = defineModel()
@@ -122,8 +127,12 @@ const emit = defineEmits(["decision-done"])
 const needsVisa = ref(false)
 const mandatoryVisaProposals = ["objection", "rejection"]
 const disableVisaCheckbox = computed(() => !proposal.value || mandatoryVisaProposals.indexOf(proposal.value) > -1)
+const disableDelayDays = computed(() => proposal.value === "rejection")
 watch(proposal, (newProposal) => {
   if (mandatoryVisaProposals.indexOf(newProposal) > -1) needsVisa.value = true
+  if (newProposal === "objection") delayDays.value = 30
+  else if (newProposal === "rejection") delayDays.value = null
+  else delayDays.value = 15
 })
 
 const decisionCategories = [


### PR DESCRIPTION
Closes #1087 

## Contexte

Le délai de réponse était figé à 15 jours

## Scope

Le délai de réponse est de 15 jours en cas d'observation, 30 jours en cas d'objection, et reste vide en cas de refus.

## Démo

[Screencast from 01-10-24 09:38:58.webm](https://github.com/user-attachments/assets/ac0e4352-12f2-4d44-ad17-1018a2aa14e0)
