### PR TITLE
Permettre la création de nouveaux ingrédients

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -9,7 +9,7 @@ from .user import (
 from .global_roles import SimpleInstructorSerializer, SimpleVisorSerializer
 from .webinar import WebinarSerializer
 from .search_result import SearchResultSerializer
-from .plant import PlantSerializer, PlantPartSerializer, PlantModificationSerializer
+from .plant import PlantSerializer, PlantPartSerializer, PlantModificationSerializer, PlantFamilySerializer
 from .ingredient import IngredientSerializer, IngredientModificationSerializer
 from .microorganism import MicroorganismSerializer, MicroorganismModificationSerializer
 from .substance import SubstanceSerializer, SubstanceShortSerializer, SubstanceModificationSerializer

--- a/api/serializers/common_ingredient.py
+++ b/api/serializers/common_ingredient.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError
+from simple_history.utils import update_change_reason
 
 from data.models import Substance
 
@@ -36,6 +37,7 @@ class CommonIngredientModificationSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         synonyms = validated_data.pop(self.synonym_set_field_name, [])
         ingredient = super().create(validated_data)
+        update_change_reason(ingredient, "CommonIngredientModificationSerializer")
 
         for synonym in synonyms:
             try:

--- a/api/serializers/plant.py
+++ b/api/serializers/plant.py
@@ -20,6 +20,7 @@ class PlantFamilySerializer(serializers.ModelSerializer):
     class Meta:
         model = PlantFamily
         fields = (
+            "id",
             "name",
             "is_obsolete",
             "name_en",

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -377,3 +377,19 @@ class TestElementsCreateApi(APITestCase):
         payload = {"name": "My new ingredient"}
         response = self.client.post(reverse("api:ingredient_create"), payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @authenticate
+    def test_change_reason_on_create_ingredient(self):
+        """
+        Une raison de changement est donnée quand une création est effectué depuis cet API
+        """
+        InstructionRoleFactory(user=authenticate.user)
+
+        payload = {
+            "name": "My new ingredient",
+        }
+        response = self.client.post(reverse("api:ingredient_create"), payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        ingredient = Ingredient.objects.get(name="My new ingredient")
+        self.assertEqual(ingredient.history.first().history_change_reason, "CommonIngredientModificationSerializer")

--- a/api/urls.py
+++ b/api/urls.py
@@ -23,7 +23,7 @@ urlpatterns = {
     path("microorganisms/<int:pk>", views.MicroorganismRetrieveView.as_view(), name="single_microorganism"),
     path("substances/", views.SubstanceCreateView.as_view(), name="substance_create"),
     path("substances/<int:pk>", views.SubstanceRetrieveView.as_view(), name="single_substance"),
-    path("elements/autocomplete/", views.AutocompleteView.as_view(), name="substance_autocomplete"),
+    path("elements/autocomplete/", views.AutocompleteView.as_view(), name="element_autocomplete"),
     # Declared elements
     path("new-declared-elements/", views.DeclaredElementsView.as_view(), name="list_new_declared_elements"),
     path("declared-elements/<str:type>/<int:pk>", views.DeclaredElementView.as_view(), name="declared_element"),

--- a/api/urls.py
+++ b/api/urls.py
@@ -16,6 +16,7 @@ urlpatterns = {
     path("plants/", views.PlantCreateView.as_view(), name="plant_create"),
     path("plants/<int:pk>", views.PlantRetrieveView.as_view(), name="single_plant"),
     path("plant-parts/", views.PlantPartListView.as_view(), name="plant_part_list"),
+    path("plant-families/", views.PlantFamilyListView.as_view(), name="plant_family_list"),
     path("other-ingredients/", views.IngredientCreateView.as_view(), name="ingredient_create"),
     path("other-ingredients/<int:pk>", views.IngredientRetrieveView.as_view(), name="single_ingredient"),
     path("microorganisms/", views.MicroorganismCreateView.as_view(), name="microorganism_create"),

--- a/api/utils/search.py
+++ b/api/utils/search.py
@@ -7,15 +7,31 @@ from data.models.substance import Substance, SubstanceType
 
 
 def search_elements(query, deduplicate=False, exclude_not_authorized=False, exclude_vitamines_minerals=False):
+    term = query["term"]
+    query_type = query["type"]
     # Les plantes non autorisées peuvent être ajoutées en infimes quantités dans les elixirs
     # elles sont donc systématiquement renvoyées
-    plants = _get_plants(query, deduplicate, exclude_not_authorized=False)
-    microorganisms = _get_microorganisms(query, deduplicate, exclude_not_authorized)
-    ingredients = _get_ingredients(query, deduplicate, exclude_not_authorized)
-    substances = _get_substances(query, deduplicate, exclude_not_authorized, exclude_vitamines_minerals)
+    plants = (
+        _get_plants(term, deduplicate, exclude_not_authorized=False) if not query_type or query_type == "plant" else []
+    )
+    microorganisms = (
+        _get_microorganisms(term, deduplicate, exclude_not_authorized)
+        if not query_type or query_type == "microorganism"
+        else []
+    )
+    ingredients = (
+        _get_ingredients(term, deduplicate, exclude_not_authorized)
+        if not query_type or query_type == "other-ingredient"
+        else []
+    )
+    substances = (
+        _get_substances(term, deduplicate, exclude_not_authorized, exclude_vitamines_minerals)
+        if not query_type or query_type == "substance"
+        else []
+    )
 
     results = plants + microorganisms + ingredients + substances
-    results.sort(key=lambda x: SequenceMatcher(None, x.autocomplete_match, query).ratio(), reverse=True)
+    results.sort(key=lambda x: SequenceMatcher(None, x.autocomplete_match, term).ratio(), reverse=True)
 
     return results
 

--- a/api/utils/search.py
+++ b/api/utils/search.py
@@ -8,7 +8,7 @@ from data.models.substance import Substance, SubstanceType
 
 def search_elements(query, deduplicate=False, exclude_not_authorized=False, exclude_vitamines_minerals=False):
     term = query["term"]
-    query_type = query["type"]
+    query_type = query.get("type")
     # Les plantes non autorisées peuvent être ajoutées en infimes quantités dans les elixirs
     # elles sont donc systématiquement renvoyées
     plants = (

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -36,7 +36,7 @@ from .preparation import PreparationListView
 from .ingredient import IngredientRetrieveView, IngredientCreateView
 from .microorganism import MicroorganismRetrieveView, MicroorganismCreateView
 from .newsletter import SubscribeNewsletter
-from .plant import PlantPartListView, PlantRetrieveView, PlantCreateView
+from .plant import PlantPartListView, PlantRetrieveView, PlantCreateView, PlantFamilyListView
 from .population import PopulationListView
 from .report_issue import ReportIssue
 from .search import SearchView

--- a/api/views/autocomplete.py
+++ b/api/views/autocomplete.py
@@ -19,12 +19,13 @@ class AutocompleteView(APIView):
     max_autocomplete_items = 20
 
     def post(self, request, *args, **kwargs):
-        query = request.data.get("term")
-        if not query or len(query) < self.min_query_length:
+        term = request.data.get("term")
+        if not term or len(term) < self.min_query_length:
             raise ProjectAPIException(
                 global_error=f"Le terme de recherche doit être supérieur ou égal à {self.min_query_length} caractères"
             )
 
+        query = {"term": term, "type": request.data.get("type")}
         results = search_elements(
             query, deduplicate=False, exclude_not_authorized=True, exclude_vitamines_minerals=True
         )[: self.max_autocomplete_items]

--- a/api/views/plant.py
+++ b/api/views/plant.py
@@ -1,7 +1,7 @@
 from rest_framework.generics import ListAPIView, CreateAPIView
 
-from api.serializers import PlantPartSerializer, PlantSerializer, PlantModificationSerializer
-from data.models import Plant, PlantPart
+from api.serializers import PlantPartSerializer, PlantSerializer, PlantModificationSerializer, PlantFamilySerializer
+from data.models import Plant, PlantPart, PlantFamily
 
 from .utils import IngredientRetrieveView
 from ..permissions import IsInstructor
@@ -17,6 +17,12 @@ class PlantPartListView(ListAPIView):
     model = PlantPart
     queryset = PlantPart.objects.all()
     serializer_class = PlantPartSerializer
+
+
+class PlantFamilyListView(ListAPIView):
+    model = PlantFamily
+    queryset = PlantFamily.objects.all()
+    serializer_class = PlantFamilySerializer
 
 
 class PlantCreateView(CreateAPIView):

--- a/api/views/search.py
+++ b/api/views/search.py
@@ -32,7 +32,7 @@ class SearchView(APIView):
         if int(self.request.data.get("limit", 0)) > self.max_pagination_limit:
             raise ProjectAPIException(global_error=f"La limite de pagination excède {self.max_pagination_limit}")
 
-        results = search_elements(query, deduplicate=True)
+        results = search_elements({"term": query}, deduplicate=True)
         paginated_results = self.paginate_results(results)
         serialized_data = self.serialize_results(paginated_results)
         return self.get_paginated_response(serialized_data)

--- a/frontend/src/components/ElementAutocomplete.vue
+++ b/frontend/src/components/ElementAutocomplete.vue
@@ -91,6 +91,10 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  type: {
+    type: String,
+    default: null,
+  },
 })
 
 const emit = defineEmits(["selected", "search"])
@@ -182,7 +186,7 @@ const fetchAutocompleteResults = useDebounceFn(async () => {
     return
   }
 
-  const body = { term: searchTerm.value }
+  const body = { term: searchTerm.value, type: props.type }
   const { error, data } = await useFetch("/api/v1/elements/autocomplete/", { headers: headers() }).post(body).json()
 
   if (error.value) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -92,7 +92,7 @@ const routes = [
     props: true,
   },
   {
-    path: "/nouvel-element/:type/:id",
+    path: "/ingredient-demande/:type/:id",
     name: "DeclaredElementPage",
     component: DeclaredElementPage,
     props: true,
@@ -103,7 +103,7 @@ const routes = [
     },
   },
   {
-    path: "/element-detail",
+    path: "/nouvel-ingredient",
     name: "ElementForm",
     component: ElementForm,
     meta: {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -107,6 +107,7 @@ const routes = [
     name: "ElementForm",
     component: ElementForm,
     meta: {
+      title: "Création élément",
       authenticationRequired: true,
       requiredRole: "InstructionRole",
     },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -103,10 +103,9 @@ const routes = [
     },
   },
   {
-    path: "/element-detail/:urlComponent",
+    path: "/element-detail",
     name: "ElementForm",
     component: ElementForm,
-    props: true,
     meta: {
       authenticationRequired: true,
       requiredRole: "InstructionRole",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -34,6 +34,7 @@ import A11yPage from "@/views/A11yPage.vue"
 import ContactForm from "@/views/ContactForm"
 import CompliancePage from "@/views/CompliancePage"
 import DeclaredElementPage from "@/views/DeclaredElementPage"
+import ElementForm from "@/views/ElementForm"
 import MandatedCompaniesPage from "@/views/MandatedCompaniesPage"
 import FaqPage from "@/views/FaqPage"
 import { ref } from "vue"
@@ -99,6 +100,16 @@ const routes = [
       title: "Demande d'ajout d'ingrédient",
       requiredRole: "InstructionRole",
       authenticationRequired: true,
+    },
+  },
+  {
+    path: "/element-detail/:urlComponent",
+    name: "ElementForm",
+    component: ElementForm,
+    props: true,
+    meta: {
+      authenticationRequired: true,
+      requiredRole: "InstructionRole",
     },
   },
   {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -107,7 +107,7 @@ const routes = [
     name: "ElementForm",
     component: ElementForm,
     meta: {
-      title: "Création élément",
+      title: "Nouvel ingrédient",
       authenticationRequired: true,
       requiredRole: "InstructionRole",
     },

--- a/frontend/src/stores/root.js
+++ b/frontend/src/stores/root.js
@@ -12,6 +12,7 @@ export const useRootStore = defineStore("root", () => {
   const galenicFormulations = ref(null)
   const preparations = ref(null)
   const plantParts = ref(null)
+  const plantFamilies = ref(null)
   const units = ref(null)
 
   const fetchInitialData = async () => {
@@ -61,6 +62,10 @@ export const useRootStore = defineStore("root", () => {
     const { data } = await useFetch("/api/v1/plant-parts/").json()
     plantParts.value = data.value
   }
+  const fetchPlantFamilies = async () => {
+    const { data } = await useFetch("/api/v1/plant-families/").json()
+    plantFamilies.value = data.value
+  }
   const fetchUnits = async () => {
     const { data } = await useFetch("/api/v1/units/").json()
     units.value = data.value
@@ -91,8 +96,10 @@ export const useRootStore = defineStore("root", () => {
     fetchPreparations,
     fetchDeclarationFieldsData,
     fetchPlantParts,
+    fetchPlantFamilies,
     fetchUnits,
     plantParts,
+    plantFamilies,
     populations,
     conditions,
     effects,

--- a/frontend/src/utils/forms.js
+++ b/frontend/src/utils/forms.js
@@ -1,4 +1,4 @@
-import { helpers, required, email, numeric, minValue } from "@vuelidate/validators"
+import { helpers, required, email, numeric } from "@vuelidate/validators"
 
 /* Using vuelidate validation, return the first error message, or "" if no error found. */
 export const firstErrorMsg = (v, fieldName) => (v[fieldName]?.$error ? v[fieldName].$errors[0].$message : null)
@@ -10,9 +10,8 @@ export const errorRequiredEmail = {
   required: REQUIRED,
   email: helpers.withMessage("Ce champ doit contenir un e-mail valide", email),
 }
-export const errorRequiredPositiveNumber = {
-  required: REQUIRED,
-  numeric: helpers.withMessage("La valeur doit être un numéro positif", numeric),
+export const errorNumeric = {
+  numeric: helpers.withMessage("La valeur doit être un numéro", numeric),
 }
 
 export const getAllIndexesOfRegex = (array, regex) => {

--- a/frontend/src/utils/forms.js
+++ b/frontend/src/utils/forms.js
@@ -1,13 +1,18 @@
-import { helpers, required, email } from "@vuelidate/validators"
+import { helpers, required, email, numeric, minValue } from "@vuelidate/validators"
 
 /* Using vuelidate validation, return the first error message, or "" if no error found. */
 export const firstErrorMsg = (v, fieldName) => (v[fieldName]?.$error ? v[fieldName].$errors[0].$message : null)
 
 // reusable field errors
-export const errorRequiredField = { required: helpers.withMessage("Ce champ doit être rempli", required) }
+const REQUIRED = helpers.withMessage("Ce champ doit être rempli", required)
+export const errorRequiredField = { required: REQUIRED }
 export const errorRequiredEmail = {
-  required: helpers.withMessage("Ce champ doit être rempli", required),
+  required: REQUIRED,
   email: helpers.withMessage("Ce champ doit contenir un e-mail valide", email),
+}
+export const errorRequiredPositiveNumber = {
+  required: REQUIRED,
+  numeric: helpers.withMessage("La valeur doit être un numéro positif", numeric),
 }
 
 export const getAllIndexesOfRegex = (array, regex) => {

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -50,11 +50,6 @@
               <!-- Question: do we have this in the DB? -->
               <DsfrSelect v-model="state.ingredientType" label="Type ingrédient" :options="ingredientTypes" required />
             </DsfrInputGroup>
-            <DsfrInputGroup v-if="formForType.substanceType">
-              <!-- Question: multiselect or single? -->
-              <!-- Question: do we have this in the DB? -->
-              <DsfrSelect v-model="state.substanceType" label="Type de substance" :options="substanceTypes" required />
-            </DsfrInputGroup>
 
             <DsfrToggleSwitch
               v-model="state.novelFood"
@@ -72,14 +67,11 @@
               label-left
               class="self-center mt-4"
             />
-            <DsfrInputGroup v-if="formForType.einecsNumber">
-              <DsfrInput v-model="state.einecsNumber" label="Numéro EINECS" labelVisible />
+            <DsfrInputGroup v-if="formForType.einecNumber">
+              <DsfrInput v-model="state.einecNumber" label="Numéro EINECS" labelVisible />
             </DsfrInputGroup>
             <DsfrInputGroup v-if="formForType.casNumber">
               <DsfrInput v-model="state.casNumber" label="Numéro CAS" labelVisible />
-            </DsfrInputGroup>
-            <DsfrInputGroup v-if="formForType.source">
-              <DsfrInput v-model="state.source" label="Source" labelVisible />
             </DsfrInputGroup>
           </div>
           <div class="grid md:grid-cols-2 mt-4">
@@ -144,6 +136,28 @@
               ></DsfrTag>
             </div>
           </div>
+          <div class="grid grid-cols-3 gap-x-8" v-if="formForType.nutritionalReference">
+            <div>
+              <NumberField
+                label="Apport nutritionnel de référence"
+                label-visible
+                v-model="state.nutritionalReference"
+              />
+            </div>
+            <div>
+              <NumberField label="Quantité maximale autorisée" label-visible v-model="state.maxQuantity" />
+            </div>
+            <div class="max-w-32">
+              <DsfrSelect
+                label="Unité"
+                label-visible
+                required
+                :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
+                v-model="state.unit"
+                defaultUnselectedText="Unité"
+              />
+            </div>
+          </div>
           <!-- TODO: add max quantity, nutritional reference, unit for substance -->
           <p class="my-4"><i>Population cible et à risque en construction</i></p>
         </DsfrFieldset>
@@ -181,11 +195,12 @@ import { handleError } from "@/utils/error-handling"
 import useToaster from "@/composables/use-toaster"
 import FormWrapper from "@/components/FormWrapper"
 import ElementAutocomplete from "@/components/ElementAutocomplete"
+import NumberField from "@/components/NumberField"
 
 // const props = defineProps({ urlComponent: String })
 // const elementId = computed(() => props.urlComponent.split("--")[0])
 // const type = computed(() => unSlugifyType(props.urlComponent.split("--")[1]))
-const type = ref("microorganism")
+const type = ref("substance")
 const icon = computed(() => getTypeIcon(type.value))
 const typeName = computed(() => getTypeInFrench(type.value))
 const router = useRouter()
@@ -256,14 +271,11 @@ const formQuestions = {
     name: {
       label: "Nom de la substance",
     },
-    nameEn: {
-      label: "Nom de la substance en anglais",
-    },
-    substanceType: true,
-    einecsNumber: true,
+    einecNumber: true,
     casNumber: true,
-    source: true,
-    sourceEn: true,
+    nutritionalReference: true,
+    maxQuantity: true,
+    unit: true,
   },
   microorganism: {
     species: true,
@@ -274,9 +286,6 @@ const formQuestions = {
   default: {
     name: {
       label: "Nom ingrédient",
-    },
-    nameEn: {
-      label: "Nom ingrédient en anglais",
     },
     ingredientType: true,
     function: true,
@@ -292,7 +301,6 @@ const { plantParts, plantFamilies } = storeToRefs(store)
 store.fetchDeclarationFieldsData()
 store.fetchPlantFamilies()
 
-const substanceTypes = [] // TODO: fetch options from DB
 const ingredientTypes = [] // TODO: fetch options from DB
 
 const selectOption = async (result) => {

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -39,7 +39,6 @@
               label-left
               class="self-center mt-4 col-span-2 sm:col-span-1"
             />
-            <!-- TODO: either sort alphabetically or allow for search to select -->
             <div class="col-span-2" v-if="formForType.family && plantFamiliesDisplay">
               <DsfrInputGroup :error-message="firstErrorMsg(v$, 'family')">
                 <DsfrSelect
@@ -173,7 +172,7 @@
           </div>
         </DsfrFieldset>
         <div class="flex gap-x-2 mt-4">
-          <DsfrButton label="Enregistrer ingrédient" @click="saveElement" :disabled="isFetching" />
+          <DsfrButton label="Enregistrer ingrédient" @click="saveElement" />
         </div>
       </FormWrapper>
     </div>
@@ -352,7 +351,9 @@ const optionLabel = (options, id) => {
 }
 
 const plantFamiliesDisplay = computed(() => {
-  return plantFamilies.value?.map((family) => ({ value: family.id, text: family.name }))
+  return plantFamilies.value
+    ?.map((family) => ({ value: family.id, text: family.name }))
+    .sort((a, b) => a.text.localeCompare(b.text))
 })
 
 const AROMA = ref(3)

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -102,12 +102,23 @@
           </div>
           <div v-if="formForType.substances" class="flex items-center my-4">
             <!-- TODO: option to create new active substance -->
-            <DsfrMultiselect v-model="state.substances" :options="substances" label="Substances actives" search />
+            <ElementAutocomplete
+              autocomplete="nothing"
+              label="Substances actives"
+              label-visible
+              class="max-w-md grow"
+              hint="Tapez au moins trois caractères pour démarrer la recherche"
+              :hideSearchButton="true"
+              @selected="selectOption"
+            />
             <div class="ml-4">
+              <!-- TODO: align tags with input -->
+              <!-- TODO: filter to only include substances -->
+              <!-- TODO: make tags deleteable -->
               <DsfrTag
-                v-for="id in state.substances"
-                :key="id"
-                :label="optionLabel(substances, id)"
+                v-for="substance in state.substances"
+                :key="substance.id"
+                :label="substance.name"
                 class="mx-1"
               ></DsfrTag>
             </div>
@@ -148,6 +159,7 @@ import { storeToRefs } from "pinia"
 // import { useFetch } from "@vueuse/core"
 // import { handleError } from "@/utils/error-handling"
 import FormWrapper from "@/components/FormWrapper"
+import ElementAutocomplete from "@/components/ElementAutocomplete"
 
 // const props = defineProps({ urlComponent: String })
 // const elementId = computed(() => props.urlComponent.split("--")[0])
@@ -238,10 +250,9 @@ const synonyms = [
   { label: "Cassius", type: "Nom en latin" },
 ]
 
-const substances = [
-  { label: "Ex 1", id: 1 },
-  { label: "Ex 2", id: 2 },
-]
+const selectOption = async (result) => {
+  state.value.substances.push(result)
+}
 
 const optionLabel = (options, id) => {
   return options.find((o) => o.id === id)?.name || "Inconnu"

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -46,7 +46,7 @@
 
           <DsfrToggleSwitch
             v-model="state.authorised"
-            label="Authoriser l'ingrédient"
+            label="Autorisation de l’ingrédient"
             activeText="Authorisé"
             inactiveText="Non authorisé"
             label-left

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -17,8 +17,8 @@
       <FormWrapper class="mx-auto">
         <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4 !mb-0 !pb-2">
           <!-- TODO: validation -->
-          <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-x-4">
-            <div class="col-span-2">
+          <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-x-8">
+            <div class="col-span-2 lg:col-span-5">
               <DsfrInputGroup>
                 <DsfrInput v-model="state.name" :label="formForType.name.label" required labelVisible />
               </DsfrInputGroup>
@@ -51,12 +51,20 @@
             </DsfrInputGroup>
 
             <DsfrToggleSwitch
+              v-model="state.novelFood"
+              label="Novel food"
+              activeText="Oui"
+              inactiveText="Non"
+              label-left
+              class="self-center"
+            />
+            <DsfrToggleSwitch
               v-model="state.status"
               label="Autorisation de l’ingrédient"
               activeText="Authorisé"
               inactiveText="Non authorisé"
               label-left
-              class="self-center col-span-2 md:col-span-1"
+              class="self-center"
             />
             <DsfrInputGroup v-if="formForType.einecsNumber">
               <DsfrInput v-model="state.einecsNumber" label="Numéro EINECS" labelVisible />
@@ -232,6 +240,7 @@ const formQuestions = {
     // authorise: true for every type
     // description is true for every type
     // synonymes are true for every type
+    // novelFood is true for every type TODO: not for aromes
     plantParts: true,
     substances: true,
     // population cible: true for everyone also not yet in our database

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="fr-container">
+    <DsfrBreadcrumb class="mb-8" :links="breadcrumbLinks" />
+
+    <h1>
+      <v-icon scale="2" :name="icon" />
+      Modification élément
+    </h1>
+  </div>
+</template>
+
+<script setup>
+import { /*ref, */ computed /*, watch*/ } from "vue"
+import { getTypeIcon, /*getTypeInFrench,*/ unSlugifyType /*, getApiType*/ } from "@/utils/mappings"
+// import { useRoute, useRouter } from "vue-router"
+// import { useFetch } from "@vueuse/core"
+// import { handleError } from "@/utils/error-handling"
+
+const props = defineProps({ urlComponent: String })
+const elementId = computed(() => props.urlComponent.split("--")[0])
+const type = computed(() => unSlugifyType(props.urlComponent.split("--")[1]))
+const icon = computed(() => getTypeIcon(type.value))
+
+const breadcrumbLinks = computed(() => {
+  const links = [{ to: { name: "DashboardPage" }, text: "Tableau de bord" }]
+  links.push({ text: `Modification élément ${elementId.value}` })
+  return links
+})
+</script>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -161,10 +161,11 @@ import { getTypeIcon, getTypeInFrench, unSlugifyType /*, getApiType*/ } from "@/
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 // import { firstErrorMsg } from "@/utils/forms"
-// import { useRoute, useRouter } from "vue-router"
+import { /*useRoute,*/ useRouter } from "vue-router"
 import { useFetch } from "@vueuse/core"
 import { headers } from "@/utils/data-fetching"
 import { handleError } from "@/utils/error-handling"
+import useToaster from "@/composables/use-toaster"
 import FormWrapper from "@/components/FormWrapper"
 import ElementAutocomplete from "@/components/ElementAutocomplete"
 
@@ -174,6 +175,7 @@ import ElementAutocomplete from "@/components/ElementAutocomplete"
 const type = ref("plant")
 const icon = computed(() => getTypeIcon(type.value))
 const typeName = computed(() => getTypeInFrench(type.value))
+const router = useRouter()
 
 const breadcrumbLinks = computed(() => {
   const links = [{ to: { name: "DashboardPage" }, text: "Tableau de bord" }]
@@ -198,7 +200,12 @@ const saveElement = async () => {
   const { response } = await useFetch(url, { headers: headers() }).post(payload).json()
   await handleError(response)
   if (response.value.ok) {
-    // TODO: redirect
+    useToaster().addMessage({
+      type: "success",
+      id: "element-creation-success",
+      description: "L'élément a été créé",
+    })
+    router.push({ name: "DashboardPage" })
   }
 }
 // const saveAsDraft = async () => {}

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -17,6 +17,7 @@
       <FormWrapper class="mx-auto">
         <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4">
           <!-- TODO: validation -->
+          <!-- TODO: responsiveness -->
           <div class="flex gap-x-4">
             <div class="flex-1">
               <DsfrInputGroup>
@@ -70,23 +71,28 @@
               <DsfrInput v-model="state.source" label="Source" labelVisible />
             </DsfrInputGroup>
           </div>
-          <DsfrFieldset legend="Synonymes" legendClass="fr-text--lg !pb-0 !mb-2 !mt-4">
-            <ul>
-              <li v-for="(synonym, idx) in synonyms" :key="idx">{{ synonym.label }}, {{ synonym.type }}</li>
-            </ul>
-            <!-- TODO: table -->
-            <!-- TODO: delete/edit per line -->
-            <!-- TODO: add new line -->
-            <!-- TODO: if new, three ? editable lines by default -->
-            <DsfrButton label="Ajouter un synonyme" @click="addNewSynonym" icon="ri-add-line" size="sm" />
-          </DsfrFieldset>
-          <!-- name: {
-            label: "Nom de la plante",
-          },
-          family: true,
-          function: true,
-          // authorise: true for every type
-          // description is true for every type -->
+          <div class="grid md:grid-cols-2">
+            <DsfrFieldset legend="Synonymes" legendClass="fr-text--lg !pb-0 !mb-2 !mt-4">
+              <DsfrInput
+                v-for="(_, idx) in state.synonyms"
+                :key="`synonym-${idx}`"
+                v-model="state.synonyms[idx].name"
+                class="mb-4"
+              />
+              <!-- TODO: table -->
+              <!-- TODO: delete/edit per line -->
+              <!-- TODO: add new line -->
+              <!-- TODO: if new, three ? editable lines by default -->
+              <DsfrButton
+                label="Ajouter un synonyme"
+                @click="addNewSynonym"
+                icon="ri-add-line"
+                size="sm"
+                class="mt-2"
+                secondary
+              />
+            </DsfrFieldset>
+          </div>
         </DsfrFieldset>
         <DsfrFieldset legend="Utilisation de l’ingrédient" legendClass="fr-h4 !pb-0">
           <div v-if="formForType.plantParts" class="flex items-center my-4">
@@ -185,9 +191,13 @@ const breadcrumbLinks = computed(() => {
   return links
 })
 
+const EMPTY_SYNONYM = { name: "" }
+const newSynonym = () => JSON.parse(JSON.stringify(EMPTY_SYNONYM))
+
 const state = ref({
   plantParts: [],
   substances: [],
+  synonyms: [newSynonym(), newSynonym(), newSynonym()],
 }) // TODO: prefill with existing data if modifying
 
 const isFetching = false // TODO: set to true when fetching data or sending update, see CompanyForm
@@ -200,6 +210,8 @@ const saveElement = async () => {
   if (payload.substances.length) {
     payload.substances = payload.substances.map((substance) => substance.id)
   }
+  // TODO: this will need updating when modifying ingredients
+  payload.synonyms = payload.synonyms.filter((s) => !!s.name)
   const { response } = await useFetch(url, { headers: headers() }).post(payload).json()
   await handleError(response)
   if (response.value.ok) {
@@ -212,7 +224,9 @@ const saveElement = async () => {
   }
 }
 // const saveAsDraft = async () => {}
-const addNewSynonym = async () => {}
+const addNewSynonym = async () => {
+  state.value.synonyms.push(newSynonym())
+}
 
 const formQuestions = {
   plant: {
@@ -273,11 +287,6 @@ store.fetchPlantFamilies()
 
 const substanceTypes = [] // TODO: fetch options from DB
 const ingredientTypes = [] // TODO: fetch options from DB
-
-const synonyms = [
-  { label: "Example", type: "Nom en anglais" },
-  { label: "Cassius", type: "Nom en latin" },
-]
 
 const selectOption = async (result) => {
   state.value.substances.push(result)

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -68,7 +68,7 @@
               <DsfrInput v-model="state.casNumber" label="Numéro CAS" labelVisible />
             </DsfrInputGroup>
             <DsfrToggleSwitch
-              v-if="!state.ingredientType || state.ingredientType != AROMA"
+              v-if="!state.ingredientType || state.ingredientType != aromaId"
               v-model="state.novelFood"
               label="Novel food"
               activeText="Oui"
@@ -242,7 +242,7 @@ const saveElement = async () => {
   }
   payload.synonyms = payload.synonyms.filter((s) => !!s.name)
   payload.status = payload.status ? 1 : 2
-  if (payload.ingredientType && payload.ingredientType == AROMA.value) delete payload.novelFood
+  if (payload.ingredientType && payload.ingredientType == aromaId) delete payload.novelFood
 
   const { response } = await useFetch(url, { headers: headers() }).post(payload).json()
   $externalResults.value = await handleError(response)
@@ -355,5 +355,5 @@ const plantFamiliesDisplay = computed(() => {
     .sort((a, b) => a.text.localeCompare(b.text))
 })
 
-const AROMA = ref(3)
+const aromaId = 3
 </script>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -1,138 +1,148 @@
 <template>
-  <div class="fr-container mb-8">
-    <DsfrBreadcrumb class="mb-8" :links="breadcrumbLinks" />
+  <div class="mb-8">
+    <div class="bg-blue-france-950 py-1">
+      <div class="fr-container">
+        <DsfrBreadcrumb :links="breadcrumbLinks" />
 
-    <h1>Modification élément</h1>
+        <h1 class="-mt-6 mb-4">Modification élément</h1>
+      </div>
+    </div>
+    <div class="fr-container">
+      <p>
+        <v-icon :name="icon" />
+        {{ typeName }}
+      </p>
 
-    <p>
-      <v-icon :name="icon" />
-      {{ typeName }}
-    </p>
+      <!-- TODO: tabs -->
+      <FormWrapper class="mx-auto">
+        <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4">
+          <!-- TODO: validation -->
+          <div class="flex gap-x-4 -mb-8">
+            <DsfrInputGroup>
+              <DsfrInput v-model="state.caName" :label="formForType.name.label" required labelVisible />
+            </DsfrInputGroup>
+            <DsfrInputGroup v-if="formForType.nameEn">
+              <DsfrInput v-model="state.caNameEn" :label="formForType.nameEn.label" labelVisible />
+            </DsfrInputGroup>
+            <DsfrInputGroup v-if="formForType.family">
+              <!-- Question: multiselect or single? -->
+              <DsfrSelect v-model="state.caFamily" label="Famille de la plante" :options="plantFamilies" required />
+            </DsfrInputGroup>
+            <DsfrInputGroup v-if="formForType.genre">
+              <DsfrInput v-model="state.genre" label="Genre" labelVisible />
+            </DsfrInputGroup>
+            <DsfrInputGroup v-if="formForType.ingredientType">
+              <!-- Question: multiselect or single? -->
+              <!-- Question: do we have this in the DB? -->
+              <DsfrSelect v-model="state.ingredientType" label="Type ingrédient" :options="ingredientTypes" required />
+            </DsfrInputGroup>
+            <!-- TODO: sort out row col wrapping for default -->
+            <DsfrInputGroup v-if="formForType.function">
+              <!-- Question: multiselect or single? -->
+              <!-- Question: do we have this in the DB? -->
+              <DsfrSelect v-model="state.function" label="Fonction de l'ingrédient" :options="functions" required />
+            </DsfrInputGroup>
+            <DsfrInputGroup v-if="formForType.substanceType">
+              <!-- Question: multiselect or single? -->
+              <!-- Question: do we have this in the DB? -->
+              <DsfrSelect v-model="state.substanceType" label="Type de substance" :options="substanceTypes" required />
+            </DsfrInputGroup>
 
-    <!-- TODO: tabs -->
-    <FormWrapper class="mx-auto">
-      <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4">
-        <!-- TODO: validation -->
-        <div class="flex gap-x-4 -mb-8">
+            <DsfrToggleSwitch
+              v-model="state.authorised"
+              label="Autorisation de l’ingrédient"
+              activeText="Authorisé"
+              inactiveText="Non authorisé"
+              label-left
+              class="self-center"
+            />
+          </div>
+          <div class="flex gap-x-4 -mb-4">
+            <DsfrInputGroup v-if="formForType.einecsNumber">
+              <DsfrInput v-model="state.einecsNumber" label="Numéro EINECS" labelVisible />
+            </DsfrInputGroup>
+            <DsfrInputGroup v-if="formForType.casNumber">
+              <DsfrInput v-model="state.casNumber" label="Numéro CAS" labelVisible />
+            </DsfrInputGroup>
+            <DsfrInputGroup v-if="formForType.source">
+              <DsfrInput v-model="state.source" label="Source" labelVisible />
+            </DsfrInputGroup>
+            <DsfrInputGroup v-if="formForType.sourceEn">
+              <DsfrInput v-model="state.sourceEn" label="Source en anglais" labelVisible />
+            </DsfrInputGroup>
+          </div>
           <DsfrInputGroup>
-            <DsfrInput v-model="state.caName" :label="formForType.name.label" required labelVisible />
+            <DsfrInput v-model="state.description" label="Description" labelVisible />
           </DsfrInputGroup>
-          <DsfrInputGroup v-if="formForType.nameEn">
-            <DsfrInput v-model="state.caNameEn" :label="formForType.nameEn.label" labelVisible />
-          </DsfrInputGroup>
-          <DsfrInputGroup v-if="formForType.family">
-            <!-- Question: multiselect or single? -->
-            <DsfrSelect v-model="state.caFamily" label="Famille de la plante" :options="plantFamilies" required />
-          </DsfrInputGroup>
-          <DsfrInputGroup v-if="formForType.genre">
-            <DsfrInput v-model="state.genre" label="Genre" labelVisible />
-          </DsfrInputGroup>
-          <DsfrInputGroup v-if="formForType.ingredientType">
-            <!-- Question: multiselect or single? -->
-            <!-- Question: do we have this in the DB? -->
-            <DsfrSelect v-model="state.ingredientType" label="Type ingrédient" :options="ingredientTypes" required />
-          </DsfrInputGroup>
-          <!-- TODO: sort out row col wrapping for default -->
-          <DsfrInputGroup v-if="formForType.function">
-            <!-- Question: multiselect or single? -->
-            <!-- Question: do we have this in the DB? -->
-            <DsfrSelect v-model="state.function" label="Fonction de l'ingrédient" :options="functions" required />
-          </DsfrInputGroup>
-          <DsfrInputGroup v-if="formForType.substanceType">
-            <!-- Question: multiselect or single? -->
-            <!-- Question: do we have this in the DB? -->
-            <DsfrSelect v-model="state.substanceType" label="Type de substance" :options="substanceTypes" required />
-          </DsfrInputGroup>
-
-          <DsfrToggleSwitch
-            v-model="state.authorised"
-            label="Autorisation de l’ingrédient"
-            activeText="Authorisé"
-            inactiveText="Non authorisé"
-            label-left
-            class="self-center"
-          />
-        </div>
-        <div class="flex gap-x-4 -mb-4">
-          <DsfrInputGroup v-if="formForType.einecsNumber">
-            <DsfrInput v-model="state.einecsNumber" label="Numéro EINECS" labelVisible />
-          </DsfrInputGroup>
-          <DsfrInputGroup v-if="formForType.casNumber">
-            <DsfrInput v-model="state.casNumber" label="Numéro CAS" labelVisible />
-          </DsfrInputGroup>
-          <DsfrInputGroup v-if="formForType.source">
-            <DsfrInput v-model="state.source" label="Source" labelVisible />
-          </DsfrInputGroup>
-          <DsfrInputGroup v-if="formForType.sourceEn">
-            <DsfrInput v-model="state.sourceEn" label="Source en anglais" labelVisible />
-          </DsfrInputGroup>
-        </div>
-        <DsfrInputGroup>
-          <DsfrInput v-model="state.description" label="Description" labelVisible />
-        </DsfrInputGroup>
-        <DsfrFieldset legend="Synonymes" legendClass="fr-text--lg">
-          <ul>
-            <li v-for="(synonym, idx) in synonyms" :key="idx">{{ synonym.label }}, {{ synonym.type }}</li>
-          </ul>
-          <!-- TODO: table -->
-          <!-- TODO: delete/edit per line -->
-          <!-- TODO: add new line -->
-          <!-- TODO: if new, three ? editable lines by default -->
-          <DsfrButton label="Ajouter un synonyme" @click="addNewSynonym" icon="ri-add-line" size="sm" />
-        </DsfrFieldset>
-        <!-- name: {
+          <DsfrFieldset legend="Synonymes" legendClass="fr-text--lg">
+            <ul>
+              <li v-for="(synonym, idx) in synonyms" :key="idx">{{ synonym.label }}, {{ synonym.type }}</li>
+            </ul>
+            <!-- TODO: table -->
+            <!-- TODO: delete/edit per line -->
+            <!-- TODO: add new line -->
+            <!-- TODO: if new, three ? editable lines by default -->
+            <DsfrButton label="Ajouter un synonyme" @click="addNewSynonym" icon="ri-add-line" size="sm" />
+          </DsfrFieldset>
+          <!-- name: {
             label: "Nom de la plante",
           },
           family: true,
           function: true,
           // authorise: true for every type
           // description is true for every type -->
-      </DsfrFieldset>
-      <DsfrFieldset legend="Utilisation de l’ingrédient" legendClass="fr-h4">
-        <div v-if="formForType.usedParts" class="flex items-center my-4">
-          <DsfrMultiselect v-model="state.usedParts" :options="usedParts" label="Partie(s) utilisée(s)" search />
-          <div class="ml-4">
-            <DsfrTag v-for="id in state.usedParts" :key="id" :label="optionLabel(usedParts, id)" class="mx-1"></DsfrTag>
+        </DsfrFieldset>
+        <DsfrFieldset legend="Utilisation de l’ingrédient" legendClass="fr-h4">
+          <div v-if="formForType.usedParts" class="flex items-center my-4">
+            <DsfrMultiselect v-model="state.usedParts" :options="usedParts" label="Partie(s) utilisée(s)" search />
+            <div class="ml-4">
+              <DsfrTag
+                v-for="id in state.usedParts"
+                :key="id"
+                :label="optionLabel(usedParts, id)"
+                class="mx-1"
+              ></DsfrTag>
+            </div>
           </div>
-        </div>
-        <div v-if="formForType.activeSubstances" class="flex items-center my-4">
-          <!-- TODO: option to create new active substance -->
-          <DsfrMultiselect
-            v-model="state.activeSubstances"
-            :options="activeSubstances"
-            label="Substances actives"
-            search
-          />
-          <div class="ml-4">
-            <DsfrTag
-              v-for="id in state.activeSubstances"
-              :key="id"
-              :label="optionLabel(activeSubstances, id)"
-              class="mx-1"
-            ></DsfrTag>
-          </div>
-        </div>
-        <p><i>Population cible et à risque en construction</i></p>
-      </DsfrFieldset>
-      <DsfrFieldset legend="Commentaire à destination du public" legendClass="fr-h4">
-        <div class="flex">
-          <DsfrInput label="Commentaire" v-model="state.publicComment" :isTextarea="true" />
-          <div class="mt-2">
-            <DsfrCheckbox
-              v-model="state.copyPublicCommentToPrivate"
-              name="copy-comment"
-              label="Copier dans les notes internes"
+          <div v-if="formForType.activeSubstances" class="flex items-center my-4">
+            <!-- TODO: option to create new active substance -->
+            <DsfrMultiselect
+              v-model="state.activeSubstances"
+              :options="activeSubstances"
+              label="Substances actives"
+              search
             />
+            <div class="ml-4">
+              <DsfrTag
+                v-for="id in state.activeSubstances"
+                :key="id"
+                :label="optionLabel(activeSubstances, id)"
+                class="mx-1"
+              ></DsfrTag>
+            </div>
           </div>
+          <p><i>Population cible et à risque en construction</i></p>
+        </DsfrFieldset>
+        <DsfrFieldset legend="Commentaire à destination du public" legendClass="fr-h4">
+          <div class="flex">
+            <DsfrInput label="Commentaire" v-model="state.publicComment" :isTextarea="true" />
+            <div class="mt-2">
+              <DsfrCheckbox
+                v-model="state.copyPublicCommentToPrivate"
+                name="copy-comment"
+                label="Copier dans les notes internes"
+              />
+            </div>
+          </div>
+        </DsfrFieldset>
+        <div class="flex gap-x-2 mt-4">
+          <!-- Question: cancel button? -->
+          <!-- Question: use DsfrButtonGroup? -->
+          <DsfrButton label="Enregistrer ingrédient" @click="saveElement" :disabled="isFetching" />
+          <DsfrButton label="Sauvegarder brouillon" @click="saveAsDraft" :disabled="isFetching" secondary />
         </div>
-      </DsfrFieldset>
-      <div class="flex gap-x-2 mt-4">
-        <!-- Question: cancel button? -->
-        <!-- Question: use DsfrButtonGroup? -->
-        <DsfrButton label="Enregistrer ingrédient" @click="saveElement" :disabled="isFetching" />
-        <DsfrButton label="Sauvegarder brouillon" @click="saveAsDraft" :disabled="isFetching" secondary />
-      </div>
-    </FormWrapper>
+      </FormWrapper>
+    </div>
   </div>
 </template>
 

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -219,13 +219,12 @@ const breadcrumbLinks = computed(() => {
   return links
 })
 
-const EMPTY_SYNONYM = { name: "" }
-const newSynonym = () => JSON.parse(JSON.stringify(EMPTY_SYNONYM))
+const createEmptySynonym = () => ({ name: "" })
 
 const state = ref({
   plantParts: [],
   substances: [],
-  synonyms: [newSynonym(), newSynonym(), newSynonym()],
+  synonyms: [createEmptySynonym(), createEmptySynonym(), createEmptySynonym()],
 })
 
 const saveElement = async () => {
@@ -258,7 +257,7 @@ const saveElement = async () => {
   }
 }
 const addNewSynonym = async () => {
-  state.value.synonyms.push(newSynonym())
+  state.value.synonyms.push(createEmptySynonym())
 }
 
 const formQuestions = {

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -7,7 +7,7 @@
         <h1 class="-mt-6 mb-4">{{ pageTitle }}</h1>
       </div>
     </div>
-    <div class="fr-container">
+    <div v-if="formForType" class="fr-container">
       <p class="mt-6">
         <v-icon :name="icon" />
         {{ typeName }}
@@ -43,8 +43,8 @@
                 <DsfrInput v-model="state.genus" label="Genre" labelVisible required />
               </DsfrInputGroup>
             </div>
-            <div class="col-span-2">
-              <DsfrInputGroup v-if="formForType.ingredientType">
+            <div v-if="formForType.ingredientType" class="col-span-2">
+              <DsfrInputGroup>
                 <DsfrSelect
                   v-model="state.ingredientType"
                   label="Type de l'ingrédient"
@@ -175,16 +175,26 @@
         </div>
       </FormWrapper>
     </div>
+    <div v-else class="fr-container">
+      <div class="grid sm:grid-cols-2 gap-8 sm:p-8 m-8">
+        <DsfrTile
+          v-for="(content, type) in formQuestions"
+          :key="type"
+          :title="content.title"
+          :to="{ query: { type: type } }"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed } from "vue"
+import { ref, computed, watch } from "vue"
 import { getTypeIcon, getTypeInFrench, unSlugifyType, getApiType } from "@/utils/mappings"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 // import { firstErrorMsg } from "@/utils/forms"
-import { /*useRoute,*/ useRouter } from "vue-router"
+import { useRoute, useRouter } from "vue-router"
 import { useFetch } from "@vueuse/core"
 import { headers } from "@/utils/data-fetching"
 import { handleError } from "@/utils/error-handling"
@@ -193,9 +203,9 @@ import FormWrapper from "@/components/FormWrapper"
 import ElementAutocomplete from "@/components/ElementAutocomplete"
 import NumberField from "@/components/NumberField"
 
-// TODO: make type changeable and prefillable via query param
-const type = ref("ingredient")
-const icon = computed(() => getTypeIcon(type.value))
+const route = useRoute()
+const type = computed(() => route.query.type)
+const icon = computed(() => formForType.value.icon)
 const typeName = computed(() => getTypeInFrench(type.value))
 const router = useRouter()
 
@@ -244,6 +254,8 @@ const addNewSynonym = async () => {
 
 const formQuestions = {
   plant: {
+    title: "Plante",
+    icon: getTypeIcon("plant"),
     name: {
       label: "Nom de la plante",
     },
@@ -259,6 +271,8 @@ const formQuestions = {
     // public notes true for every type
   },
   substance: {
+    title: "Substance",
+    icon: getTypeIcon("substance"),
     name: {
       label: "Nom de la substance",
     },
@@ -269,12 +283,16 @@ const formQuestions = {
     unit: true,
   },
   microorganism: {
+    title: "Micro organisme",
+    icon: getTypeIcon("microorganism"),
     species: true,
     genus: true,
     function: true,
     substances: true,
   },
-  default: {
+  ingredient: {
+    title: "Autre ingrédient",
+    icon: getTypeIcon("ingredient"),
     name: {
       label: "Nom ingrédient",
     },
@@ -284,7 +302,7 @@ const formQuestions = {
   },
 }
 const formForType = computed(() => {
-  return formQuestions[type.value] || formQuestions.default
+  return formQuestions[type.value]
 })
 
 const store = useRootStore()

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -58,6 +58,29 @@
           // description is true for every type -->
       </DsfrFieldset>
       <DsfrFieldset legend="Utilisation de l’ingrédient" legendClass="fr-h4">
+        <div v-if="formForType.usedParts" class="flex items-center my-4">
+          <DsfrMultiselect v-model="state.usedParts" :options="usedParts" label="Partie(s) utilisée(s)" search />
+          <div class="ml-4">
+            <DsfrTag v-for="id in state.usedParts" :key="id" :label="optionLabel(usedParts, id)" class="mx-1"></DsfrTag>
+          </div>
+        </div>
+        <div v-if="formForType.activeSubstances" class="flex items-center my-4">
+          <!-- TODO: option to create new active substance -->
+          <DsfrMultiselect
+            v-model="state.activeSubstances"
+            :options="activeSubstances"
+            label="Substances actives"
+            search
+          />
+          <div class="ml-4">
+            <DsfrTag
+              v-for="id in state.activeSubstances"
+              :key="id"
+              :label="optionLabel(activeSubstances, id)"
+              class="mx-1"
+            ></DsfrTag>
+          </div>
+        </div>
         <!-- usedParts: true,
         activeSubstances: true,
         // population cible: true for everyone also not yet in our database -->
@@ -74,7 +97,7 @@
 </template>
 
 <script setup>
-import { /*ref, */ computed /*, watch*/ } from "vue"
+import { ref, computed /*, watch*/ } from "vue"
 import { getTypeIcon, getTypeInFrench, unSlugifyType /*, getApiType*/ } from "@/utils/mappings"
 // import { firstErrorMsg } from "@/utils/forms"
 // import { useRoute, useRouter } from "vue-router"
@@ -94,7 +117,10 @@ const breadcrumbLinks = computed(() => {
   return links
 })
 
-const state = {} // TODO: prefill with existing data if modifying
+const state = ref({
+  usedParts: [],
+  activeSubstances: [],
+}) // TODO: prefill with existing data if modifying
 
 const isFetching = false // TODO: set to true when fetching data or sending update, see CompanyForm
 
@@ -161,4 +187,17 @@ const synonyms = [
   { label: "Example", type: "Nom en anglais" },
   { label: "Cassius", type: "Nom en latin" },
 ]
+
+const usedParts = [
+  { label: "Root", id: 1 },
+  { label: "Leaf", id: 2 },
+]
+const activeSubstances = [
+  { label: "Ex 1", id: 1 },
+  { label: "Ex 2", id: 2 },
+]
+
+const optionLabel = (options, id) => {
+  return options.find((o) => o.id === id)?.label || "Inconnu"
+}
 </script>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -27,6 +27,12 @@
           <DsfrInputGroup v-if="formForType.genre">
             <DsfrInput v-model="state.genre" label="Genre" labelVisible />
           </DsfrInputGroup>
+          <DsfrInputGroup v-if="formForType.ingredientType">
+            <!-- Question: multiselect or single? -->
+            <!-- Question: do we have this in the DB? -->
+            <DsfrSelect v-model="state.ingredientType" label="Type ingrédient" :options="ingredientTypes" required />
+          </DsfrInputGroup>
+          <!-- TODO: sort out row col wrapping for default -->
           <DsfrInputGroup v-if="formForType.function">
             <!-- Question: multiselect or single? -->
             <!-- Question: do we have this in the DB? -->
@@ -211,12 +217,13 @@ const formQuestions = {
   },
 }
 const formForType = computed(() => {
-  return formQuestions.microorganism // TODO: choose based on type
+  return formQuestions.default // TODO: choose based on type
 })
 
 const plantFamilies = [] // TODO: fetch options from DB
 const functions = [] // TODO: fetch options from DB
 const substanceTypes = [] // TODO: fetch options from DB
+const ingredientTypes = [] // TODO: fetch options from DB
 
 const synonyms = [
   { label: "Example", type: "Nom en anglais" },

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -79,10 +79,7 @@
                 v-model="state.synonyms[idx].name"
                 class="mb-4"
               />
-              <!-- TODO: table -->
               <!-- TODO: delete/edit per line -->
-              <!-- TODO: add new line -->
-              <!-- TODO: if new, three ? editable lines by default -->
               <DsfrButton
                 label="Ajouter un synonyme"
                 @click="addNewSynonym"
@@ -122,6 +119,7 @@
               hint="Tapez au moins trois caractères pour démarrer la recherche"
               :hideSearchButton="true"
               @selected="selectOption"
+              type="substance"
             />
             <div class="ml-4">
               <!-- TODO: align tags with input -->

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -162,8 +162,9 @@ import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 // import { firstErrorMsg } from "@/utils/forms"
 // import { useRoute, useRouter } from "vue-router"
-// import { useFetch } from "@vueuse/core"
-// import { handleError } from "@/utils/error-handling"
+import { useFetch } from "@vueuse/core"
+import { headers } from "@/utils/data-fetching"
+import { handleError } from "@/utils/error-handling"
 import FormWrapper from "@/components/FormWrapper"
 import ElementAutocomplete from "@/components/ElementAutocomplete"
 
@@ -187,7 +188,19 @@ const state = ref({
 
 const isFetching = false // TODO: set to true when fetching data or sending update, see CompanyForm
 
-const saveElement = async () => {}
+const saveElement = async () => {
+  // TODO: map misc ingredient types to other-ingrediet with getApiType or whatever
+  const url = `/api/v1/${type.value}s/`
+  const payload = state.value
+  if (payload.substances.length) {
+    payload.substances = payload.substances.map((substance) => substance.id)
+  }
+  const { response } = await useFetch(url, { headers: headers() }).post(payload).json()
+  await handleError(response)
+  if (response.value.ok) {
+    // TODO: redirect
+  }
+}
 // const saveAsDraft = async () => {}
 const addNewSynonym = async () => {}
 

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -70,6 +70,7 @@
               <DsfrInput v-model="state.casNumber" label="Numéro CAS" labelVisible />
             </DsfrInputGroup>
             <DsfrToggleSwitch
+              v-if="!state.ingredientType || state.ingredientType != AROMA"
               v-model="state.novelFood"
               label="Novel food"
               activeText="Oui"
@@ -249,6 +250,7 @@ const saveElement = async () => {
   }
   payload.synonyms = payload.synonyms.filter((s) => !!s.name)
   payload.status = payload.status ? 1 : 2
+  if (payload.ingredientType && payload.ingredientType == AROMA.value) delete payload.novelFood
 
   const { response } = await useFetch(url, { headers: headers() }).post(payload).json()
   $externalResults.value = await handleError(response)
@@ -276,7 +278,7 @@ const formQuestions = {
     family: true,
     function: true,
     // authorise: true for every type
-    // novelFood is true for every type TODO: not for aromes
+    // novelFood is true for every type
     // synonymes are true for every type
     plantParts: true,
     substances: true,
@@ -360,4 +362,6 @@ const optionLabel = (options, id) => {
 const plantFamiliesDisplay = computed(() => {
   return plantFamilies.value?.map((family) => ({ value: family.id, text: family.name }))
 })
+
+const AROMA = ref(3)
 </script>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -52,7 +52,7 @@
             </DsfrInputGroup>
 
             <DsfrToggleSwitch
-              v-model="state.authorised"
+              v-model="state.status"
               label="Autorisation de l’ingrédient"
               activeText="Authorisé"
               inactiveText="Non authorisé"
@@ -208,6 +208,7 @@ const saveElement = async () => {
   }
   // TODO: this will need updating when modifying ingredients
   payload.synonyms = payload.synonyms.filter((s) => !!s.name)
+  payload.status = payload.status ? 1 : 2
   const { response } = await useFetch(url, { headers: headers() }).post(payload).json()
   await handleError(response)
   if (response.value.ok) {

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -24,6 +24,9 @@
             <!-- Question: multiselect or single? -->
             <DsfrSelect v-model="state.caFamily" label="Famille de la plante" :options="plantFamilies" required />
           </DsfrInputGroup>
+          <DsfrInputGroup v-if="formForType.genre">
+            <DsfrInput v-model="state.genre" label="Genre" labelVisible />
+          </DsfrInputGroup>
           <DsfrInputGroup v-if="formForType.function">
             <!-- Question: multiselect or single? -->
             <!-- Question: do we have this in the DB? -->
@@ -208,7 +211,7 @@ const formQuestions = {
   },
 }
 const formForType = computed(() => {
-  return formQuestions.substance // TODO: choose based on type
+  return formQuestions.microorganism // TODO: choose based on type
 })
 
 const plantFamilies = [] // TODO: fetch options from DB

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -136,15 +136,13 @@
           <!-- TODO: add max quantity, nutritional reference, unit for substance -->
           <p><i>Population cible et à risque en construction</i></p>
         </DsfrFieldset>
-        <DsfrFieldset legend="Commentaire à destination du public" legendClass="fr-h4">
-          <div class="flex">
-            <DsfrInput label="Commentaire" v-model="state.publicComment" :isTextarea="true" />
-            <div class="mt-2">
-              <DsfrCheckbox
-                v-model="state.copyPublicCommentToPrivate"
-                name="copy-comment"
-                label="Copier dans les notes internes"
-              />
+        <DsfrFieldset legend="Commentaires" legendClass="fr-h4">
+          <div class="grid md:grid-cols-2 md:gap-4">
+            <div>
+              <DsfrInput label="Commentaire public" v-model="state.publicComments" :isTextarea="true" label-visible />
+            </div>
+            <div>
+              <DsfrInput label="Commentaire privé" v-model="state.privateComments" :isTextarea="true" label-visible />
             </div>
           </div>
         </DsfrFieldset>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -15,7 +15,7 @@
 
       <!-- TODO: tabs -->
       <FormWrapper class="mx-auto">
-        <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4">
+        <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4 !mb-0 !pb-2">
           <!-- TODO: validation -->
           <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-x-4">
             <div class="col-span-2">
@@ -88,8 +88,8 @@
             </DsfrFieldset>
           </div>
         </DsfrFieldset>
-        <DsfrFieldset legend="Utilisation de l’ingrédient" legendClass="fr-h4 !pb-0">
-          <div v-if="formForType.plantParts" class="flex items-center my-4">
+        <DsfrFieldset legend="Utilisation de l’ingrédient" legendClass="fr-h4 !mb-0 !pb-2">
+          <div v-if="formForType.plantParts" class="grid md:grid-cols-3 items-end my-4 md:my-2">
             <DsfrMultiselect
               v-model="state.plantParts"
               :options="plantParts"
@@ -97,7 +97,7 @@
               search
               labelKey="name"
             />
-            <div class="ml-4">
+            <div class="md:ml-4 md:my-8 md:col-span-2">
               <DsfrTag
                 v-for="id in state.plantParts"
                 :key="id"
@@ -106,19 +106,19 @@
               ></DsfrTag>
             </div>
           </div>
-          <div v-if="formForType.substances" class="flex items-center my-4">
+          <div v-if="formForType.substances" class="grid md:grid-cols-3 items-end my-4 md:my-2">
             <!-- TODO: option to create new active substance -->
             <ElementAutocomplete
               autocomplete="nothing"
               label="Substances actives"
               label-visible
-              class="max-w-md grow"
+              class="max-w-md grow mb-3"
               hint="Tapez au moins trois caractères pour démarrer la recherche"
               :hideSearchButton="true"
               @selected="selectOption"
               type="substance"
             />
-            <div class="ml-4">
+            <div class="md:ml-4 md:my-7 md:col-span-2">
               <!-- TODO: align tags with input -->
               <!-- TODO: filter to only include substances -->
               <!-- TODO: make tags deleteable -->
@@ -131,14 +131,14 @@
             </div>
           </div>
           <!-- TODO: add max quantity, nutritional reference, unit for substance -->
-          <p><i>Population cible et à risque en construction</i></p>
+          <p class="my-4"><i>Population cible et à risque en construction</i></p>
         </DsfrFieldset>
-        <DsfrFieldset legend="Commentaires" legendClass="fr-h4">
+        <DsfrFieldset legend="Commentaires" legendClass="fr-h4 !mb-0">
           <div class="grid md:grid-cols-2 md:gap-4">
-            <div>
+            <div class="mb-4">
               <DsfrInput label="Commentaire public" v-model="state.publicComments" :isTextarea="true" label-visible />
             </div>
-            <div>
+            <div class="mb-4">
               <DsfrInput label="Commentaire privé" v-model="state.privateComments" :isTextarea="true" label-visible />
             </div>
           </div>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div class="fr-container">
-      <p>
+      <p class="mt-6">
         <v-icon :name="icon" />
         {{ typeName }}
       </p>
@@ -227,7 +227,7 @@ const formQuestions = {
   },
 }
 const formForType = computed(() => {
-  return formQuestions.default // TODO: choose based on type
+  return formQuestions[type.value] || formQuestions.default
 })
 
 const plantFamilies = [] // TODO: fetch options from DB

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -34,8 +34,8 @@
             <DsfrToggleSwitch
               v-model="state.status"
               label="Autorisation de l’ingrédient"
-              activeText="Authorisé"
-              inactiveText="Non authorisé"
+              activeText="Autorisé"
+              inactiveText="Non autorisé"
               label-left
               class="self-center mt-4 col-span-2 sm:col-span-1"
             />
@@ -108,7 +108,7 @@
             <div class="md:ml-4 md:my-8 md:col-span-2">
               <DsfrTag
                 v-for="id in state.plantParts"
-                :key="id"
+                :key="`plant-part-${id}`"
                 :label="optionLabel(plantParts, id)"
                 class="mx-1"
               ></DsfrTag>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -1,17 +1,32 @@
 <template>
-  <div class="fr-container">
+  <div class="fr-container mb-8">
     <DsfrBreadcrumb class="mb-8" :links="breadcrumbLinks" />
 
-    <h1>
-      <v-icon scale="2" :name="icon" />
-      Modification élément
-    </h1>
+    <h1>Modification élément</h1>
+
+    <p>
+      <v-icon :name="icon" />
+      {{ typeName }}
+    </p>
+
+    <!-- TODO: tabs -->
+    <FormWrapper class="mx-auto">
+      <DsfrFieldset legend="Identité de l’ingrédient"></DsfrFieldset>
+      <DsfrFieldset legend="Utilisation de l’ingrédient"></DsfrFieldset>
+      <DsfrFieldset legend="Commentaire à destination du public"></DsfrFieldset>
+      <div class="flex gap-x-2 mt-4">
+        <!-- Question: cancel button? -->
+        <DsfrButton label="Enregistrer ingrédient" @click="saveElement" :disabled="isFetching" />
+        <DsfrButton label="Sauvegarder brouillon" @click="saveAsDraft" :disabled="isFetching" secondary />
+      </div>
+    </FormWrapper>
   </div>
 </template>
 
 <script setup>
 import { /*ref, */ computed /*, watch*/ } from "vue"
-import { getTypeIcon, /*getTypeInFrench,*/ unSlugifyType /*, getApiType*/ } from "@/utils/mappings"
+import { getTypeIcon, getTypeInFrench, unSlugifyType /*, getApiType*/ } from "@/utils/mappings"
+import FormWrapper from "@/components/FormWrapper"
 // import { useRoute, useRouter } from "vue-router"
 // import { useFetch } from "@vueuse/core"
 // import { handleError } from "@/utils/error-handling"
@@ -20,10 +35,16 @@ const props = defineProps({ urlComponent: String })
 const elementId = computed(() => props.urlComponent.split("--")[0])
 const type = computed(() => unSlugifyType(props.urlComponent.split("--")[1]))
 const icon = computed(() => getTypeIcon(type.value))
+const typeName = computed(() => getTypeInFrench(type.value))
 
 const breadcrumbLinks = computed(() => {
   const links = [{ to: { name: "DashboardPage" }, text: "Tableau de bord" }]
   links.push({ text: `Modification élément ${elementId.value}` })
   return links
 })
+
+const isFetching = false // TODO: set to true when fetching data or sending update, see CompanyForm
+
+const saveElement = async () => {}
+const saveAsDraft = async () => {}
 </script>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -85,7 +85,18 @@
         activeSubstances: true,
         // population cible: true for everyone also not yet in our database -->
       </DsfrFieldset>
-      <DsfrFieldset legend="Commentaire à destination du public" legendClass="fr-h4"></DsfrFieldset>
+      <DsfrFieldset legend="Commentaire à destination du public" legendClass="fr-h4">
+        <div class="flex">
+          <DsfrInput label="Commentaire" v-model="state.publicComment" :isTextarea="true" />
+          <div class="mt-2">
+            <DsfrCheckbox
+              v-model="state.copyPublicCommentToPrivate"
+              name="copy-comment"
+              label="Copier dans les notes internes"
+            />
+          </div>
+        </div>
+      </DsfrFieldset>
       <div class="flex gap-x-2 mt-4">
         <!-- Question: cancel button? -->
         <!-- Question: use DsfrButtonGroup? -->

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -17,14 +17,13 @@
       <FormWrapper class="mx-auto">
         <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4">
           <!-- TODO: validation -->
-          <!-- TODO: responsiveness -->
-          <div class="flex gap-x-4">
-            <div class="flex-1">
+          <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-x-4">
+            <div class="col-span-2">
               <DsfrInputGroup>
                 <DsfrInput v-model="state.name" :label="formForType.name.label" required labelVisible />
               </DsfrInputGroup>
             </div>
-            <div class="flex-1">
+            <div class="col-span-2">
               <DsfrInputGroup v-if="formForType.family && plantFamiliesDisplay">
                 <!-- Question: multiselect or single? -->
                 <DsfrSelect
@@ -57,10 +56,8 @@
               activeText="Authorisé"
               inactiveText="Non authorisé"
               label-left
-              class="self-center"
+              class="self-center col-span-2 md:col-span-1"
             />
-          </div>
-          <div class="flex gap-x-4">
             <DsfrInputGroup v-if="formForType.einecsNumber">
               <DsfrInput v-model="state.einecsNumber" label="Numéro EINECS" labelVisible />
             </DsfrInputGroup>
@@ -71,7 +68,7 @@
               <DsfrInput v-model="state.source" label="Source" labelVisible />
             </DsfrInputGroup>
           </div>
-          <div class="grid md:grid-cols-2">
+          <div class="grid md:grid-cols-2 mt-4">
             <DsfrFieldset legend="Synonymes" legendClass="fr-text--lg !pb-0 !mb-2 !mt-4">
               <DsfrInput
                 v-for="(_, idx) in state.synonyms"

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -4,7 +4,7 @@
       <div class="fr-container">
         <DsfrBreadcrumb :links="breadcrumbLinks" />
 
-        <h1 class="-mt-6 mb-4">Modification élément</h1>
+        <h1 class="-mt-6 mb-4">{{ pageTitle }}</h1>
       </div>
     </div>
     <div class="fr-container">
@@ -177,9 +177,11 @@ const icon = computed(() => getTypeIcon(type.value))
 const typeName = computed(() => getTypeInFrench(type.value))
 const router = useRouter()
 
+const pageTitle = "Création élément" // eventually will be computed on the action (create/modify)
+
 const breadcrumbLinks = computed(() => {
   const links = [{ to: { name: "DashboardPage" }, text: "Tableau de bord" }]
-  // links.push({ text: `Modification élément ${elementId.value}` })
+  links.push({ text: pageTitle })
   return links
 })
 
@@ -191,6 +193,7 @@ const state = ref({
 const isFetching = false // TODO: set to true when fetching data or sending update, see CompanyForm
 
 const saveElement = async () => {
+  // TODO: validate form before anything else
   // TODO: map misc ingredient types to other-ingrediet with getApiType or whatever
   const url = `/api/v1/${type.value}s/`
   const payload = state.value

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -20,13 +20,13 @@
           <div class="flex gap-x-4">
             <div class="flex-1">
               <DsfrInputGroup>
-                <DsfrInput v-model="state.caName" :label="formForType.name.label" required labelVisible />
+                <DsfrInput v-model="state.name" :label="formForType.name.label" required labelVisible />
               </DsfrInputGroup>
             </div>
             <div class="flex-1">
               <DsfrInputGroup v-if="formForType.family">
                 <!-- Question: multiselect or single? -->
-                <DsfrSelect v-model="state.caFamily" label="Famille de la plante" :options="plantFamilies" required />
+                <DsfrSelect v-model="state.family" label="Famille de la plante" :options="plantFamilies" required />
               </DsfrInputGroup>
             </div>
             <!-- TODO: add species -->
@@ -55,13 +55,13 @@
           </div>
           <div class="flex gap-x-4">
             <DsfrInputGroup v-if="formForType.einecsNumber">
-              <DsfrInput v-model="state.caEinecsNumber" label="Numéro EINECS" labelVisible />
+              <DsfrInput v-model="state.einecsNumber" label="Numéro EINECS" labelVisible />
             </DsfrInputGroup>
             <DsfrInputGroup v-if="formForType.casNumber">
-              <DsfrInput v-model="state.caCasNumber" label="Numéro CAS" labelVisible />
+              <DsfrInput v-model="state.casNumber" label="Numéro CAS" labelVisible />
             </DsfrInputGroup>
             <DsfrInputGroup v-if="formForType.source">
-              <DsfrInput v-model="state.caSource" label="Source" labelVisible />
+              <DsfrInput v-model="state.source" label="Source" labelVisible />
             </DsfrInputGroup>
           </div>
           <DsfrFieldset legend="Synonymes" legendClass="fr-text--lg !pb-0 !mb-2 !mt-4">
@@ -162,7 +162,7 @@ const state = ref({
 const isFetching = false // TODO: set to true when fetching data or sending update, see CompanyForm
 
 const saveElement = async () => {}
-const saveAsDraft = async () => {}
+// const saveAsDraft = async () => {}
 const addNewSynonym = async () => {}
 
 const formQuestions = {

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -40,6 +40,7 @@
               label-left
               class="self-center mt-4 col-span-2 sm:col-span-1"
             />
+            <!-- TODO: either sort alphabetically or allow for search to select -->
             <div class="col-span-2" v-if="formForType.family && plantFamiliesDisplay">
               <DsfrInputGroup :error-message="firstErrorMsg(v$, 'family')">
                 <DsfrSelect
@@ -116,6 +117,7 @@
           </div>
           <div v-if="formForType.substances" class="grid md:grid-cols-3 items-end my-4 md:my-2">
             <!-- TODO: option to create new active substance -->
+            <!-- TODO: remove asterix -->
             <ElementAutocomplete
               autocomplete="nothing"
               label="Substances actives"
@@ -213,7 +215,7 @@ const icon = computed(() => formForType.value.icon)
 const typeName = computed(() => getTypeInFrench(type.value))
 const router = useRouter()
 
-const pageTitle = "Création élément" // eventually will be computed on the action (create/modify)
+const pageTitle = "Nouvel ingrédient" // eventually will be computed on the action (create/modify)
 
 const breadcrumbLinks = computed(() => {
   const links = [{ to: { name: "DashboardPage" }, text: "Tableau de bord" }]
@@ -323,6 +325,7 @@ const rules = computed(() => {
     genus: form?.genus ? errorRequiredField : {},
     ingredientType: form?.ingredientType ? errorRequiredField : {},
     family: form?.family ? errorRequiredField : {},
+    // TODO: the following are optional
     nutritionalReference: form?.nutritionalReference ? errorRequiredPositiveNumber : {},
     maxQuantity: form?.maxQuantity ? errorRequiredPositiveNumber : {},
     unit: form?.unit ? errorRequiredField : {},

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -13,7 +13,6 @@
         {{ typeName }}
       </p>
 
-      <!-- TODO: tabs -->
       <FormWrapper class="mx-auto">
         <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4 !mb-0 !pb-2">
           <!-- TODO: validation -->
@@ -25,7 +24,6 @@
             </div>
             <div class="col-span-2" v-if="formForType.family && plantFamiliesDisplay">
               <DsfrInputGroup>
-                <!-- Question: multiselect or single? -->
                 <DsfrSelect
                   v-model="state.family"
                   label="Famille de la plante"
@@ -46,7 +44,6 @@
               </DsfrInputGroup>
             </div>
             <DsfrInputGroup v-if="formForType.ingredientType">
-              <!-- Question: multiselect or single? -->
               <!-- Question: do we have this in the DB? -->
               <DsfrSelect v-model="state.ingredientType" label="Type ingrédient" :options="ingredientTypes" required />
             </DsfrInputGroup>
@@ -82,7 +79,6 @@
                 v-model="state.synonyms[idx].name"
                 class="mb-4"
               />
-              <!-- TODO: delete/edit per line -->
               <DsfrButton
                 label="Ajouter un synonyme"
                 @click="addNewSynonym"
@@ -125,8 +121,6 @@
               type="substance"
             />
             <div class="md:ml-4 md:my-7 md:col-span-2">
-              <!-- TODO: align tags with input -->
-              <!-- TODO: filter to only include substances -->
               <!-- TODO: make tags deleteable -->
               <DsfrTag
                 v-for="substance in state.substances"
@@ -158,7 +152,6 @@
               />
             </div>
           </div>
-          <!-- TODO: add max quantity, nutritional reference, unit for substance -->
           <p class="my-4"><i>Population cible et à risque en construction</i></p>
         </DsfrFieldset>
         <DsfrFieldset legend="Commentaires" legendClass="fr-h4 !mb-0">
@@ -172,10 +165,7 @@
           </div>
         </DsfrFieldset>
         <div class="flex gap-x-2 mt-4">
-          <!-- Question: cancel button? -->
-          <!-- Question: use DsfrButtonGroup? -->
           <DsfrButton label="Enregistrer ingrédient" @click="saveElement" :disabled="isFetching" />
-          <!-- <DsfrButton label="Sauvegarder brouillon" @click="saveAsDraft" :disabled="isFetching" secondary /> -->
         </div>
       </FormWrapper>
     </div>
@@ -183,7 +173,7 @@
 </template>
 
 <script setup>
-import { ref, computed /*, watch*/ } from "vue"
+import { ref, computed } from "vue"
 import { getTypeIcon, getTypeInFrench, unSlugifyType /*, getApiType*/ } from "@/utils/mappings"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
@@ -197,9 +187,7 @@ import FormWrapper from "@/components/FormWrapper"
 import ElementAutocomplete from "@/components/ElementAutocomplete"
 import NumberField from "@/components/NumberField"
 
-// const props = defineProps({ urlComponent: String })
-// const elementId = computed(() => props.urlComponent.split("--")[0])
-// const type = computed(() => unSlugifyType(props.urlComponent.split("--")[1]))
+// TODO: make type changeable and prefillable via query param
 const type = ref("substance")
 const icon = computed(() => getTypeIcon(type.value))
 const typeName = computed(() => getTypeInFrench(type.value))
@@ -220,7 +208,7 @@ const state = ref({
   plantParts: [],
   substances: [],
   synonyms: [newSynonym(), newSynonym(), newSynonym()],
-}) // TODO: prefill with existing data if modifying
+})
 
 const isFetching = false // TODO: set to true when fetching data or sending update, see CompanyForm
 
@@ -232,7 +220,6 @@ const saveElement = async () => {
   if (payload.substances.length) {
     payload.substances = payload.substances.map((substance) => substance.id)
   }
-  // TODO: this will need updating when modifying ingredients
   payload.synonyms = payload.synonyms.filter((s) => !!s.name)
   payload.status = payload.status ? 1 : 2
   const { response } = await useFetch(url, { headers: headers() }).post(payload).json()
@@ -246,7 +233,6 @@ const saveElement = async () => {
     router.push({ name: "DashboardPage" })
   }
 }
-// const saveAsDraft = async () => {}
 const addNewSynonym = async () => {
   state.value.synonyms.push(newSynonym())
 }

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -24,9 +24,15 @@
               </DsfrInputGroup>
             </div>
             <div class="flex-1">
-              <DsfrInputGroup v-if="formForType.family">
+              <DsfrInputGroup v-if="formForType.family && plantFamiliesDisplay">
                 <!-- Question: multiselect or single? -->
-                <DsfrSelect v-model="state.family" label="Famille de la plante" :options="plantFamilies" required />
+                <DsfrSelect
+                  v-model="state.family"
+                  label="Famille de la plante"
+                  :options="plantFamiliesDisplay"
+                  labelKey="name"
+                  required
+                />
               </DsfrInputGroup>
             </div>
             <!-- TODO: add species -->
@@ -238,10 +244,10 @@ const formForType = computed(() => {
 })
 
 const store = useRootStore()
-const { plantParts } = storeToRefs(store)
+const { plantParts, plantFamilies } = storeToRefs(store)
 store.fetchDeclarationFieldsData()
+store.fetchPlantFamilies()
 
-const plantFamilies = [] // TODO: fetch options from DB
 const substanceTypes = [] // TODO: fetch options from DB
 const ingredientTypes = [] // TODO: fetch options from DB
 
@@ -257,4 +263,8 @@ const selectOption = async (result) => {
 const optionLabel = (options, id) => {
   return options.find((o) => o.id === id)?.name || "Inconnu"
 }
+
+const plantFamiliesDisplay = computed(() => {
+  return plantFamilies.value?.map((family) => ({ value: family.id, text: family.name }))
+})
 </script>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -17,6 +17,9 @@
           <DsfrInputGroup>
             <DsfrInput v-model="state.caName" :label="formForType.name.label" required labelVisible />
           </DsfrInputGroup>
+          <DsfrInputGroup v-if="formForType.nameEn">
+            <DsfrInput v-model="state.caNameEn" :label="formForType.nameEn.label" labelVisible />
+          </DsfrInputGroup>
           <DsfrInputGroup v-if="formForType.family">
             <!-- Question: multiselect or single? -->
             <DsfrSelect v-model="state.caFamily" label="Famille de la plante" :options="plantFamilies" required />
@@ -25,6 +28,11 @@
             <!-- Question: multiselect or single? -->
             <!-- Question: do we have this in the DB? -->
             <DsfrSelect v-model="state.function" label="Fonction de l'ingrédient" :options="functions" required />
+          </DsfrInputGroup>
+          <DsfrInputGroup v-if="formForType.substanceType">
+            <!-- Question: multiselect or single? -->
+            <!-- Question: do we have this in the DB? -->
+            <DsfrSelect v-model="state.substanceType" label="Type de substance" :options="substanceTypes" required />
           </DsfrInputGroup>
 
           <DsfrToggleSwitch
@@ -35,6 +43,20 @@
             label-left
             class="self-center"
           />
+        </div>
+        <div class="flex gap-x-4 -mb-4">
+          <DsfrInputGroup v-if="formForType.einecsNumber">
+            <DsfrInput v-model="state.einecsNumber" label="Numéro EINECS" labelVisible />
+          </DsfrInputGroup>
+          <DsfrInputGroup v-if="formForType.casNumber">
+            <DsfrInput v-model="state.casNumber" label="Numéro CAS" labelVisible />
+          </DsfrInputGroup>
+          <DsfrInputGroup v-if="formForType.source">
+            <DsfrInput v-model="state.source" label="Source" labelVisible />
+          </DsfrInputGroup>
+          <DsfrInputGroup v-if="formForType.sourceEn">
+            <DsfrInput v-model="state.sourceEn" label="Source en anglais" labelVisible />
+          </DsfrInputGroup>
         </div>
         <DsfrInputGroup>
           <DsfrInput v-model="state.description" label="Description" labelVisible />
@@ -81,9 +103,7 @@
             ></DsfrTag>
           </div>
         </div>
-        <!-- usedParts: true,
-        activeSubstances: true,
-        // population cible: true for everyone also not yet in our database -->
+        <p><i>Population cible et à risque en construction</i></p>
       </DsfrFieldset>
       <DsfrFieldset legend="Commentaire à destination du public" legendClass="fr-h4">
         <div class="flex">
@@ -188,11 +208,12 @@ const formQuestions = {
   },
 }
 const formForType = computed(() => {
-  return formQuestions.plant // TODO: choose based on type
+  return formQuestions.substance // TODO: choose based on type
 })
 
 const plantFamilies = [] // TODO: fetch options from DB
 const functions = [] // TODO: fetch options from DB
+const substanceTypes = [] // TODO: fetch options from DB
 
 const synonyms = [
   { label: "Example", type: "Nom en anglais" },

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -84,7 +84,13 @@
         </DsfrFieldset>
         <DsfrFieldset legend="Utilisation de l’ingrédient" legendClass="fr-h4 !pb-0">
           <div v-if="formForType.plantParts" class="flex items-center my-4">
-            <DsfrMultiselect v-model="state.plantParts" :options="plantParts" label="Partie(s) utilisée(s)" search />
+            <DsfrMultiselect
+              v-model="state.plantParts"
+              :options="plantParts"
+              label="Partie(s) utilisée(s)"
+              search
+              labelKey="name"
+            />
             <div class="ml-4">
               <DsfrTag
                 v-for="id in state.plantParts"
@@ -135,6 +141,8 @@
 <script setup>
 import { ref, computed /*, watch*/ } from "vue"
 import { getTypeIcon, getTypeInFrench, unSlugifyType /*, getApiType*/ } from "@/utils/mappings"
+import { useRootStore } from "@/stores/root"
+import { storeToRefs } from "pinia"
 // import { firstErrorMsg } from "@/utils/forms"
 // import { useRoute, useRouter } from "vue-router"
 // import { useFetch } from "@vueuse/core"
@@ -217,6 +225,10 @@ const formForType = computed(() => {
   return formQuestions[type.value] || formQuestions.default
 })
 
+const store = useRootStore()
+const { plantParts } = storeToRefs(store)
+store.fetchDeclarationFieldsData()
+
 const plantFamilies = [] // TODO: fetch options from DB
 const substanceTypes = [] // TODO: fetch options from DB
 const ingredientTypes = [] // TODO: fetch options from DB
@@ -226,16 +238,12 @@ const synonyms = [
   { label: "Cassius", type: "Nom en latin" },
 ]
 
-const plantParts = [
-  { label: "Root", id: 1 },
-  { label: "Leaf", id: 2 },
-]
 const substances = [
   { label: "Ex 1", id: 1 },
   { label: "Ex 2", id: 2 },
 ]
 
 const optionLabel = (options, id) => {
-  return options.find((o) => o.id === id)?.label || "Inconnu"
+  return options.find((o) => o.id === id)?.name || "Inconnu"
 }
 </script>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -43,10 +43,16 @@
                 <DsfrInput v-model="state.genus" label="Genre" labelVisible required />
               </DsfrInputGroup>
             </div>
-            <DsfrInputGroup v-if="formForType.ingredientType">
-              <!-- Question: do we have this in the DB? -->
-              <DsfrSelect v-model="state.ingredientType" label="Type ingrédient" :options="ingredientTypes" required />
-            </DsfrInputGroup>
+            <div class="col-span-2">
+              <DsfrInputGroup v-if="formForType.ingredientType">
+                <DsfrSelect
+                  v-model="state.ingredientType"
+                  label="Type de l'ingrédient"
+                  :options="ingredientTypes"
+                  required
+                />
+              </DsfrInputGroup>
+            </div>
 
             <DsfrToggleSwitch
               v-model="state.novelFood"
@@ -174,7 +180,7 @@
 
 <script setup>
 import { ref, computed } from "vue"
-import { getTypeIcon, getTypeInFrench, unSlugifyType /*, getApiType*/ } from "@/utils/mappings"
+import { getTypeIcon, getTypeInFrench, unSlugifyType, getApiType } from "@/utils/mappings"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 // import { firstErrorMsg } from "@/utils/forms"
@@ -188,7 +194,7 @@ import ElementAutocomplete from "@/components/ElementAutocomplete"
 import NumberField from "@/components/NumberField"
 
 // TODO: make type changeable and prefillable via query param
-const type = ref("substance")
+const type = ref("ingredient")
 const icon = computed(() => getTypeIcon(type.value))
 const typeName = computed(() => getTypeInFrench(type.value))
 const router = useRouter()
@@ -214,8 +220,7 @@ const isFetching = false // TODO: set to true when fetching data or sending upda
 
 const saveElement = async () => {
   // TODO: validate form before anything else
-  // TODO: map misc ingredient types to other-ingrediet with getApiType or whatever
-  const url = `/api/v1/${type.value}s/`
+  const url = `/api/v1/${getApiType(type.value)}s/`
   const payload = state.value
   if (payload.substances.length) {
     payload.substances = payload.substances.map((substance) => substance.id)
@@ -287,7 +292,13 @@ const { plantParts, plantFamilies } = storeToRefs(store)
 store.fetchDeclarationFieldsData()
 store.fetchPlantFamilies()
 
-const ingredientTypes = [] // TODO: fetch options from DB
+const ingredientTypes = [
+  { value: 1, text: "Nutriment (Forme d'apport)" },
+  { value: 2, text: "Additif" },
+  { value: 3, text: "Arôme" },
+  { value: 4, text: "Autre ingrédient actif" },
+  { value: 5, text: "Autre ingrédient" },
+]
 
 const selectOption = async (result) => {
   state.value.substances.push(result)

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -11,11 +11,61 @@
 
     <!-- TODO: tabs -->
     <FormWrapper class="mx-auto">
-      <DsfrFieldset legend="Identité de l’ingrédient"></DsfrFieldset>
-      <DsfrFieldset legend="Utilisation de l’ingrédient"></DsfrFieldset>
-      <DsfrFieldset legend="Commentaire à destination du public"></DsfrFieldset>
+      <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4">
+        <!-- TODO: validation -->
+        <div class="flex gap-x-4 -mb-8">
+          <DsfrInputGroup>
+            <DsfrInput v-model="state.caName" :label="formForType.name.label" required labelVisible />
+          </DsfrInputGroup>
+          <DsfrInputGroup v-if="formForType.family">
+            <!-- Question: multiselect or single? -->
+            <DsfrSelect v-model="state.caFamily" label="Famille de la plante" :options="plantFamilies" required />
+          </DsfrInputGroup>
+          <DsfrInputGroup v-if="formForType.function">
+            <!-- Question: multiselect or single? -->
+            <!-- Question: do we have this in the DB? -->
+            <DsfrSelect v-model="state.function" label="Fonction de l'ingrédient" :options="functions" required />
+          </DsfrInputGroup>
+
+          <DsfrToggleSwitch
+            v-model="state.authorised"
+            label="Authoriser l'ingrédient"
+            activeText="Authorisé"
+            inactiveText="Non authorisé"
+            label-left
+            class="self-center"
+          />
+        </div>
+        <DsfrInputGroup>
+          <DsfrInput v-model="state.description" label="Description" labelVisible />
+        </DsfrInputGroup>
+        <DsfrFieldset legend="Synonymes" legendClass="fr-text--lg">
+          <ul>
+            <li v-for="(synonym, idx) in synonyms" :key="idx">{{ synonym.label }}, {{ synonym.type }}</li>
+          </ul>
+          <!-- TODO: table -->
+          <!-- TODO: delete/edit per line -->
+          <!-- TODO: add new line -->
+          <!-- TODO: if new, three ? editable lines by default -->
+          <DsfrButton label="Ajouter un synonyme" @click="addNewSynonym" icon="ri-add-line" size="sm" />
+        </DsfrFieldset>
+        <!-- name: {
+            label: "Nom de la plante",
+          },
+          family: true,
+          function: true,
+          // authorise: true for every type
+          // description is true for every type -->
+      </DsfrFieldset>
+      <DsfrFieldset legend="Utilisation de l’ingrédient" legendClass="fr-h4">
+        <!-- usedParts: true,
+        activeSubstances: true,
+        // population cible: true for everyone also not yet in our database -->
+      </DsfrFieldset>
+      <DsfrFieldset legend="Commentaire à destination du public" legendClass="fr-h4"></DsfrFieldset>
       <div class="flex gap-x-2 mt-4">
         <!-- Question: cancel button? -->
+        <!-- Question: use DsfrButtonGroup? -->
         <DsfrButton label="Enregistrer ingrédient" @click="saveElement" :disabled="isFetching" />
         <DsfrButton label="Sauvegarder brouillon" @click="saveAsDraft" :disabled="isFetching" secondary />
       </div>
@@ -26,10 +76,11 @@
 <script setup>
 import { /*ref, */ computed /*, watch*/ } from "vue"
 import { getTypeIcon, getTypeInFrench, unSlugifyType /*, getApiType*/ } from "@/utils/mappings"
-import FormWrapper from "@/components/FormWrapper"
+// import { firstErrorMsg } from "@/utils/forms"
 // import { useRoute, useRouter } from "vue-router"
 // import { useFetch } from "@vueuse/core"
 // import { handleError } from "@/utils/error-handling"
+import FormWrapper from "@/components/FormWrapper"
 
 const props = defineProps({ urlComponent: String })
 const elementId = computed(() => props.urlComponent.split("--")[0])
@@ -43,8 +94,71 @@ const breadcrumbLinks = computed(() => {
   return links
 })
 
+const state = {} // TODO: prefill with existing data if modifying
+
 const isFetching = false // TODO: set to true when fetching data or sending update, see CompanyForm
 
 const saveElement = async () => {}
 const saveAsDraft = async () => {}
+const addNewSynonym = async () => {}
+
+const formQuestions = {
+  plant: {
+    name: {
+      label: "Nom de la plante",
+    },
+    family: true,
+    function: true,
+    // authorise: true for every type
+    // description is true for every type
+    // synonymes are true for every type
+    usedParts: true,
+    activeSubstances: true,
+    // population cible: true for everyone also not yet in our database
+    // public notes true for every type
+  },
+  substance: {
+    name: {
+      label: "Nom de la substance",
+    },
+    nameEn: {
+      label: "Nom de la substance en anglais",
+    },
+    substanceType: true,
+    einecsNumber: true,
+    casNumber: true,
+    source: true,
+    sourceEn: true,
+  },
+  microorganism: {
+    name: {
+      label: "Espèce du micro organisme",
+    },
+    genre: true,
+    function: true,
+    activeSubstances: true,
+  },
+  default: {
+    name: {
+      label: "Nom ingrédient",
+    },
+    nameEn: {
+      label: "Nom ingrédient en anglais",
+    },
+    ingredientType: true,
+    function: true,
+    activeSubstances: true,
+  },
+}
+const formForType = computed(() => {
+  return formQuestions.plant // TODO: choose based on type
+})
+
+const plantFamilies = [] // TODO: fetch options from DB
+const functions = [] // TODO: fetch options from DB
+
+const synonyms = [
+  { label: "Example", type: "Nom en anglais" },
+  { label: "Cassius", type: "Nom en latin" },
+]
 </script>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -15,7 +15,6 @@
 
       <FormWrapper :externalResults="$externalResults" class="mx-auto">
         <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4 !mb-0 !pb-2">
-          <!-- TODO: validation -->
           <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-x-8">
             <div class="col-span-2 lg:col-span-4" v-if="formForType.name">
               <DsfrInputGroup :error-message="firstErrorMsg(v$, 'name')">
@@ -117,8 +116,6 @@
             </div>
           </div>
           <div v-if="formForType.substances" class="grid md:grid-cols-3 items-end my-4 md:my-2">
-            <!-- TODO: option to create new active substance -->
-            <!-- TODO: remove asterix -->
             <ElementAutocomplete
               autocomplete="nothing"
               label="Substances actives"
@@ -128,6 +125,7 @@
               :hideSearchButton="true"
               @selected="selectOption"
               type="substance"
+              :required="false"
             />
             <div class="md:ml-4 md:my-7 md:col-span-2">
               <!-- TODO: make tags deleteable -->
@@ -145,18 +143,16 @@
                 label="Apport nutritionnel de référence"
                 label-visible
                 v-model="state.nutritionalReference"
-                required
               />
             </DsfrInputGroup>
             <DsfrInputGroup :error-message="firstErrorMsg(v$, 'maxQuantity')">
-              <NumberField label="Quantité maximale autorisée" label-visible v-model="state.maxQuantity" required />
+              <NumberField label="Quantité maximale autorisée" label-visible v-model="state.maxQuantity" />
             </DsfrInputGroup>
             <div class="max-w-32">
               <DsfrInputGroup :error-message="firstErrorMsg(v$, 'unit')">
                 <DsfrSelect
                   label="Unité"
                   label-visible
-                  required
                   :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
                   v-model="state.unit"
                   defaultUnselectedText="Unité"
@@ -203,7 +199,7 @@ import { useRoute, useRouter } from "vue-router"
 import { useFetch } from "@vueuse/core"
 import { headers } from "@/utils/data-fetching"
 import { handleError } from "@/utils/error-handling"
-import { firstErrorMsg, errorRequiredField, errorRequiredPositiveNumber } from "@/utils/forms"
+import { firstErrorMsg, errorRequiredField, errorNumeric } from "@/utils/forms"
 import { useVuelidate } from "@vuelidate/core"
 import useToaster from "@/composables/use-toaster"
 import FormWrapper from "@/components/FormWrapper"
@@ -232,8 +228,6 @@ const state = ref({
   substances: [],
   synonyms: [newSynonym(), newSynonym(), newSynonym()],
 })
-
-const isFetching = false // TODO: set to true when fetching data or sending update, see CompanyForm
 
 const saveElement = async () => {
   v$.value.$reset()
@@ -277,7 +271,7 @@ const formQuestions = {
     },
     family: true,
     function: true,
-    // authorise: true for every type
+    // status: true for every type
     // novelFood is true for every type
     // synonymes are true for every type
     plantParts: true,
@@ -327,10 +321,8 @@ const rules = computed(() => {
     genus: form?.genus ? errorRequiredField : {},
     ingredientType: form?.ingredientType ? errorRequiredField : {},
     family: form?.family ? errorRequiredField : {},
-    // TODO: the following are optional
-    nutritionalReference: form?.nutritionalReference ? errorRequiredPositiveNumber : {},
-    maxQuantity: form?.maxQuantity ? errorRequiredPositiveNumber : {},
-    unit: form?.unit ? errorRequiredField : {},
+    nutritionalReference: form?.nutritionalReference ? errorNumeric : {},
+    maxQuantity: form?.maxQuantity ? errorNumeric : {},
   }
 })
 watch(formForType, () => v$.value.$reset())

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -18,13 +18,13 @@
         <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4 !mb-0 !pb-2">
           <!-- TODO: validation -->
           <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-x-8">
-            <div class="col-span-2 lg:col-span-5">
+            <div class="col-span-2 lg:col-span-5" v-if="formForType.name">
               <DsfrInputGroup>
                 <DsfrInput v-model="state.name" :label="formForType.name.label" required labelVisible />
               </DsfrInputGroup>
             </div>
-            <div class="col-span-2">
-              <DsfrInputGroup v-if="formForType.family && plantFamiliesDisplay">
+            <div class="col-span-2" v-if="formForType.family && plantFamiliesDisplay">
+              <DsfrInputGroup>
                 <!-- Question: multiselect or single? -->
                 <DsfrSelect
                   v-model="state.family"
@@ -35,10 +35,16 @@
                 />
               </DsfrInputGroup>
             </div>
-            <!-- TODO: add species -->
-            <DsfrInputGroup v-if="formForType.genre">
-              <DsfrInput v-model="state.genre" label="Genre" labelVisible />
-            </DsfrInputGroup>
+            <div v-if="formForType.species" class="col-span-2">
+              <DsfrInputGroup>
+                <DsfrInput v-model="state.species" label="Espèce du micro organisme" labelVisible required />
+              </DsfrInputGroup>
+            </div>
+            <div v-if="formForType.genus" class="col-span-2">
+              <DsfrInputGroup>
+                <DsfrInput v-model="state.genus" label="Genre" labelVisible required />
+              </DsfrInputGroup>
+            </div>
             <DsfrInputGroup v-if="formForType.ingredientType">
               <!-- Question: multiselect or single? -->
               <!-- Question: do we have this in the DB? -->
@@ -56,7 +62,7 @@
               activeText="Oui"
               inactiveText="Non"
               label-left
-              class="self-center"
+              class="self-center mt-4"
             />
             <DsfrToggleSwitch
               v-model="state.status"
@@ -64,7 +70,7 @@
               activeText="Authorisé"
               inactiveText="Non authorisé"
               label-left
-              class="self-center"
+              class="self-center mt-4"
             />
             <DsfrInputGroup v-if="formForType.einecsNumber">
               <DsfrInput v-model="state.einecsNumber" label="Numéro EINECS" labelVisible />
@@ -179,7 +185,7 @@ import ElementAutocomplete from "@/components/ElementAutocomplete"
 // const props = defineProps({ urlComponent: String })
 // const elementId = computed(() => props.urlComponent.split("--")[0])
 // const type = computed(() => unSlugifyType(props.urlComponent.split("--")[1]))
-const type = ref("plant")
+const type = ref("microorganism")
 const icon = computed(() => getTypeIcon(type.value))
 const typeName = computed(() => getTypeInFrench(type.value))
 const router = useRouter()
@@ -260,10 +266,8 @@ const formQuestions = {
     sourceEn: true,
   },
   microorganism: {
-    name: {
-      label: "Espèce du micro organisme",
-    },
-    genre: true,
+    species: true,
+    genus: true,
     function: true,
     substances: true,
   },

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -191,7 +191,7 @@
 
 <script setup>
 import { ref, computed, watch } from "vue"
-import { getTypeIcon, getTypeInFrench, unSlugifyType, getApiType } from "@/utils/mappings"
+import { getTypeIcon, getTypeInFrench, getApiType } from "@/utils/mappings"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import { useRoute, useRouter } from "vue-router"

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -17,17 +17,19 @@
       <FormWrapper class="mx-auto">
         <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4">
           <!-- TODO: validation -->
-          <div class="flex gap-x-4 -mb-8">
-            <DsfrInputGroup>
-              <DsfrInput v-model="state.caName" :label="formForType.name.label" required labelVisible />
-            </DsfrInputGroup>
-            <DsfrInputGroup v-if="formForType.nameEn">
-              <DsfrInput v-model="state.caNameEn" :label="formForType.nameEn.label" labelVisible />
-            </DsfrInputGroup>
-            <DsfrInputGroup v-if="formForType.family">
-              <!-- Question: multiselect or single? -->
-              <DsfrSelect v-model="state.caFamily" label="Famille de la plante" :options="plantFamilies" required />
-            </DsfrInputGroup>
+          <div class="flex gap-x-4">
+            <div class="flex-1">
+              <DsfrInputGroup>
+                <DsfrInput v-model="state.caName" :label="formForType.name.label" required labelVisible />
+              </DsfrInputGroup>
+            </div>
+            <div class="flex-1">
+              <DsfrInputGroup v-if="formForType.family">
+                <!-- Question: multiselect or single? -->
+                <DsfrSelect v-model="state.caFamily" label="Famille de la plante" :options="plantFamilies" required />
+              </DsfrInputGroup>
+            </div>
+            <!-- TODO: add species -->
             <DsfrInputGroup v-if="formForType.genre">
               <DsfrInput v-model="state.genre" label="Genre" labelVisible />
             </DsfrInputGroup>
@@ -35,12 +37,6 @@
               <!-- Question: multiselect or single? -->
               <!-- Question: do we have this in the DB? -->
               <DsfrSelect v-model="state.ingredientType" label="Type ingrédient" :options="ingredientTypes" required />
-            </DsfrInputGroup>
-            <!-- TODO: sort out row col wrapping for default -->
-            <DsfrInputGroup v-if="formForType.function">
-              <!-- Question: multiselect or single? -->
-              <!-- Question: do we have this in the DB? -->
-              <DsfrSelect v-model="state.function" label="Fonction de l'ingrédient" :options="functions" required />
             </DsfrInputGroup>
             <DsfrInputGroup v-if="formForType.substanceType">
               <!-- Question: multiselect or single? -->
@@ -57,24 +53,18 @@
               class="self-center"
             />
           </div>
-          <div class="flex gap-x-4 -mb-4">
+          <div class="flex gap-x-4">
             <DsfrInputGroup v-if="formForType.einecsNumber">
-              <DsfrInput v-model="state.einecsNumber" label="Numéro EINECS" labelVisible />
+              <DsfrInput v-model="state.caEinecsNumber" label="Numéro EINECS" labelVisible />
             </DsfrInputGroup>
             <DsfrInputGroup v-if="formForType.casNumber">
-              <DsfrInput v-model="state.casNumber" label="Numéro CAS" labelVisible />
+              <DsfrInput v-model="state.caCasNumber" label="Numéro CAS" labelVisible />
             </DsfrInputGroup>
             <DsfrInputGroup v-if="formForType.source">
-              <DsfrInput v-model="state.source" label="Source" labelVisible />
-            </DsfrInputGroup>
-            <DsfrInputGroup v-if="formForType.sourceEn">
-              <DsfrInput v-model="state.sourceEn" label="Source en anglais" labelVisible />
+              <DsfrInput v-model="state.caSource" label="Source" labelVisible />
             </DsfrInputGroup>
           </div>
-          <DsfrInputGroup>
-            <DsfrInput v-model="state.description" label="Description" labelVisible />
-          </DsfrInputGroup>
-          <DsfrFieldset legend="Synonymes" legendClass="fr-text--lg">
+          <DsfrFieldset legend="Synonymes" legendClass="fr-text--lg !pb-0 !mb-2 !mt-4">
             <ul>
               <li v-for="(synonym, idx) in synonyms" :key="idx">{{ synonym.label }}, {{ synonym.type }}</li>
             </ul>
@@ -92,35 +82,31 @@
           // authorise: true for every type
           // description is true for every type -->
         </DsfrFieldset>
-        <DsfrFieldset legend="Utilisation de l’ingrédient" legendClass="fr-h4">
-          <div v-if="formForType.usedParts" class="flex items-center my-4">
-            <DsfrMultiselect v-model="state.usedParts" :options="usedParts" label="Partie(s) utilisée(s)" search />
+        <DsfrFieldset legend="Utilisation de l’ingrédient" legendClass="fr-h4 !pb-0">
+          <div v-if="formForType.plantParts" class="flex items-center my-4">
+            <DsfrMultiselect v-model="state.plantParts" :options="plantParts" label="Partie(s) utilisée(s)" search />
             <div class="ml-4">
               <DsfrTag
-                v-for="id in state.usedParts"
+                v-for="id in state.plantParts"
                 :key="id"
-                :label="optionLabel(usedParts, id)"
+                :label="optionLabel(plantParts, id)"
                 class="mx-1"
               ></DsfrTag>
             </div>
           </div>
-          <div v-if="formForType.activeSubstances" class="flex items-center my-4">
+          <div v-if="formForType.substances" class="flex items-center my-4">
             <!-- TODO: option to create new active substance -->
-            <DsfrMultiselect
-              v-model="state.activeSubstances"
-              :options="activeSubstances"
-              label="Substances actives"
-              search
-            />
+            <DsfrMultiselect v-model="state.substances" :options="substances" label="Substances actives" search />
             <div class="ml-4">
               <DsfrTag
-                v-for="id in state.activeSubstances"
+                v-for="id in state.substances"
                 :key="id"
-                :label="optionLabel(activeSubstances, id)"
+                :label="optionLabel(substances, id)"
                 class="mx-1"
               ></DsfrTag>
             </div>
           </div>
+          <!-- TODO: add max quantity, nutritional reference, unit for substance -->
           <p><i>Population cible et à risque en construction</i></p>
         </DsfrFieldset>
         <DsfrFieldset legend="Commentaire à destination du public" legendClass="fr-h4">
@@ -139,7 +125,7 @@
           <!-- Question: cancel button? -->
           <!-- Question: use DsfrButtonGroup? -->
           <DsfrButton label="Enregistrer ingrédient" @click="saveElement" :disabled="isFetching" />
-          <DsfrButton label="Sauvegarder brouillon" @click="saveAsDraft" :disabled="isFetching" secondary />
+          <!-- <DsfrButton label="Sauvegarder brouillon" @click="saveAsDraft" :disabled="isFetching" secondary /> -->
         </div>
       </FormWrapper>
     </div>
@@ -155,21 +141,22 @@ import { getTypeIcon, getTypeInFrench, unSlugifyType /*, getApiType*/ } from "@/
 // import { handleError } from "@/utils/error-handling"
 import FormWrapper from "@/components/FormWrapper"
 
-const props = defineProps({ urlComponent: String })
-const elementId = computed(() => props.urlComponent.split("--")[0])
-const type = computed(() => unSlugifyType(props.urlComponent.split("--")[1]))
+// const props = defineProps({ urlComponent: String })
+// const elementId = computed(() => props.urlComponent.split("--")[0])
+// const type = computed(() => unSlugifyType(props.urlComponent.split("--")[1]))
+const type = ref("plant")
 const icon = computed(() => getTypeIcon(type.value))
 const typeName = computed(() => getTypeInFrench(type.value))
 
 const breadcrumbLinks = computed(() => {
   const links = [{ to: { name: "DashboardPage" }, text: "Tableau de bord" }]
-  links.push({ text: `Modification élément ${elementId.value}` })
+  // links.push({ text: `Modification élément ${elementId.value}` })
   return links
 })
 
 const state = ref({
-  usedParts: [],
-  activeSubstances: [],
+  plantParts: [],
+  substances: [],
 }) // TODO: prefill with existing data if modifying
 
 const isFetching = false // TODO: set to true when fetching data or sending update, see CompanyForm
@@ -188,8 +175,8 @@ const formQuestions = {
     // authorise: true for every type
     // description is true for every type
     // synonymes are true for every type
-    usedParts: true,
-    activeSubstances: true,
+    plantParts: true,
+    substances: true,
     // population cible: true for everyone also not yet in our database
     // public notes true for every type
   },
@@ -212,7 +199,7 @@ const formQuestions = {
     },
     genre: true,
     function: true,
-    activeSubstances: true,
+    substances: true,
   },
   default: {
     name: {
@@ -223,7 +210,7 @@ const formQuestions = {
     },
     ingredientType: true,
     function: true,
-    activeSubstances: true,
+    substances: true,
   },
 }
 const formForType = computed(() => {
@@ -231,7 +218,6 @@ const formForType = computed(() => {
 })
 
 const plantFamilies = [] // TODO: fetch options from DB
-const functions = [] // TODO: fetch options from DB
 const substanceTypes = [] // TODO: fetch options from DB
 const ingredientTypes = [] // TODO: fetch options from DB
 
@@ -240,11 +226,11 @@ const synonyms = [
   { label: "Cassius", type: "Nom en latin" },
 ]
 
-const usedParts = [
+const plantParts = [
   { label: "Root", id: 1 },
   { label: "Leaf", id: 2 },
 ]
-const activeSubstances = [
+const substances = [
   { label: "Ex 1", id: 1 },
   { label: "Ex 2", id: 2 },
 ]

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -24,7 +24,7 @@
             </div>
             <div v-if="formForType.species" class="col-span-2">
               <DsfrInputGroup>
-                <DsfrInput v-model="state.species" label="Espèce du micro organisme" labelVisible required />
+                <DsfrInput v-model="state.species" label="Espèce du micro-organisme" labelVisible required />
               </DsfrInputGroup>
             </div>
             <div v-if="formForType.genus" class="col-span-2">
@@ -283,7 +283,7 @@ const formQuestions = {
     unit: true,
   },
   microorganism: {
-    title: "Micro organisme",
+    title: "Micro-organisme",
     icon: getTypeIcon("microorganism"),
     species: true,
     genus: true,

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -17,20 +17,9 @@
         <DsfrFieldset legend="Identité de l’ingrédient" legendClass="fr-h4 !mb-0 !pb-2">
           <!-- TODO: validation -->
           <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-x-8">
-            <div class="col-span-2 lg:col-span-5" v-if="formForType.name">
+            <div class="col-span-2 lg:col-span-4" v-if="formForType.name">
               <DsfrInputGroup>
                 <DsfrInput v-model="state.name" :label="formForType.name.label" required labelVisible />
-              </DsfrInputGroup>
-            </div>
-            <div class="col-span-2" v-if="formForType.family && plantFamiliesDisplay">
-              <DsfrInputGroup>
-                <DsfrSelect
-                  v-model="state.family"
-                  label="Famille de la plante"
-                  :options="plantFamiliesDisplay"
-                  labelKey="name"
-                  required
-                />
               </DsfrInputGroup>
             </div>
             <div v-if="formForType.species" class="col-span-2">
@@ -41,6 +30,25 @@
             <div v-if="formForType.genus" class="col-span-2">
               <DsfrInputGroup>
                 <DsfrInput v-model="state.genus" label="Genre" labelVisible required />
+              </DsfrInputGroup>
+            </div>
+            <DsfrToggleSwitch
+              v-model="state.status"
+              label="Autorisation de l’ingrédient"
+              activeText="Authorisé"
+              inactiveText="Non authorisé"
+              label-left
+              class="self-center mt-4 col-span-2 sm:col-span-1"
+            />
+            <div class="col-span-2" v-if="formForType.family && plantFamiliesDisplay">
+              <DsfrInputGroup>
+                <DsfrSelect
+                  v-model="state.family"
+                  label="Famille de la plante"
+                  :options="plantFamiliesDisplay"
+                  labelKey="name"
+                  required
+                />
               </DsfrInputGroup>
             </div>
             <div v-if="formForType.ingredientType" class="col-span-2">
@@ -54,28 +62,20 @@
               </DsfrInputGroup>
             </div>
 
-            <DsfrToggleSwitch
-              v-model="state.novelFood"
-              label="Novel food"
-              activeText="Oui"
-              inactiveText="Non"
-              label-left
-              class="self-center mt-4"
-            />
-            <DsfrToggleSwitch
-              v-model="state.status"
-              label="Autorisation de l’ingrédient"
-              activeText="Authorisé"
-              inactiveText="Non authorisé"
-              label-left
-              class="self-center mt-4"
-            />
             <DsfrInputGroup v-if="formForType.einecNumber">
               <DsfrInput v-model="state.einecNumber" label="Numéro EINECS" labelVisible />
             </DsfrInputGroup>
             <DsfrInputGroup v-if="formForType.casNumber">
               <DsfrInput v-model="state.casNumber" label="Numéro CAS" labelVisible />
             </DsfrInputGroup>
+            <DsfrToggleSwitch
+              v-model="state.novelFood"
+              label="Novel food"
+              activeText="Oui"
+              inactiveText="Non"
+              label-left
+              class="self-center mt-4 col-span-2 sm:col-span-1"
+            />
           </div>
           <div class="grid md:grid-cols-2 mt-4">
             <DsfrFieldset legend="Synonymes" legendClass="fr-text--lg !pb-0 !mb-2 !mt-4">

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -137,25 +137,28 @@
             </div>
           </div>
           <div class="grid grid-cols-3 gap-x-8" v-if="formForType.nutritionalReference">
-            <div>
+            <DsfrInputGroup :error-message="firstErrorMsg(v$, 'nutritionalReference')">
               <NumberField
                 label="Apport nutritionnel de référence"
                 label-visible
                 v-model="state.nutritionalReference"
-              />
-            </div>
-            <div>
-              <NumberField label="Quantité maximale autorisée" label-visible v-model="state.maxQuantity" />
-            </div>
-            <div class="max-w-32">
-              <DsfrSelect
-                label="Unité"
-                label-visible
                 required
-                :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
-                v-model="state.unit"
-                defaultUnselectedText="Unité"
               />
+            </DsfrInputGroup>
+            <DsfrInputGroup :error-message="firstErrorMsg(v$, 'maxQuantity')">
+              <NumberField label="Quantité maximale autorisée" label-visible v-model="state.maxQuantity" required />
+            </DsfrInputGroup>
+            <div class="max-w-32">
+              <DsfrInputGroup :error-message="firstErrorMsg(v$, 'unit')">
+                <DsfrSelect
+                  label="Unité"
+                  label-visible
+                  required
+                  :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
+                  v-model="state.unit"
+                  defaultUnselectedText="Unité"
+                />
+              </DsfrInputGroup>
             </div>
           </div>
           <p class="my-4"><i>Population cible et à risque en construction</i></p>
@@ -197,7 +200,7 @@ import { useRoute, useRouter } from "vue-router"
 import { useFetch } from "@vueuse/core"
 import { headers } from "@/utils/data-fetching"
 import { handleError } from "@/utils/error-handling"
-import { errorRequiredField, firstErrorMsg } from "@/utils/forms"
+import { firstErrorMsg, errorRequiredField, errorRequiredPositiveNumber } from "@/utils/forms"
 import { useVuelidate } from "@vuelidate/core"
 import useToaster from "@/composables/use-toaster"
 import FormWrapper from "@/components/FormWrapper"
@@ -320,6 +323,9 @@ const rules = computed(() => {
     genus: form?.genus ? errorRequiredField : {},
     ingredientType: form?.ingredientType ? errorRequiredField : {},
     family: form?.family ? errorRequiredField : {},
+    nutritionalReference: form?.nutritionalReference ? errorRequiredPositiveNumber : {},
+    maxQuantity: form?.maxQuantity ? errorRequiredPositiveNumber : {},
+    unit: form?.unit ? errorRequiredField : {},
   }
 })
 watch(formForType, () => v$.value.$reset())


### PR DESCRIPTION
Dans cette PR :
- nouvelle page création ingrédient pour les quatre types ([maquette originelle](https://www.figma.com/design/0pv6zTHf7IW3wbxmmScSUh/Nouvel-ingr%C3%A9dient?node-id=1-2&t=TXdRfMITmRXOVont-0))
- l'option dans le front et le back de filtrer l'autocomplete d'element par type (pour cette page on a besoin d'offrir que les substances)
- l'ajout de l'endpoint `plant-families`

à faire:

- [x] reparer le test cassé
- [x] formulaire pour le type "ingredient" (novel food n'est pas applicable pour les aromes)
- [x] validation formulaire
- [x] type devrait être selectionnable
- [x] vérifier qu'on rend l'historique comprehensible (p-e sauvegarde une raison particulière ?)
- [x] ajouter des screenshots ici

En deuxième temps :
- ajouter champ lien/document authorisation (coordonner avec Perrine)
- pour les demandes dans la déclaration: relier les documents à la demande et non pas la déclaration pour après copier les documents dans le nouveau champ lien/document authorisation
- decouper les commentaires public et les commentaires ANSES (coordonner avec Perrine)
- ajouter l'option de "supprimer" l'ingrédient en mettant le champ `is_obsolete` à vrai
- #1628
- #1630 
- ajouter le bouton remplacer sur la page décision demande d'ingrédient qui redirige vers cette nouvelle page
- pré remplir le formulaire avec les données de la demande
- après la création, remplacer la demande avec le nouvel ingrédient et rediriger l'utilisateur vers la page demande d'ingrédient ou même la page decla/tableau
- remplacer le champ `first_ocurrence` avec un champ `first_declaration` sur le modèle commun ingrédient

Autres remarques :
- on ignore le champ `ca_is_related` quand on crée un synonyme. C'est fait exprès, peut-être ce champ sera supprimé, ce n'est pas utilisé
- il y a des differences entre les maquettes et ce formulaire car les maquettes sont basées sur les anciens modèles

![Screenshot 2025-02-11 at 18-56-38 Nouvel ingrédient - Compl'Alim](https://github.com/user-attachments/assets/0e27dba7-50d1-4e3e-8a10-9b0568cc6fc1)
![Screenshot 2025-02-11 at 18-56-48 Nouvel ingrédient - Compl'Alim](https://github.com/user-attachments/assets/6c08034e-7d07-4d01-a2f8-b0991b5ec11b)
![Screenshot 2025-02-11 at 18-56-55 Nouvel ingrédient - Compl'Alim](https://github.com/user-attachments/assets/ab3dacf9-85f1-40a3-8c27-9e05f4158c7c)
![Screenshot 2025-02-11 at 18-57-04 Nouvel ingrédient - Compl'Alim](https://github.com/user-attachments/assets/665b788e-fa8a-4084-898b-73a36517a7d6)
![Screenshot 2025-02-11 at 18-57-09 Nouvel ingrédient - Compl'Alim](https://github.com/user-attachments/assets/2e2defc8-9b73-4886-a985-19bca4945010)
