### PR TITLE
Affiche l'ID dans la table admin des déclarations

### DIFF
--- a/data/admin/blogpost.py
+++ b/data/admin/blogpost.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import BlogPost
 
 
@@ -29,6 +30,7 @@ class BlogPostAdmin(admin.ModelAdmin):
         "published_state",
     )
     list_filter = ("published",)
+    show_facets = admin.ShowFacets.NEVER
 
     def published_state(self, obj):
         return "✅ Publié" if obj.published else "🔒 Non publié"

--- a/data/admin/condition.py
+++ b/data/admin/condition.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import Condition
 
 
@@ -34,3 +35,4 @@ class ConditionAdmin(admin.ModelAdmin):
         "modification_date",
     ]
     list_filter = ("is_obsolete",)
+    show_facets = admin.ShowFacets.NEVER

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -189,7 +189,7 @@ class DeclarationForm(forms.ModelForm):
 @admin.register(Declaration)
 class DeclarationAdmin(SimpleHistoryAdmin):
     form = DeclarationForm
-    list_display = ("name", "status", "company", "author")
+    list_display = ("id", "name", "status", "company", "author")
     list_filter = ("status", "company", "author")
 
     show_facets = admin.ShowFacets.NEVER

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -191,6 +191,8 @@ class DeclarationAdmin(SimpleHistoryAdmin):
     form = DeclarationForm
     list_display = ("name", "status", "company", "author")
     list_filter = ("status", "company", "author")
+
+    show_facets = admin.ShowFacets.NEVER
     inlines = (
         DeclaredPlantInline,
         DeclaredMicroorganismInline,

--- a/data/admin/effect.py
+++ b/data/admin/effect.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import Effect
 
 
@@ -34,3 +35,4 @@ class EffectAdmin(admin.ModelAdmin):
         "modification_date",
     ]
     list_filter = ("is_obsolete",)
+    show_facets = admin.ShowFacets.NEVER

--- a/data/admin/galenic_formulation.py
+++ b/data/admin/galenic_formulation.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import GalenicFormulation
 
 
@@ -41,3 +42,4 @@ class GalenicFormulationAdmin(admin.ModelAdmin):
         "is_liquid",
         "is_risky",
     )
+    show_facets = admin.ShowFacets.NEVER

--- a/data/admin/ingredient.py
+++ b/data/admin/ingredient.py
@@ -40,6 +40,7 @@ class IngredientAdmin(ElementAdminWithChangeReason):
     )
     list_display = ("name", "status", "is_risky")
     list_filter = ("is_obsolete", "status", "is_risky")
+    show_facets = admin.ShowFacets.NEVER
     readonly_fields = (
         "name",
         "is_obsolete",

--- a/data/admin/microorganism.py
+++ b/data/admin/microorganism.py
@@ -58,6 +58,7 @@ class MicroorganismAdmin(ElementAdminWithChangeReason):
 
     list_display = ("name", "status", "is_risky")
     list_filter = ("is_obsolete", "status", "is_risky")
+    show_facets = admin.ShowFacets.NEVER
     readonly_fields = (
         "name",
         "is_obsolete",

--- a/data/admin/plant.py
+++ b/data/admin/plant.py
@@ -81,6 +81,7 @@ class PlantAdmin(ElementAdminWithChangeReason):
     )
     list_display = ("name", "siccrf_family", "status", "is_risky")
     list_filter = ("is_obsolete", "siccrf_family", "status", "is_risky")
+    show_facets = admin.ShowFacets.NEVER
     readonly_fields = (
         "siccrf_name",
         "name",

--- a/data/admin/population.py
+++ b/data/admin/population.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+
 from data.models import Population
 
 
@@ -39,3 +40,4 @@ class PopulationAdmin(admin.ModelAdmin):
         "is_obsolete",
         "is_defined_by_anses",
     )
+    show_facets = admin.ShowFacets.NEVER

--- a/data/admin/preparation.py
+++ b/data/admin/preparation.py
@@ -31,3 +31,4 @@ class PreparationAdmin(admin.ModelAdmin):
     ]
     list_display = ["name", "modification_date", "contains_alcohol"]
     list_filter = ("is_obsolete",)
