### PR TITLE
820 duplication

### DIFF
--- a/frontend/src/views/CompanyDeclarationsPage/index.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/index.vue
@@ -68,6 +68,7 @@ import { useRootStore } from "@/stores/root"
 import { computed, watch } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import { handleError } from "@/utils/error-handling"
+import { getPagesForPagination } from "@/utils/components"
 import CompanyDeclarationsTable from "./CompanyDeclarationsTable"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import StatusFilter from "@/components/StatusFilter.vue"
@@ -94,6 +95,8 @@ const limit = 10
 const hasDeclarations = computed(() => data.value?.count > 0)
 const showPagination = computed(() => data.value?.count > data.value?.results?.length)
 const offset = computed(() => (page.value - 1) * limit)
+
+const pages = computed(() => getPagesForPagination(data.value.count, limit, route.path))
 
 // Valeurs obtenus du queryparams
 const page = computed(() => parseInt(route.query.page))

--- a/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
+++ b/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
@@ -22,7 +22,7 @@ const emit = defineEmits("open")
 // Les données pour la table
 const headers = computed(() => {
   if (useShortTable.value) return ["Nom", "État"]
-  return ["ID", "Nom du produit", "Entreprise", "Déclarant·e", "État", "Date de modification"]
+  return ["ID", "Nom du produit", "Entreprise", "Déclarant·e", "État", "Date de modification", ""]
 })
 
 const rows = computed(() => {
@@ -41,12 +41,18 @@ const rows = computed(() => {
       {
         component: "router-link",
         text: d.name,
+        class: "font-medium",
         to: { name: "DeclarationPage", params: { id: d.id } },
       },
       d.company?.socialName || "Inconnue",
       d.author ? `${d.author.firstName} ${d.author.lastName}` : "",
       getStatusTagForCell(d.status, true),
       timeAgo(d.modificationDate),
+      {
+        component: "router-link",
+        text: "Dupliquer",
+        to: { name: "NewDeclaration", query: { duplicate: d.id } },
+      },
     ],
   }))
 })


### PR DESCRIPTION
Closes #820 

## Scope

Permet de dupliquer une déclaration.

Cette fonctionnalité est opérée par le frontend, qui fetch la déclaration et crée un payload avec certains de ses paramètres, ce qui a comme effet de peupler les champs de la nouvelle déclaration.

:warning:  Les pièces jointes ne sont pas recopiées. 

## Démo

https://github.com/user-attachments/assets/225065b1-9ded-4000-ad25-7809ceacdfb5

