### PR TITLE
Envoi des emails à l'auteur·ice de la déclaration et non pas à la personne ayant effectué l'action

### DIFF
--- a/api/tests/test_flow_emails.py
+++ b/api/tests/test_flow_emails.py
@@ -45,8 +45,8 @@ class TestDeclarationFlow(APITestCase):
         mocked_brevo.assert_called_once_with(
             template_number,
             declaration.brevo_parameters,
-            authenticate.user.email,
-            authenticate.user.get_full_name(),
+            declaration.author.email,
+            declaration.author.get_full_name(),
         )
 
     @authenticate
@@ -63,8 +63,8 @@ class TestDeclarationFlow(APITestCase):
         mocked_brevo.assert_called_once_with(
             template_number,
             declaration.brevo_parameters,
-            authenticate.user.email,
-            authenticate.user.get_full_name(),
+            declaration.author.email,
+            declaration.author.get_full_name(),
         )
 
     @authenticate
@@ -81,8 +81,8 @@ class TestDeclarationFlow(APITestCase):
         mocked_brevo.assert_called_once_with(
             template_number,
             declaration.brevo_parameters,
-            authenticate.user.email,
-            authenticate.user.get_full_name(),
+            declaration.author.email,
+            declaration.author.get_full_name(),
         )
 
     @authenticate
@@ -117,8 +117,8 @@ class TestDeclarationFlow(APITestCase):
         mocked_brevo.assert_called_once_with(
             template_number,
             declaration.brevo_parameters,
-            authenticate.user.email,
-            authenticate.user.get_full_name(),
+            declaration.author.email,
+            declaration.author.get_full_name(),
         )
 
     @authenticate
@@ -140,8 +140,8 @@ class TestDeclarationFlow(APITestCase):
         mocked_brevo.assert_called_once_with(
             template_number,
             declaration.brevo_parameters,
-            authenticate.user.email,
-            authenticate.user.get_full_name(),
+            declaration.author.email,
+            declaration.author.get_full_name(),
         )
 
     @authenticate
@@ -163,8 +163,8 @@ class TestDeclarationFlow(APITestCase):
         mocked_brevo.assert_called_once_with(
             template_number,
             declaration.brevo_parameters,
-            authenticate.user.email,
-            authenticate.user.get_full_name(),
+            declaration.author.email,
+            declaration.author.get_full_name(),
         )
 
     @authenticate
@@ -186,8 +186,8 @@ class TestDeclarationFlow(APITestCase):
         mocked_brevo.assert_called_once_with(
             template_number,
             declaration.brevo_parameters,
-            authenticate.user.email,
-            authenticate.user.get_full_name(),
+            declaration.author.email,
+            declaration.author.get_full_name(),
         )
 
     @authenticate
@@ -203,8 +203,8 @@ class TestDeclarationFlow(APITestCase):
         mocked_brevo.assert_called_once_with(
             template_number,
             declaration.brevo_parameters,
-            authenticate.user.email,
-            authenticate.user.get_full_name(),
+            declaration.author.email,
+            declaration.author.get_full_name(),
         )
 
     def test_expire_observed_declaration(self, mocked_brevo):

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -481,13 +481,13 @@ class DeclarationFlowView(GenericAPIView):
         if self.create_snapshot:
             self.perform_snapshot_creation(request, declaration)
         self.on_transition_success(request, declaration)
-        if brevo_template_id:
+        if brevo_template_id and declaration.author:
             try:
                 email.send_sib_template(
                     brevo_template_id,
                     self.get_brevo_parameters(request, declaration),
-                    request.user.email,
-                    request.user.get_full_name(),
+                    declaration.author.email,
+                    declaration.author.get_full_name(),
                 )
             except Exception as e:
                 logger.error(f"Email not sent on transition {self.get_transition(request, declaration)}")


### PR DESCRIPTION
## Contexte

Les emails transactionnels liés au changement de statut d'une déclaration étaient envoyés à la personne ayant effectué l'action et non pas à l'auteur·ice de la déclaration.

Ceci avait comme effet que les instructrices recevaient les emails à destination des pros.

## Scope

Changer pour toujours utiliser l'email de l'auteur·ice de la déclaration dans la view « declarationFlow »