### PR TITLE
:lady_beetle:  Correction des permissions pour les viseuses et instructrices

### DIFF
--- a/api/views/company.py
+++ b/api/views/company.py
@@ -20,7 +20,7 @@ from data.utils.external_utils import SiretData
 from data.validators import validate_siret, validate_vat  # noqa
 
 from ..exception_handling import ProjectAPIException
-from ..permissions import IsSupervisor, IsSupervisorOrInstructor
+from ..permissions import IsSupervisor, IsSupervisorOrAgent
 from ..serializers import CollaboratorSerializer, CompanySerializer
 
 User = get_user_model()
@@ -159,7 +159,7 @@ class CompanyRetrieveUpdateView(RetrieveUpdateAPIView):
 
     def get_permissions(self):
         if self.request.method in permissions.SAFE_METHODS:
-            return [IsAuthenticated(), IsSupervisorOrInstructor()]
+            return [IsAuthenticated(), IsSupervisorOrAgent()]
         else:
             return [IsAuthenticated(), IsSupervisor()]
 

--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -10,14 +10,14 @@ from rest_framework.exceptions import NotFound
 from rest_framework.generics import GenericAPIView
 from xhtml2pdf import pisa
 
-from api.permissions import IsDeclarationAuthor
+from api.permissions import CanAccessIndividualDeclaration
 from data.models import Declaration
 
 logger = logging.getLogger(__name__)
 
 
 class CertificateView(GenericAPIView):
-    permission_classes = [IsDeclarationAuthor]
+    permission_classes = [CanAccessIndividualDeclaration]
     queryset = Declaration.objects.all()
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
Closes #1160 

## Scope

- S'assure que les ressources API accessibles par le rôle _instruction_ le soient aussi avec le rôle _visa_.
- L'accès aux certificats PDF ont les mêmes conditions (permissions) que l'accès à la déclaration elle même.