### PR TITLE
Le mot "sauvegarder" est inclut dans les boutons de changement d'onglet seulement si la sauvegarde en backend s'effectue

### DIFF
--- a/frontend/src/components/TabStepper.vue
+++ b/frontend/src/components/TabStepper.vue
@@ -1,21 +1,23 @@
 <template>
   <div class="border p-4 bg-gray-100 text-right">
-    <DsfrButton
-      secondary
-      v-if="selectedTabIndex > 0"
-      @click="emit('back')"
-      :label="`Sauvegarder et revenir à l'onglet « ${titles[selectedTabIndex - 1].title} »`"
-    />
-    <DsfrButton
-      class="ml-4"
-      v-if="selectedTabIndex < titles.length - 1"
-      @click="emit('forward')"
-      :label="`Sauvegarder et passer à l'onglet « ${titles[selectedTabIndex + 1].title} »`"
-    />
+    <DsfrButton secondary v-if="selectedTabIndex > 0" @click="emit('back')" :label="backLabel" />
+    <DsfrButton class="ml-4" v-if="selectedTabIndex < titles.length - 1" @click="emit('forward')" :label="fwdLabel" />
   </div>
 </template>
 
 <script setup>
-defineProps(["titles", "selectedTabIndex"])
+import { computed } from "vue"
+
+const props = defineProps(["titles", "selectedTabIndex", "removeSaveLabel"])
 const emit = defineEmits(["back", "forward"])
+
+const backLabel = computed(() => {
+  if (props.removeSaveLabel) return `Revenir à l'onglet « ${props.titles[props.selectedTabIndex - 1].title} »`
+  return `Sauvegarder et revenir à l'onglet « ${props.titles[props.selectedTabIndex - 1].title} »`
+})
+
+const fwdLabel = computed(() => {
+  if (props.removeSaveLabel) return `Passer à l'onglet « ${props.titles[props.selectedTabIndex + 1].title} »`
+  return `Sauvegarder et passer à l'onglet « ${props.titles[props.selectedTabIndex + 1].title} »`
+})
 </script>

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -56,6 +56,7 @@
           :selectedTabIndex="selectedTabIndex"
           @back="selectedTabIndex -= 1"
           @forward="selectedTabIndex += 1"
+          :removeSaveLabel="true"
         />
       </div>
     </div>

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -64,6 +64,7 @@
         :selectedTabIndex="selectedTabIndex"
         @back="selectTab(selectedTabIndex - 1)"
         @forward="selectTab(selectedTabIndex + 1)"
+        :removeSaveLabel="readonly"
       />
     </div>
   </div>

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -52,6 +52,7 @@
           :selectedTabIndex="selectedTabIndex"
           @back="selectedTabIndex -= 1"
           @forward="selectedTabIndex += 1"
+          :removeSaveLabel="true"
         />
       </div>
     </div>


### PR DESCRIPTION
Closes #1204 

## Contexte

Les boutons en bas des onglets avait toujours le mot "Sauvegarder et..." même si le changement d'onglet n'effectuait pas une sauvegarde en backend.

![image](https://github.com/user-attachments/assets/71aebabc-b671-4700-bf9f-cecb64f22166)

## Scope

Le label de ces boutons change dynamiquement en dépendant de si une sauvegarde s'effectue ou pas.

![image](https://github.com/user-attachments/assets/7d74ca69-bd42-4cde-9b6c-ee30f113fd3f)
