### PR TITLE
Réduction du nombre d'appels SQL pour le calcul de l'article

### DIFF
--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -1240,6 +1240,7 @@ class TestDeclarationApi(APITestCase):
             computed_substances=[],
         )
         DeclaredPlantFactory(new=False, declaration=art_15)
+        art_15.save()
 
         art_15.refresh_from_db()
         self.assertEqual(art_15.article, Declaration.Article.ARTICLE_15)

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Case, Value, When
 from django.db.models.functions import Coalesce
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from dateutil.relativedelta import relativedelta
@@ -564,10 +564,6 @@ class Attachment(Historisable):
     name = models.TextField("nom du fichier", blank=True)
 
 
-@receiver((post_save, post_delete), sender=DeclaredPlant)
-@receiver((post_save, post_delete), sender=DeclaredMicroorganism)
-@receiver((post_save, post_delete), sender=DeclaredSubstance)
-@receiver((post_save, post_delete), sender=DeclaredIngredient)
-@receiver((post_save, post_delete), sender=ComputedSubstance)
+@receiver((post_save), sender=Declaration)
 def update_article(sender, instance, *args, **kwargs):
-    instance.declaration.assign_article()
+    instance.assign_article()

--- a/data/tests/test_declaration.py
+++ b/data/tests/test_declaration.py
@@ -193,6 +193,7 @@ class DeclarationTestCase(TestCase):
         plant_not_autorized = PlantFactory(ca_status=IngredientStatus.NOT_AUTHORIZED)
         DeclaredPlantFactory(plant=plant_not_autorized, declaration=declaration_not_autorized)
 
+        declaration_not_autorized.save()
         declaration_not_autorized.refresh_from_db()
 
         self.assertEqual(declaration_not_autorized.article, Declaration.Article.ARTICLE_16)
@@ -211,6 +212,7 @@ class DeclarationTestCase(TestCase):
         declared_plant.new = False
         declared_plant.save()
 
+        declaration.save()
         declaration.refresh_from_db()
         self.assertEqual(declaration.article, Declaration.Article.ARTICLE_15)
         self.assertEqual(declaration.calculated_article, Declaration.Article.ARTICLE_15)

--- a/data/tests/test_declaration.py
+++ b/data/tests/test_declaration.py
@@ -137,6 +137,7 @@ class DeclarationTestCase(TestCase):
             computed_substances=[],
         )
         DeclaredPlantFactory(new=False, declaration=declaration)
+        declaration.save()
         declaration.refresh_from_db()
 
         self.assertEqual(declaration.article, Declaration.Article.ARTICLE_15)
@@ -175,6 +176,7 @@ class DeclarationTestCase(TestCase):
             computed_substances=[],
         )
         DeclaredPlantFactory(new=True, declaration=declaration_new)
+        declaration_new.save()
         declaration_new.refresh_from_db()
 
         self.assertEqual(declaration_new.article, Declaration.Article.ARTICLE_16)
@@ -225,6 +227,7 @@ class DeclarationTestCase(TestCase):
             quantity=1.2,
             declaration=declaration,
         )
+        declaration.save()
         declaration.refresh_from_db()
         self.assertEqual(declaration.article, Declaration.Article.ARTICLE_17)
         self.assertEqual(declaration.calculated_article, Declaration.Article.ARTICLE_17)


### PR DESCRIPTION
## Problème

Les signals utilisés pour le calcul de l'article se lancent une fois par ingrédient, noyant la base de données et contribuant au N+1.

## Solution

Dans un premier temps, on fera le calcul seulement une fois à chaque sauvegarde de la déclaration.

Par la suite, si besoin, on passera le calcul de l'article aux transitions de la state machine.

## Stats

La réduction des requêtes est d'autour de 60% pour une sauvegarde. Le temps d'exécution côté DB est réduit d'autour de 70%.