### PR TITLE
Demande de preuve de reconnaissance en cas d'article 16 (mode d'autorisation EU)

### DIFF
--- a/api/views/declaration/declaration_flow_validations.py
+++ b/api/views/declaration/declaration_flow_validations.py
@@ -41,7 +41,7 @@ def validate_mandatory_fields(declaration) -> tuple[list, list]:
     substances = list(declaration.declared_substances.all())
 
     all_ingredients = [] + plants + microorganisms + substances + ingredients
-    needs_eu_proof = any(x.authorization_mode == AuthorizationModes.EU for x in all_ingredients)
+    needs_eu_proof = any(x.authorization_mode == AuthorizationModes.EU and x.new for x in all_ingredients)
     if needs_eu_proof and not declaration.attachments.exclude(type=Attachment.AttachmentType.LABEL).exists():
         field_errors.append(
             {

--- a/api/views/declaration/declaration_flow_validations.py
+++ b/api/views/declaration/declaration_flow_validations.py
@@ -1,3 +1,4 @@
+from data.choices import AuthorizationModes
 from data.models import Attachment, Declaration
 
 # Les validateurs dans ce fichier retournent une tuple avec les `field_errors` et les
@@ -34,11 +35,25 @@ def validate_mandatory_fields(declaration) -> tuple[list, list]:
     if not has_label:
         field_errors.append({"attachments": "La demande doit contenir au moins une pièce jointe de l'étiquetage"})
 
-    for declared_plant in declaration.declared_plants.all():
+    plants = list(declaration.declared_plants.all())
+    microorganisms = list(declaration.declared_microorganisms.all())
+    ingredients = list(declaration.declared_ingredients.all())
+    substances = list(declaration.declared_substances.all())
+
+    all_ingredients = [] + plants + microorganisms + substances + ingredients
+    needs_eu_proof = any(x.authorization_mode == AuthorizationModes.EU for x in all_ingredients)
+    if needs_eu_proof and not declaration.attachments.exclude(type=Attachment.AttachmentType.LABEL).exists():
+        field_errors.append(
+            {
+                "attachments": "La demande doit contenir la pièce jointe du texte qui permette de justifier de l’application du principe de reconnaissance mutuelle"
+            }
+        )
+
+    for declared_plant in plants:
         if not declared_plant_is_complete(declared_plant):
             non_field_errors += ["Merci de renseigner les informations manquantes des plantes ajoutées"]
 
-    for declared_microorganism in declaration.declared_microorganisms.all():
+    for declared_microorganism in microorganisms:
         if not declared_microorganism_is_complete(declared_microorganism):
             non_field_errors += ["Merci de renseigner les informations manquantes des micro-organismes ajoutées"]
 

--- a/data/factories/__init__.py
+++ b/data/factories/__init__.py
@@ -30,6 +30,7 @@ from .declaration import (
     AuthorizedDeclarationFactory,
     DeclaredPlantFactory,
     ComputedSubstanceFactory,
+    AttachmentFactory,
 )
 from .solicitation import CollaborationInvitationFactory, CompanyAccessClaimFactory, SupervisionClaimFactory
 from .global_roles import InstructionRoleFactory, VisaRoleFactory

--- a/frontend/src/views/ProducerFormPage/AttachmentTab.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentTab.vue
@@ -19,11 +19,12 @@
 
     <DsfrInputGroup>
       <DsfrFileUpload
-        label="Vous pouvez nous transmettre tout autre document que vous jugez utile à l'examen de votre dossier"
+        :label="otherAttachmentsLabel"
         :acceptTypes="['image/jpeg, image/gif, image/png, application/pdf']"
         hint="Taille maximale du fichier : 2 Mo"
         @change="addOtherFiles"
         v-model="selectedOtherFile"
+        :required="needsEuProof"
       />
     </DsfrInputGroup>
 
@@ -38,6 +39,27 @@ import SectionTitle from "@/components/SectionTitle"
 
 const props = defineProps(["externalResults"])
 const payload = defineModel()
+
+const needsEuProof = computed(() => {
+  return []
+    .concat(
+      payload.value.declaredPlants,
+      payload.value.declaredMicroorganisms,
+      payload.value.declaredIngredients,
+      payload.value.declaredSubstances
+    )
+    .filter((x) => x.new)
+    .some((x) => x.authorizationMode === "EU")
+})
+
+const otherAttachmentsLabel = computed(() => {
+  let label = ""
+  if (needsEuProof.value)
+    label +=
+      "Merci de fournir la pièce jointe du texte qui permette de justifier de l’application du principe de reconnaissance mutuelle (obligation art 16.2°.c) du décret 2006-352.\n"
+  label += "Vous pouvez nous transmettre tout autre document que vous jugez utile à l'examen de votre dossier."
+  return label
+})
 
 const validationError = computed(() => props.externalResults?.[0]?.attachments)
 

--- a/frontend/src/views/ProducerFormPage/NewElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementCard.vue
@@ -73,10 +73,10 @@
             <DsfrInput
               v-model="model.euLegalSource"
               label-visible
-              label="Source réglementaire"
+              label="Lien de la source réglementaire"
               is-textarea
               :required="true"
-              hint="Veuillez préciser la référence exacte du texte réglementaire."
+              hint="Veuillez préciser l'URL du texte réglementaire."
             />
           </DsfrInputGroup>
           <DsfrInputGroup>


### PR DESCRIPTION
Closes #1086 

## Contexte

Les déclarations ayant des nouveaux ingrédients avec `authorization_mode == "EU"` doivent présenter une pièce jointe du texte qui permette de justifier de l’application du principe de reconnaissance mutuelle.

## Scope

#### Frontend
- Changement de label pour demander le lien de la source réglementaire
![image](https://github.com/user-attachments/assets/1d5837c5-efad-4e20-96d8-e2ce5d12888c)
 
- Changement dynamique du label « Autres pièces jointes » en cas de nouvel ingrédient avec `authorization_mode == "EU"` 
![image](https://github.com/user-attachments/assets/12227386-88b5-4653-a621-bdb4ee052ef8)

#### Backend
- Validation lors de la soumission : en cas de nouvel ingrédient avec `authorization_mode == "EU"` une pièce jointe non-étiquetage doit être présente.
![image](https://github.com/user-attachments/assets/576485a7-9c35-439a-ac64-bfb2b5f902be)
