### PR TITLE
Réorganiser les options populations cibles pour être en ordre alphabetique

### DIFF
--- a/api/views/condition.py
+++ b/api/views/condition.py
@@ -7,4 +7,4 @@ from data.models import Condition
 class ConditionListView(ListAPIView):
     model = Condition
     serializer_class = ConditionSerializer
-    queryset = Condition.up_to_date_objects.filter(missing_import_data=False)
+    queryset = Condition.up_to_date_objects.filter(missing_import_data=False).order_by("name")

--- a/api/views/effect.py
+++ b/api/views/effect.py
@@ -7,4 +7,4 @@ from data.models import Effect
 class EffectListView(ListAPIView):
     model = Effect
     serializer_class = EffectSerializer
-    queryset = Effect.up_to_date_objects.filter(missing_import_data=False)
+    queryset = Effect.up_to_date_objects.filter(missing_import_data=False).order_by("name")

--- a/api/views/population.py
+++ b/api/views/population.py
@@ -7,4 +7,4 @@ from data.models import Population
 class PopulationListView(ListAPIView):
     model = Population
     serializer_class = PopulationSerializer
-    queryset = Population.up_to_date_objects.filter(missing_import_data=False)
+    queryset = Population.up_to_date_objects.filter(missing_import_data=False).order_by("name")

--- a/frontend/src/views/ProducerFormPage/ProductTab.vue
+++ b/frontend/src/views/ProducerFormPage/ProductTab.vue
@@ -147,7 +147,7 @@
     </DsfrInputGroup>
     <SectionTitle title="Populations cibles et à risque" class="!mt-10" sizeTag="h6" icon="ri-file-user-fill" />
     <DsfrFieldset legend="Population cible" legendClass="fr-label">
-      <div v-if="populations" class="grid sm:grid-flow-col sm:grid-rows-6 lg:grid-rows-4 gap-4 fr-checkbox-group input">
+      <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
         <div
           v-for="population in populations"
           :key="`effect-${population.id}`"

--- a/frontend/src/views/ProducerFormPage/ProductTab.vue
+++ b/frontend/src/views/ProducerFormPage/ProductTab.vue
@@ -147,7 +147,7 @@
     </DsfrInputGroup>
     <SectionTitle title="Populations cibles et à risque" class="!mt-10" sizeTag="h6" icon="ri-file-user-fill" />
     <DsfrFieldset legend="Population cible" legendClass="fr-label">
-      <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
+      <div v-if="populations" class="grid sm:grid-flow-col sm:grid-rows-6 lg:grid-rows-4 gap-4 fr-checkbox-group input">
         <div
           v-for="population in populations"
           :key="`effect-${population.id}`"


### PR DESCRIPTION
- populations, conditions, et effects trié par ordre alphabetique
- on garde l'ordre de lecture en files

![Screenshot 2024-10-31 at 11-51-42 Nouvelle démarche - Compl'Alim](https://github.com/user-attachments/assets/194bb512-2ee2-4385-8341-a8454f2be34a)


