### PR TITLE
Recherche dans les pages admin

### DIFF
--- a/data/admin/company.py
+++ b/data/admin/company.py
@@ -5,14 +5,28 @@ from ..models.company import Company, DeclarantRole, SupervisorRole
 
 @admin.register(Company)
 class CompanyAdmin(admin.ModelAdmin):
-    pass
+    search_fields = (
+        "social_name",
+        "commercial_name",
+        "vat",
+        "siret",
+    )
 
 
 @admin.register(SupervisorRole)
 class SupervisorRoleAdmin(admin.ModelAdmin):
-    pass
+    search_fields = (
+        "user__first_name",
+        "user__last_name",
+        "company__social_name",
+    )
 
 
 @admin.register(DeclarantRole)
 class DeclarantRoleAdmin(admin.ModelAdmin):
-    pass
+    search_fields = (
+        "user__first_name",
+        "user__last_name",
+        "company__social_name",
+        "company__commercial_name",
+    )

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -175,6 +175,13 @@ class DeclarationAdmin(admin.ModelAdmin):
         DeclaredSubstanceInline,
         SnapshotInline,
     )
+    search_fields = (
+        "name",
+        "author__first_name",
+        "author__last_name",
+        "company__social_name",
+        "company__commercial_name",
+    )
 
     fieldsets = (
         (

--- a/data/admin/user.py
+++ b/data/admin/user.py
@@ -13,3 +13,10 @@ class UserAdmin(UserAdmin):
     add_fieldsets = UserAdmin.add_fieldsets + (
         (None, {"fields": ("email", "first_name", "last_name", "phone_number")}),
     )
+
+    search_fields = (
+        "first_name",
+        "last_name",
+        "email",
+        "username",
+    )


### PR DESCRIPTION
## Scope

Cette PR ajoute un champ de recherche en haut de la vue liste avec les champs spécifiés ci-dessous. À noter qu'il n'y a pas besoin d'écrire la totalité du terme recherché. Par exemple « AMGU » fera retourner l'entreprise « AMGUILLEN »

### Page Déclarations
##### :mag: Champs de recherche : 
- nom du produit
- nom de l'auteur
- nom de l'entreprise

### Page Entreprise
##### :mag: Champs de recherche :
- nom de l'entreprise
- TVA
- SIRET

### Page rôle gestionnaire
##### :mag: Champs de recherche :
- nom de l'entreprise
- nom de la personne ayant le rôle

### Page rôle déclarant·e
##### :mag: Champs de recherche :
- nom de l'entreprise
- nom de la personne ayant le rôle

### Page utilisateur·ice
##### :mag: Champs de recherche :
- nom de la personne
- adresse email
- nom d'utilisateur·ice

## Démo
[Screencast from 03-10-24 16:36:11.webm](https://github.com/user-attachments/assets/fcaae8df-f426-4757-98b9-f7fc59bb72a8)

