### PR TITLE
Améliore l'affichage des plantes non-actives

### DIFF
--- a/frontend/src/components/DeclarationSummary/SummaryElementItem.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementItem.vue
@@ -9,8 +9,9 @@
       </div>
 
       <DsfrBadge v-if="model.new" label="Nouvel ingrédient" type="info" class="self-center ml-2" small />
+      <DsfrBadge v-if="isPlant && !model.active" label="Non-actif" type="none" class="self-center ml-2" small />
     </div>
-    <p class="my-2">
+    <p class="my-2" v-if="model.active">
       {{ elementInfo }}
     </p>
   </li>
@@ -28,6 +29,7 @@ const { plantParts, units, preparations } = storeToRefs(useRootStore())
 const model = defineModel()
 const props = defineProps({ objectType: { type: String } })
 
+const isPlant = computed(() => props.objectType === "plant")
 const plantPartName = computed(() => plantParts.value?.find((x) => x.id === model.value.usedPart)?.name || "Aucune")
 const unitName = computed(() => units.value?.find((x) => x.id === model.value.unit)?.name || "")
 const preparationName = computed(

--- a/frontend/src/components/DeclarationSummary/SummaryElementItem.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementItem.vue
@@ -9,7 +9,7 @@
       </div>
 
       <DsfrBadge v-if="model.new" label="Nouvel ingrédient" type="info" class="self-center ml-2" small />
-      <DsfrBadge v-if="isPlant && !model.active" label="Non-actif" type="none" class="self-center ml-2" small />
+      <DsfrBadge v-if="!model.active" label="Non-actif" type="none" class="self-center ml-2" small />
     </div>
     <p class="my-2" v-if="model.active">
       {{ elementInfo }}
@@ -29,7 +29,6 @@ const { plantParts, units, preparations } = storeToRefs(useRootStore())
 const model = defineModel()
 const props = defineProps({ objectType: { type: String } })
 
-const isPlant = computed(() => props.objectType === "plant")
 const plantPartName = computed(() => plantParts.value?.find((x) => x.id === model.value.usedPart)?.name || "Aucune")
 const unitName = computed(() => units.value?.find((x) => x.id === model.value.unit)?.name || "")
 const preparationName = computed(


### PR DESCRIPTION
Closes #1257 

## Contexte

Les informations affichées pour les plantes non actives étaient trompeuses dans la vue résumé, car les usagers n'étaient pas obligés de mettre des informations supplémentaires comme la partie de la plante.

## Scope

Un badge est affiché pour tous les ingrédients non-actives et les informations supplémentaires sont cachées : 
![image](https://github.com/user-attachments/assets/892ef26a-d553-4703-8afb-c09a9bb28cbb)
