### PR TITLE
Fix du souci lors de l'approbation des déclarations

### DIFF
--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -210,7 +210,7 @@ const submitDecision = async () => {
 
   const actions = {
     observation: "observe",
-    approve: "authorize",
+    autorisation: "authorize",
     objection: "object",
     rejection: "reject",
   }


### PR DESCRIPTION
Closes #1200 

## Scope

On avait un dictionnaire des actions URL qui ne correspondait pas à la valeur de la prop `proposal` 