### PR TITLE
Permet aux viseuses de modifier le commentaire pour le pro

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -371,6 +371,7 @@ class DeclarationSerializer(serializers.ModelSerializer):
             "private_notes",
             "blocking_reasons",
             "expiration_date",
+            "last_administration_comment",
         )
         read_only_fields = (
             "id",

--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -658,6 +658,44 @@ class TestDeclarationFlow(APITestCase):
         self.assertEqual(latest_snapshot.expiration_days, 23)
 
     @authenticate
+    def test_visor_can_modify_comment(self):
+        """
+        Une personne avec le rôle de visa peut modifier le commentaire à destination du pro
+        """
+        VisaRoleFactory(user=authenticate.user)
+
+        # Visa acceptée
+        declaration = OngoingVisaDeclarationFactory(
+            post_validation_status=Declaration.DeclarationStatus.AUTHORIZED,
+            post_validation_producer_message="À authoriser",
+            post_validation_expiration_days=12,
+        )
+
+        response = self.client.post(
+            reverse("api:accept_visa", kwargs={"pk": declaration.id}), {"comment": "Overriden comment"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        declaration.refresh_from_db()
+        self.assertEqual(declaration.last_administration_comment, "Overriden comment")
+
+        # Visa refusée
+        declaration = OngoingVisaDeclarationFactory(
+            post_validation_status=Declaration.DeclarationStatus.REJECTED,
+            post_validation_producer_message="À refuser",
+            post_validation_expiration_days=20,
+        )
+
+        response = self.client.post(
+            reverse("api:refuse_visa", kwargs={"pk": declaration.id}),
+            {"comment": "Overriden comment 2"},
+            format="json",
+        )
+
+        declaration.refresh_from_db()
+        self.assertEqual(declaration.last_administration_comment, "Overriden comment 2")
+
+    @authenticate
     def accept_visa_unauthorized(self):
         """
         Passage de ONGOING_VISA à à { AUTHORIZED | REJECTED | OBJECTION | OBSERVATION }

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -626,6 +626,7 @@ class DeclarationRefuseVisaView(VisaDecisionView):
         declaration.create_snapshot(
             user=request.user,
             action=self.get_snapshot_action(request, declaration),
+            comment=request.data.get("comment", declaration.post_validation_producer_message),
             post_validation_status=self.get_snapshot_post_validation_status(request, declaration),
         )
 
@@ -647,7 +648,7 @@ class DeclarationAcceptVisaView(VisaDecisionView):
         """
         declaration.create_snapshot(
             user=request.user,
-            comment=declaration.post_validation_producer_message,
+            comment=request.data.get("comment", declaration.post_validation_producer_message),
             expiration_days=declaration.post_validation_expiration_days,
             action=self.get_snapshot_action(request, declaration),
             post_validation_status=self.get_snapshot_post_validation_status(request, declaration),

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -218,10 +218,18 @@ class Declaration(Historisable, TimeStampable):
     def last_administration_comment(self):
         from data.models import Snapshot
 
+        admin_actions = [
+            Snapshot.SnapshotActions.OBSERVE_NO_VISA,
+            Snapshot.SnapshotActions.AUTHORIZE_NO_VISA,
+            Snapshot.SnapshotActions.REQUEST_VISA,
+            Snapshot.SnapshotActions.ACCEPT_VISA,
+            Snapshot.SnapshotActions.REFUSE_VISA,
+        ]
+
         try:
-            latest_snapshot = self.snapshots.filter(
-                comment__isnull=False, action__in=["OBSERVE_NO_VISA", "APPROVE_VISA"]
-            ).latest("creation_date")
+            latest_snapshot = self.snapshots.filter(comment__isnull=False, action__in=admin_actions).latest(
+                "creation_date"
+            )
             return latest_snapshot.comment
         except Snapshot.DoesNotExist:
             return None

--- a/frontend/src/components/HistoryTab.vue
+++ b/frontend/src/components/HistoryTab.vue
@@ -46,6 +46,7 @@ const snapshots = computed(() => {
       "AUTHORIZE_NO_VISA",
       "RESPOND_TO_OBSERVATION",
       "RESPOND_TO_OBJECTION",
+      "APPROVE_VISA",
       "WITHDRAW",
       "ABANDON",
     ]

--- a/frontend/src/components/SnapshotItem.vue
+++ b/frontend/src/components/SnapshotItem.vue
@@ -61,7 +61,7 @@ const isAdministrativeAction = computed(() => {
     "AUTHORIZE_NO_VISA",
     "REQUEST_VISA",
     "TAKE_FOR_VISA",
-    "ACCEPT_VISA",
+    "APPROVE_VISA",
     "REFUSE_VISA",
   ]
   return instructionActions.indexOf(props.snapshot.action) > -1
@@ -85,7 +85,7 @@ const actionText = computed(() => {
     RESPOND_TO_OBSERVATION: "a répondu aux observations",
     RESPOND_TO_OBJECTION: "a répondu aux objections",
     REQUEST_VISA: `a demandé un visa pour passer à l'état « ${statusProps[props.snapshot.postValidationStatus]?.label} »`,
-    ACCEPT_VISA: `a accepté le visa pour passer à l'état « ${statusProps[props.snapshot.postValidationStatus]?.label} »`,
+    APPROVE_VISA: `a mis la déclaration en état « ${statusProps[props.snapshot.postValidationStatus]?.label} »`,
     REFUSE_VISA: `a refusé le visa pour passer à l'état « ${statusProps[props.snapshot.postValidationStatus]?.label} »`,
     WITHDRAW: "a retiré le produit du marché",
   }

--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -115,7 +115,7 @@ const rules = computed(() => {
 const declaration = defineModel()
 const proposal = ref(null)
 const delayDays = ref(15)
-const comment = ref("")
+const comment = ref(declaration.value?.lastAdministrationComment || "")
 const reasons = ref([])
 const privateNotes = ref(declaration.value?.privateNotes || "")
 

--- a/frontend/src/views/VisaPage/VisaInfoLine.vue
+++ b/frontend/src/views/VisaPage/VisaInfoLine.vue
@@ -5,7 +5,9 @@
       <span>{{ title }}</span>
     </div>
     <div class="comment sm:flex-auto">
-      {{ text }}
+      <slot name="value">
+        {{ text }}
+      </slot>
     </div>
   </div>
 </template>
@@ -16,5 +18,8 @@ defineProps(["icon", "title", "text"])
 <style scoped>
 .comment {
   white-space: pre-line;
+}
+.comment :deep(.fr-input-group) {
+  @apply !mt-0;
 }
 </style>


### PR DESCRIPTION
Closes #1202
Closes #1199

## Contexte

Aujourd'hui la viseuse ne peut pas modifier le commentaire à destination des professionnels qui sera pris en compte après l'acceptation ou le refus de la décision de l'instructrice.

## Scope

Le commentaire est maintenant éditable. Côté UI, l'onglet décision de l'instructrice aura le champ _commentaire à destination du professionnel_ prérempli avec la valeur.

## Démo

### Étape 1 : L'instructrice émet une décision à faire valider par un visa

https://github.com/user-attachments/assets/100d4067-9d69-47c9-abdb-924fa67d762e

### Étape 2 : La viseuse modifie le commentaire et le renvoie à l'instructrice

https://github.com/user-attachments/assets/ea25ae0d-26cb-4681-96fc-5041a5c2d94e

### Étape 3 : L'instructrice a le nouveau commentaire prérempli dans la UI

https://github.com/user-attachments/assets/b0309cb1-866b-4cbd-b1cc-ab564bf1c6b7



