### PR TITLE
Améliore des éléments de l'interface admin

### DIFF
--- a/data/admin/__init__.py
+++ b/data/admin/__init__.py
@@ -20,6 +20,8 @@ from .global_roles import InstructionRoleAdmin
 from data.models import PlantPart, PlantFamily
 from simple_history.admin import SimpleHistoryAdmin
 
+from django.contrib.auth.models import Group
+
 
 @admin.register(PlantPart)
 class PlantPartAdmin(SimpleHistoryAdmin):
@@ -37,3 +39,4 @@ def get_admin_header():
 
 admin.site.site_header = get_admin_header()
 admin.site.site_title = get_admin_header()
+admin.site.unregister(Group)

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.contrib import admin
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from data.models import (
     ComputedSubstance,
     Declaration,
@@ -184,7 +186,7 @@ class DeclarationForm(forms.ModelForm):
 
 
 @admin.register(Declaration)
-class DeclarationAdmin(admin.ModelAdmin):
+class DeclarationAdmin(SimpleHistoryAdmin):
     form = DeclarationForm
     list_display = ("name", "status", "company", "author")
     list_filter = ("status", "company", "author")

--- a/data/admin/user.py
+++ b/data/admin/user.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
+from django.utils.translation import gettext_lazy as _
 
 from data.models import DeclarantRole, SupervisorRole
 
@@ -23,11 +24,6 @@ class SupervisorRoleInline(admin.TabularInline):
 
 @admin.register(get_user_model())
 class UserAdmin(UserAdmin):
-    def __init__(self, model, admin_site):
-        fieldsets = self.fieldsets[:1] + ((None, {"fields": ("is_verified", "phone_number")}),) + self.fieldsets[1:]
-        self.fieldsets = fieldsets
-        super().__init__(model, admin_site)
-
     add_fieldsets = UserAdmin.add_fieldsets + (
         (None, {"fields": ("email", "first_name", "last_name", "phone_number")}),
     )
@@ -42,4 +38,38 @@ class UserAdmin(UserAdmin):
     inlines = (
         DeclarantRoleInline,
         SupervisorRoleInline,
+    )
+
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "username",
+                    "password",
+                    "is_verified",
+                )
+            },
+        ),
+        (
+            _("Personal info"),
+            {
+                "fields": (
+                    "first_name",
+                    "last_name",
+                    "email",
+                    "phone_number",
+                )
+            },
+        ),
+        (
+            _("Permissions"),
+            {
+                "fields": (
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                ),
+            },
+        ),
     )


### PR DESCRIPTION
Closes #1213 

## Scope

- Permet de visualiser l'historique des déclarations sur l'admin
- Enlève la catégorie `Groupe` - non utillisée
- Enlève les champs `Group permissions` dans la page admin des usagers - non utilisés