### PR TITLE
Permet de filtrer par déclaration non-assignée et d'effectuer le triage par date limite de réponse en même temps

### DIFF
--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -983,6 +983,28 @@ class TestDeclarationApi(APITestCase):
         self.assertEqual(results[0]["id"], declaration.id)
 
     @authenticate
+    def test_ordering_and_filtering_instructor_not_assigned(self):
+        """
+        Le filtre des non-assignés doit pouvoir s'effectuer avec celui du triage
+        """
+        InstructionRoleFactory(user=authenticate.user)
+
+        emma = InstructionRoleFactory()
+        edouard = InstructionRoleFactory()
+        stephane = InstructionRoleFactory()
+
+        OngoingInstructionDeclarationFactory(instructor=emma)
+        OngoingInstructionDeclarationFactory(instructor=edouard)
+        OngoingInstructionDeclarationFactory(instructor=stephane)
+        declaration = AwaitingInstructionDeclarationFactory()
+
+        url = f"{reverse('api:list_all_declarations')}?instructor=None&ordering=responseLimitDate"
+        response = self.client.get(url, format="json")
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], declaration.id)
+
+    @authenticate
     def test_filter_instructor_not_assigned_and_assigned(self):
         """
         Les déclarations peuvent être filtrées par celles qui n'ont pas encore d'instructrice


### PR DESCRIPTION
Closes #1232 

## Contexte

Le bug arrivait lors qu'on effectué un filtre pour avoir les déclarations non-assignées et en même temps un triage par date limite de réponse.

L'erreur était : `Calling QuerySet.annotate() after union() is not supported.`

## Scope

La combinaison de ces deux conditions en effet provoquait un appel de _annotate_ utilisé pour le triage par date limite de réponse (fonction `filter_queryset` de `InstructionDateOrderingFilter`), et de _union_ (fonction `nullable_instructor` de `DeclarationFilterSet`). 

Il se trouve que le _union_ du dernier n'était pas nécessaire et c'était possible (et même souhaitable) de re-factoriser cette fonction pour l'enlever.
