### PR TITLE
Génère le certificat d'objection.

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -19,7 +19,6 @@ from data.models import (
     Plant,
     PlantPart,
     Population,
-    Snapshot,
     Substance,
     SubstanceUnit,
 )
@@ -322,7 +321,7 @@ class DeclarationSerializer(serializers.ModelSerializer):
     computed_substances = DeclaredListSerializer(child=ComputedSubstanceSerializer(), required=False)
     attachments = DeclaredListSerializer(child=AttachmentSerializer(), required=False)
     name = serializers.CharField(allow_blank=False, required=True)
-    blocking_reasons = serializers.SerializerMethodField(read_only=True)
+    blocking_reasons = serializers.ListField(read_only=True)
 
     class Meta:
         model = Declaration
@@ -468,13 +467,6 @@ class DeclarationSerializer(serializers.ModelSerializer):
         if not can_see_private_notes:
             ret.pop("private_notes")
         return ret
-
-    def get_blocking_reasons(self, obj):
-        try:
-            latest_snapshot = obj.snapshots.filter(blocking_reasons__isnull=False).latest("creation_date")
-            return latest_snapshot.blocking_reasons
-        except Snapshot.DoesNotExist:
-            return None
 
 
 class DeclarationShortSerializer(serializers.ModelSerializer):

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -207,6 +207,16 @@ class Declaration(Historisable, TimeStampable):
         )
 
     @property
+    def blocking_reasons(self):
+        from data.models import Snapshot
+
+        try:
+            latest_snapshot = self.snapshots.filter(blocking_reasons__isnull=False).latest("creation_date")
+            return latest_snapshot.blocking_reasons
+        except Snapshot.DoesNotExist:
+            return None
+
+    @property
     def json_representation(self):
         from api.serializers import DeclarationSerializer
 

