### PR TITLE
:lady_beetle: N'affiche plus le message d'assignation d'un dossier lors de sa création

### DIFF
--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -17,7 +17,7 @@
 
       <DsfrAlert
         class="mb-4"
-        v-if="payload.author !== loggedUser.id"
+        v-if="payload.author && payload.author !== loggedUser.id"
         type="info"
         title="Cette déclaration est gérée par une autre personne"
       >


### PR DESCRIPTION
Bug remonté par @pletelli :

Lors qu'on crée une déclaration, on voit l'encart d'assignation apparaître.

Cette PR fix ce problème :

[Screencast from 01-10-24 14:33:02.webm](https://github.com/user-attachments/assets/0806bae8-edd0-4f14-8c66-4b418ae8e43d)
