### PR TITLE
Changement de l'ordre des onglets

### DIFF
--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -139,9 +139,8 @@ onMounted(async () => {
 
 // Tab management
 const components = computed(() => {
-  const baseComponents = [DeclarationSummary, HistoryTab]
+  const baseComponents = [IdentityTab, DeclarationSummary, HistoryTab]
   if (canInstruct.value) baseComponents.push(DecisionTab)
-  baseComponents.push(IdentityTab)
   return baseComponents
 })
 const titles = computed(() => tabTitles(components.value))

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -135,9 +135,8 @@ onMounted(async () => {
 
 // Tab management
 const components = computed(() => {
-  const baseComponents = [DeclarationSummary, HistoryTab]
+  const baseComponents = [IdentityTab, DeclarationSummary, HistoryTab]
   if (canInstruct.value) baseComponents.push(VisaValidationTab)
-  baseComponents.push(IdentityTab)
   return baseComponents
 })
 const titles = computed(() => tabTitles(components.value))


### PR DESCRIPTION
Closes #1158 

## Scope

Retour à l'ordre original des onglets : _Identité / Produit/ Historique / Décision_

#### Captures d'écran

##### Instruction
![image](https://github.com/user-attachments/assets/f21c74fa-2eb2-4fab-bf26-72943536d67d)


##### Visa 
![image](https://github.com/user-attachments/assets/aeb3de3a-ea89-44c1-82ab-14bccf63c763)
