### PR TITLE
Ajout d'une vérification supplémentaire lors du calcul de l'article

### DIFF
--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -337,11 +337,17 @@ class Declaration(Historisable, TimeStampable):
             surpasses_max_dose = any(
                 x.quantity > x.substance.max_quantity
                 for x in self.computed_substances.all()
-                if x.quantity is not None and x.substance.max_quantity is not None and x.substance.unit == x.unit
+                if x.substance
+                and x.quantity is not None
+                and x.substance.max_quantity is not None
+                and x.substance.unit == x.unit
             ) or any(
                 x.quantity > x.substance.max_quantity
                 for x in self.declared_substances.all()
-                if x.quantity is not None and x.substance.max_quantity is not None and x.substance.unit == x.unit
+                if x.substance
+                and x.quantity is not None
+                and x.substance.max_quantity is not None
+                and x.substance.unit == x.unit
             )
 
             if empty_composition:


### PR DESCRIPTION
Suite à une remontée Sentry : 

```
AttributeError: 'NoneType' object has no attribute 'max_quantity'
  File "data/models/declaration.py", line 332, in assign_calculated_article
    ) or any(
  File "data/models/declaration.py", line 335, in <genexpr>
    if x.quantity is not None and x.substance.max_quantity is not None and x.substance.unit == x.unit
```