+    show_facets = admin.ShowFacets.NEVER

--- a/data/admin/substance.py
+++ b/data/admin/substance.py
@@ -122,4 +122,5 @@ class SubstanceAdmin(ElementAdminWithChangeReason):
     ]
     list_display = ("name", "get_plants", "get_microorganisms", "get_ingredients", "status", "is_risky")
     list_filter = ("is_obsolete", "status", "is_risky")
+    show_facets = admin.ShowFacets.NEVER
     search_fields = ["id", "name"]

--- a/data/admin/user.py
+++ b/data/admin/user.py
@@ -34,6 +34,7 @@ class UserAdmin(UserAdmin):
         "email",
         "username",
     )
+    show_facets = admin.ShowFacets.NEVER
 
     inlines = (
         DeclarantRoleInline,

--- a/data/admin/webinar.py
+++ b/data/admin/webinar.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib import admin
 from django.utils import timezone
+
 from data.models import Webinar
 
 
@@ -48,3 +49,4 @@ class WebinarAdmin(admin.ModelAdmin):
         "start_date",
     )
     list_filter = (UpcomingEventsFilter,)
+    show_facets = admin.ShowFacets.NEVER

--- a/tokens/admin.py
+++ b/tokens/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import MagicLinkToken, InseeToken
+from .models import InseeToken, MagicLinkToken
 
 
 @admin.register(MagicLinkToken)
@@ -12,7 +12,8 @@ class MagicLinkTokenAdmin(admin.ModelAdmin):
         "usage",
     )
     readonly_fields = ("key",)
-    list_filter = ("expiration", "user")
+    list_filter = ("expiration",)
+    show_facets = admin.ShowFacets.NEVER
 
 
 @admin.register(InseeToken)
@@ -23,3 +24,4 @@ class InseeTokenAdmin(admin.ModelAdmin):
     )
     readonly_fields = ("key",)
     list_filter = ("expiration",)
+    show_facets = admin.ShowFacets.NEVER


### PR DESCRIPTION
Closes #1258 

## Scope

On a besoin de voir l'ID de la déclaration dans la table admin. Suite à une discussion cette PR comporte deux choses :

### 1) L'ajout de la colonne `id` dans l'admin déclaration
À noter que l'ID devient l'élément à cliquer pour ouvrir la déclaration.

### 2) La désactivations des _facets_

Hélène pensait que le bouton en haut des filtres avec le label « _Afficher les nombres_ » servait à afficher les IDs :
![image](https://github.com/user-attachments/assets/d991075c-c2cb-4caa-b786-847e30b4eaed)

Or ce bouton (ajouté automatiquement dans Django 5.x) sert à afficher le nombre d'éléments qui correspond aux filtres en dessous, par exempe : 
![Screenshot from 2024-11-11 11-39-12](https://github.com/user-attachments/assets/6faa41f6-c7be-4a1e-88ca-1bc5b018f97c)

J'ai décidé de le désactiver pour plusieurs raisons :
- L'incompréhension de ce que le bouton fait,
- Les gros soucis de performance lors que les tables sont grandes (sur prod on a carrément un 500)
- Le fait qu'on a déjà Metabase pour faire des analyses BDD

Au sujet de la pref, Django met en garde [dans leur doc](https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.show_facets) avec cet encart : 
![image](https://github.com/user-attachments/assets/cbc9a4c1-703e-4976-8071-e66ab2ca17ee)
---

Cette PR donc contient plusieurs fichiers modifiés mais seulement pour modifier la valeur par défaut de Django concernant les facets et la mettre à `show_facets = admin.ShowFacets.NEVER`.