--- a/frontend/src/components/DeclarationAlert.vue
+++ b/frontend/src/components/DeclarationAlert.vue
@@ -70,7 +70,7 @@ const declarantDisplayData = computed(() => {
         title: "Une objection a été emise sur cette déclaration",
         expirationDate: props.declaration?.expirationDate,
         body: blockingReasons.value,
-        canDownloadCertificate: false,
+        canDownloadCertificate: true,
       }
     case "OBSERVATION":
       return {

--- a/frontend/src/components/DeclarationAlert.vue
+++ b/frontend/src/components/DeclarationAlert.vue
@@ -67,7 +67,7 @@ const declarantDisplayData = computed(() => {
     case "OBJECTION":
       return {
         type: "warning",
-        title: "Une objection a été emise sur cette déclaration",
+        title: "Une objection a été émise sur cette déclaration",
         expirationDate: props.declaration?.expirationDate,
         body: blockingReasons.value,
         canDownloadCertificate: true,
@@ -75,7 +75,7 @@ const declarantDisplayData = computed(() => {
     case "OBSERVATION":
       return {
         type: "warning",
-        title: "Une observation a été emise sur cette déclaration",
+        title: "Une observation a été émise sur cette déclaration",
         expirationDate: props.declaration?.expirationDate,
         body: blockingReasons.value,
         canDownloadCertificate: false,
@@ -125,14 +125,14 @@ const instructorDisplayData = computed(() => {
     case "OBJECTION":
       return {
         type: "info",
-        title: "Une objection a été emise sur cette déclaration",
+        title: "Une objection a été émise sur cette déclaration",
         body: blockingReasons.value,
-        canDownloadCertificate: false,
+        canDownloadCertificate: true,
       }
     case "OBSERVATION":
       return {
         type: "warning",
-        title: "Une observation a été emise sur cette déclaration",
+        title: "Une observation a été émise sur cette déclaration",
         body: blockingReasons.value,
         canDownloadCertificate: false,
       }
@@ -181,14 +181,14 @@ const visorDisplayData = computed(() => {
     case "OBJECTION":
       return {
         type: "info",
-        title: "Une objection a été emise sur cette déclaration",
+        title: "Une objection a été émise sur cette déclaration",
         body: blockingReasons.value,
-        canDownloadCertificate: false,
+        canDownloadCertificate: true,
       }
     case "OBSERVATION":
       return {
         type: "warning",
-        title: "Une observation a été emise sur cette déclaration",
+        title: "Une observation a été émise sur cette déclaration",
         body: blockingReasons.value,
         canDownloadCertificate: false,
       }

--- a/web/templates/certificates/certificate-objected.html
+++ b/web/templates/certificates/certificate-objected.html
@@ -1,7 +1,7 @@
 {% extends 'certificates/certificate-base-template.html' %}
 {% block 'body' %}
 <h1 style="font-family: 'Marianne-Bold'; font-weight: bold;">
-    Réf. : n° {{declaration.id}}
+    Réf. : Dossier n° {{declaration.id}}
 </h1>
 <div style="font-size: 1.2em;">
     <p>
@@ -10,13 +10,17 @@
     <p>
         Le {{ last_submission_date|date:"l j F Y" }}, vous avez déclaré la mise sur le marché du produit :
         <span style="font-family: 'Marianne-Bold'; font-weight: bold;">
-            {{ declaration.name }}
+            {{ declaration.name }} / {{ declaration.galenic_formulation }}
         </span>
     <p>
-        L’examen de cette déclaration soulève les objections suivantes, qui la rendent irrecevable:
-        <span style="font-family: 'Marianne-Bold'; font-weight: bold;"></span>
-            {{ declaration.objection }}
+        L’examen de cette déclaration soulève les objections suivantes, qui la rendent irrecevable :
+        <span style="font-family: 'Marianne-Bold'; font-weight: bold;">
+            <br>
+            {% for reason in declaration.blocking_reasons %}
+                - {{ reason }}<br>
+            {% endfor %}
         </span>
+
     </p>
     <p>
         Vous disposez d’un délai de 30 jours francs, à compter de la date de réception de la présente lettre, pour régulariser votre déclaration ou me faire part de vos observations.

--- a/web/templates/certificates/certificate-objected.html
+++ b/web/templates/certificates/certificate-objected.html
@@ -1,0 +1,43 @@
+{% extends 'certificates/certificate-base-template.html' %}
+{% block 'body' %}
+<h1 style="font-family: 'Marianne-Bold'; font-weight: bold;">
+    Réf. : n° {{declaration.id}}
+</h1>
+<div style="font-size: 1.2em;">
+    <p>
+        Madame, Monsieur,
+    </p>
+    <p>
+        Le {{ last_submission_date|date:"l j F Y" }}, vous avez déclaré la mise sur le marché du produit :
+        <span style="font-family: 'Marianne-Bold'; font-weight: bold;">
+            {{ declaration.name }}
+        </span>
+    <p>
+        L’examen de cette déclaration soulève les objections suivantes, qui la rendent irrecevable:
+        <span style="font-family: 'Marianne-Bold'; font-weight: bold;"></span>
+            {{ declaration.objection }}
+        </span>
+    </p>
+    <p>
+        Vous disposez d’un délai de 30 jours francs, à compter de la date de réception de la présente lettre, pour régulariser votre déclaration ou me faire part de vos observations.
+        Vous pouvez vous faire assister ou représenter par le conseil de votre choix.
+    </p>
+    <p>
+        En l’absence de réponse de votre part dans ce délai, le dossier sera clos et la déclaration sera réputée rejetée.
+    </p>
+    <p>
+        Je vous rappelle, à toutes fins utiles, que l’article 20 du décret du décret du 20 mars 2006 précité vous interdit d’importer pour la mise en libre pratique,
+        de détenir en vue de la vente ou de la distribution à titre gratuit, de mettre en vente, de vendre ou de distribuer à titre gratuit un complément alimentaire qui n’a pas été dûment déclaré.
+    </p>
+    <p>
+        Je vous prie d’agréer, Madame, Monsieur, l’expression de ma considération distinguée.
+    </p>
+    <p style="padding-left: 10cm;">
+        La Sous-Directrice de la sécurité sanitaire<br />
+        des aliments
+    </p>
+    <p style="padding-left: 10cm;">
+        Vanessa HUMMEL-FOURRAT
+    </p>
+</div>
+{% endblock %}

--- a/web/templates/certificates/certificate-rejected.html
+++ b/web/templates/certificates/certificate-rejected.html
@@ -1,7 +1,7 @@
 {% extends 'certificates/certificate-base-template.html' %}
 {% block 'body' %}
 <h1 style="font-family: 'Marianne-Bold'; font-weight: bold;">
-    Réf. : n° {{declaration.id}}
+    Réf. : Dossier n° {{declaration.id}}
 </h1>
 <div style="font-size: 1.2em;">
     <p>
@@ -10,7 +10,7 @@
     <p>
         Le {{ last_submission_date|date:"l j F Y" }}, vous avez déclaré la mise sur le marché du produit :
         <span style="font-family: 'Marianne-Bold'; font-weight: bold;">
-            {{ declaration.name }}
+            {{ declaration.name }} / {{ declaration.galenic_formulation }}
         </span>
     <p>
         Des objections ont été émises à l’égard de cette déclaration. Toutefois, les éléments apportés

--- a/web/templates/certificates/certificate-rejected.html
+++ b/web/templates/certificates/certificate-rejected.html
@@ -13,11 +13,11 @@
             {{ declaration.name }}
         </span>
     <p>
-        Des objections ont été émises à l’égard de cette déclaration. Aucune observation apportée n'a
-        été de nature à remettre en cause les objections opposées à la déclaration
+        Des objections ont été émises à l’égard de cette déclaration. Toutefois, les éléments apportés
+        à cette occasion ne sont pas de nature à remettre en cause les objections opposées à la déclaration.
     </p>
     <p>
-        Votre déclaration est donc refusée. En application de l’article 20 du décret n°2006-352 du décret du 20 mars 2006,
+        Votre déclaration est donc refusée. En application de l’article 20 du décret n°2006-352 du 20 mars 2006,
         il vous est interdit d’importer pour la mise en libre pratique, de détenir en vue de la vente ou de la distribution à
         titre gratuit, de mettre en vente, de vendre ou de distribuer à titre gratuit le complément alimentaire cité ci-dessus.
     </p>

--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -53,6 +53,8 @@ class CertificateView(GenericAPIView):
             return f"certificates/certificate-submitted-art-{article}.html"
         if declaration.status in [status.AUTHORIZED, status.WITHDRAWN]:
             return f"certificates/certificate-art-{article}.html"
+        if declaration.status == status.OBJECTION:
+            return "certificates/certificate-objected.html"
         if declaration.status == status.REJECTED:
             return "certificates/certificate-rejected.html"
 


### PR DESCRIPTION
[Ticket lié](https://www.notion.so/betagouv-dinum/Quickwin-Revoir-les-courriers-des-d-objections-4e207a06ab094a69a87c0aff40facc0d)

La blocking_reasons des Objections n'était pas reportée une fois le visa obtenu sur ne snapshot de déclaration une fois le visa passé.


Une fois la PR en prod, je changerais le courrier template Brevo Instruction - Objection :

_Pour consulter les détails de cette décision et y répondre, veuillez cliquer sur le bouton ci-dessous :_ ->
_Pour connaître les raisons de cette objection, nous vous invitons à prendre connaissance du courrier disponible dans votre espace personnel. Pour y accéder :_