### PR TITLE
Spécification des champs "Autre" dans les raison d'objection

### DIFF
--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -27,7 +27,7 @@
     <div v-if="decisionCategory === 'modify'" class="reject-reasons">
       <hr />
       <DsfrInputGroup :error-message="firstErrorMsg(v$, 'reasons')">
-        <div class="mb-8" v-for="reason in rejectReasons" :key="reason.title">
+        <div class="mb-8" v-for="reason in blockingReasons" :key="reason.title">
           <p class="font-bold">{{ reason.title }}</p>
           <DsfrCheckboxSet
             v-model="reasons"
@@ -152,7 +152,7 @@ const decisionCategories = [
   },
 ]
 
-const rejectReasons = [
+const blockingReasons = [
   {
     title: "Le produit ne répond pas à la définition du complément alimentaire",
     items: [

--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -159,7 +159,7 @@ const rejectReasons = [
       "Forme assimilable à un aliment courant",
       "Recommandations d'emploi incompatibles",
       "Composition (source concentrée, ...)",
-      "Autre",
+      "Autre raison pour laquelle le produit ne répond pas à la définition du complément alimentaire",
     ],
   },
   {
@@ -182,7 +182,7 @@ const rejectReasons = [
       "Informations manquantes",
       "Absence de preuve de reconnaissance mutuelle",
       "Absence ou non conformité de l'étiquetage",
-      "Autre",
+      "Autre motif d'irrecevabilité",
     ],
   },
   {


### PR DESCRIPTION
Closes #1144 

Les 2 champs autres interferaient : si l'un était coché, l'autre aussi.
En plus il aurait été impossible de savoir lequel des 2 a été coché lors de l'analyse.