### PR TITLE
Résolution des bugs changement de données lors de l'ajout d'un ingrédient et `None Value comparison`

### DIFF
--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -321,7 +321,7 @@ class Declaration(Historisable, TimeStampable):
             surpasses_max_dose = any(
                 x.quantity > x.substance.max_quantity
                 for x in self.computed_substances.all()
-                if x.substance.max_quantity and x.substance.unit == x.unit
+                if x.quantity and x.substance.max_quantity and x.substance.unit == x.unit
                 # TODO: vérifier si ce cas est possible, sinon enlever l'unit du ComputedSubstance
             )
 

--- a/frontend/src/views/ProducerFormPage/ElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/ElementCard.vue
@@ -38,7 +38,7 @@
           <DsfrSelect
             label="Partie utilisée"
             defaultUnselectedText=""
-            v-model="model.usedPart"
+            v-model.number="model.usedPart"
             :options="plantParts"
             :required="true"
           />
@@ -50,7 +50,7 @@
           <DsfrSelect
             label="Unité"
             :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
-            v-model="model.unit"
+            v-model.number="model.unit"
             defaultUnselectedText=""
             :required="true"
           />
@@ -59,7 +59,7 @@
           <DsfrSelect
             label="Préparation"
             :options="store.preparations?.map((preparation) => ({ text: preparation.name, value: preparation.id }))"
-            v-model="model.preparation"
+            v-model.number="model.preparation"
             defaultUnselectedText=""
             :required="true"
           />
@@ -94,7 +94,7 @@
             <DsfrSelect
               label="Unité"
               :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
-              v-model="model.unit"
+              v-model.number="model.unit"
               defaultUnselectedText=""
               :required="true"
             />
@@ -109,7 +109,7 @@
           <DsfrSelect
             label="Unité"
             :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
-            v-model="model.unit"
+            v-model.number="model.unit"
             defaultUnselectedText=""
             :required="true"
           />


### PR DESCRIPTION
## Scope

Cette PR adresse deux bugs :

### 1. Perte de données lors de l'ajout d'un second ingrédient

https://github.com/user-attachments/assets/9724486d-6a87-4860-9213-b6fddfe89c64

**Solution :** Lors de l'ajout d'un nouvel ingrédient les attributs retournés par le DsfrSelect étaient des ID en mode string. Par exemple : `"34"` au lieu de `34`. Ceci faisait que les selects mettaient le premier élément. Ça se règle en mettant le [modifier number](https://vuejs.org/guide/essentials/forms#number) pour s'assurer que les IDs retournés des selects restent en type numérique.

### 2. TypeError: '>' not supported between instances of 'NoneType' and 'float'

On avait eu une erreur similaire par le passé suite à la sauvegarde de la déclaration avec des valeurs nullables non settés. Lors que ceci arrive, la comparaison qu'on fait sur l'assignation de l'article échoue. 

Ce n'est pas une erreur très embêtant car ça n'a pas d'incidence dans la sauvegarde de la déclaration ni dans l'affichage à l'utilisateur·ice, mais ça arrive sur notre Sentry.