### PR TITLE
Affichage des jours d'expiration seulement pour observation et objection

### DIFF
--- a/frontend/src/views/VisaPage/VisaValidationTab.vue
+++ b/frontend/src/views/VisaPage/VisaValidationTab.vue
@@ -11,6 +11,7 @@
           :text="declaration.postValidationProducerMessage || '< sans commentaire >'"
         />
         <VisaInfoLine
+          v-if="showExpirationDays"
           title="Délai de réponse"
           icon="ri-time-fill"
           :text="declaration.postValidationExpirationDays || '< non spécifié >'"
@@ -67,6 +68,10 @@ const privateNotes = ref(declaration.value?.privateNotes || "")
 
 const instructorName = computed(
   () => `${declaration.value?.instructor?.firstName} ${declaration.value?.instructor?.lastName}`
+)
+const showExpirationDays = computed(
+  () =>
+    declaration.value.postValidationStatus === "OBJECTION" || declaration.value.postValidationStatus === "OBSERVATION"
 )
 const postValidationStatus = computed(() => statusProps[declaration.value.postValidationStatus].label)
 const refuseVisa = async () => {


### PR DESCRIPTION
Closes #1170

## Contexte

Dans l'écran de visa/signature, le délai de réponse est affiché même lors que celui-ci n'a pas de sens : par exemple lors de l'approbation ou le refus

## Scope

La ligne concernant le délai de réponse n'est affichée que si le statut à valider est l'observation ou l'objection.

![image](https://github.com/user-attachments/assets/62f3e6ae-8880-49f9-82ee-932bdb91551c)
