### PR TITLE
Hides input on read-only substance table

### DIFF
--- a/frontend/src/components/SubstancesTable.vue
+++ b/frontend/src/components/SubstancesTable.vue
@@ -62,7 +62,7 @@
               pour {{ payload.computedSubstances[rowIndex].substance.maxQuantity }} maximum autorisés
             </span>
           </div>
-          <DsfrInputGroup>
+          <DsfrInputGroup v-else>
             <NumberField
               v-model="payload.computedSubstances[rowIndex].quantity"
               label="Quantité par DJR"


### PR DESCRIPTION
Closes #1244

## Scope

Il manquait un `v-else` à la condition qui montrait ou cachait l'input de la table des substances. D'où le fait qu'on se retrouvait toujours avec un champ éditable.