### PR TITLE
Ajout des rôles entreprise dans la page admin

### DIFF
--- a/data/admin/user.py
+++ b/data/admin/user.py
@@ -2,6 +2,24 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 
+from data.models import DeclarantRole, SupervisorRole
+
+
+class DeclarantRoleInline(admin.TabularInline):
+    model = DeclarantRole
+    fields = ("company",)
+    readonly_fields = fields
+    extra = 0
+    can_delete = False
+
+
+class SupervisorRoleInline(admin.TabularInline):
+    model = SupervisorRole
+    fields = ("company",)
+    readonly_fields = fields
+    extra = 0
+    can_delete = False
+
 
 @admin.register(get_user_model())
 class UserAdmin(UserAdmin):
@@ -19,4 +37,9 @@ class UserAdmin(UserAdmin):
         "last_name",
         "email",
         "username",
+    )
+
+    inlines = (
+        DeclarantRoleInline,
+        SupervisorRoleInline,
     )


### PR DESCRIPTION
Closes #1167 

## Scope

Permet de visualiser les différents rôles entreprise d'un·e utilisateur·ice dans sa page admin.

## Capture d'écran

![image](https://github.com/user-attachments/assets/f5db2d2c-ee9a-4987-a3fb-1601f279fd52)
