### PR TITLE
Utilisation du `NumberField` pour la Qté par DJR des substances

### DIFF
--- a/frontend/src/views/ProducerFormPage/ElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/ElementCard.vue
@@ -84,7 +84,7 @@
       </div>
       <div v-else-if="objectType === 'substance'" class="ml-12 flex gap-4">
         <DsfrInputGroup class="max-w-28">
-          <DsfrInput label="Qté par DJR" v-model="model.quantity" label-visible :required="true" />
+          <NumberField label="Qté par DJR" v-model="model.quantity" label-visible :required="true" />
         </DsfrInputGroup>
         <div class="mt-12" v-if="model.element?.unit">
           {{ model.element.unit }}


### PR DESCRIPTION
Closes #1135 

Ferme le bug concernant les montants avec virgule dans le champ _Qté par DJR_ des substances :

![image](https://github.com/user-attachments/assets/0d0ef3ef-eb55-4bb9-bbda-99116eca545b)
