### PR TITLE
Le cas spécifique des aloïnes et aloe émodines avec une quantité maxi à 0

### DIFF
--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -324,11 +324,11 @@ class Declaration(Historisable, TimeStampable):
             surpasses_max_dose = any(
                 x.quantity > x.substance.max_quantity
                 for x in self.computed_substances.all()
-                if x.quantity and x.substance.max_quantity and x.substance.unit == x.unit
+                if x.quantity is not None and x.substance.max_quantity is not None and x.substance.unit == x.unit
             ) or any(
                 x.quantity > x.substance.max_quantity
                 for x in self.declared_substances.all()
-                if x.quantity and x.substance.max_quantity and x.substance.unit == x.unit
+                if x.quantity is not None and x.substance.max_quantity is not None and x.substance.unit == x.unit
             )
 
             if empty_composition:

--- a/frontend/src/components/SubstancesTable.vue
+++ b/frontend/src/components/SubstancesTable.vue
@@ -43,7 +43,8 @@
           <div
             :class="{
               '!text-red-marianne-425 font-bold':
-                payload.computedSubstances[rowIndex].substance.maxQuantity &&
+                (payload.computedSubstances[rowIndex].substance.maxQuantity ||
+                  payload.computedSubstances[rowIndex].substance.maxQuantity === 0) &&
                 payload.computedSubstances[rowIndex].quantity >=
                   payload.computedSubstances[rowIndex].substance.maxQuantity,
             }"
@@ -52,7 +53,8 @@
             {{ payload.computedSubstances[rowIndex].quantity }}
             <span
               v-if="
-                payload.computedSubstances[rowIndex].substance.maxQuantity &&
+                (payload.computedSubstances[rowIndex].substance.maxQuantity ||
+                  payload.computedSubstances[rowIndex].substance.maxQuantity === 0) &&
                 payload.computedSubstances[rowIndex].quantity >=
                   payload.computedSubstances[rowIndex].substance.maxQuantity
               "

--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -144,12 +144,13 @@ const status = computed(() =>
   ["autorisé", "non autorisé"].includes(element.value?.status) ? element.value?.status : null
 )
 const nutritionalReference = computed(() => {
-  if (element.value?.unit && element.value?.nutritionalReference)
+  if (element.value?.unit && (element.value?.nutritionalReference || element.value.nutritionalReference == 0))
     return element.value?.nutritionalReference + " " + element.value?.unit
   else return null
 })
 const maxQuantity = computed(() => {
-  if (element.value?.unit && element.value?.maxQuantity) return element.value?.maxQuantity + " " + element.value?.unit
+  if (element.value?.unit && (element.value?.maxQuantity || element.value.maxQuantity == 0))
+    return element.value?.maxQuantity + " " + element.value?.unit
   else return null
 })
 const description = computed(() => element.value?.description)


### PR DESCRIPTION
3 substances sont concernées par une quantité max à 0 :
* aloé émodine
* aloïnes
* émodine

Aujourd'hui, les déclarants doivent renseigner la quantité (qui est infinitésimale) mais la déclaration :
* ne passait pas en article `saisine ANSES`
* n'affichait pas le dépassement en rouge

En plus, on affiche aussi maintenant la quantité max à 0 sur la page de l'élement dans le moteur de recherche.