### PR TITLE
Usage des accordions pour les listes d'ingrédients (pour l'instruction et le visa)

### DIFF
--- a/frontend/src/components/DeclarationSummary/SummaryElementList.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementList.vue
@@ -1,27 +1,24 @@
 <template>
   <div v-if="elements.length">
-    <div class="flex mt-6 mb-3">
-      <div :class="`mr-2 self-center justify-center rounded-full size-4 flex`">
-        <v-icon class="self-center" :name="getTypeIcon(objectType)" />
-      </div>
-      <p class="m-0 font-bold capitalize self-center">{{ getTypeInFrench(objectType) }}s</p>
-    </div>
+    <!-- Affichage avec les accordéons : les ingrédients sont cachés à l'intérieur -->
+    <DsfrAccordion v-if="useAccordions">
+      <template v-slot:title>
+        <SummaryElementListTitle :objectType="objectType" :elementCount="`${elements.length}`" />
+      </template>
+      <SummaryElementListItems :objectType="objectType" :elements="elements" />
+    </DsfrAccordion>
 
-    <ul class="list-none">
-      <SummaryElementItem
-        class="mb-2 last:mb-0"
-        v-for="(element, index) in elements"
-        :key="`summary-${objectType}-${index}`"
-        v-model="elements[index]"
-        :objectType="objectType"
-      />
-    </ul>
+    <!-- Affichage sans les accordéons, tous les ingrédients sont affichés -->
+    <div v-else>
+      <SummaryElementListTitle class="mt-6 mb-3" :objectType="objectType" />
+      <SummaryElementListItems :objectType="objectType" :elements="elements" />
+    </div>
   </div>
 </template>
 
 <script setup>
-import { getTypeIcon, getTypeInFrench } from "@/utils/mappings"
-import SummaryElementItem from "./SummaryElementItem"
+import SummaryElementListTitle from "./SummaryElementListTitle"
+import SummaryElementListItems from "./SummaryElementListItems"
 
-defineProps({ objectType: { type: String }, elements: { type: Array } })
+defineProps({ objectType: { type: String }, elements: { type: Array }, useAccordions: { type: Boolean } })
 </script>

--- a/frontend/src/components/DeclarationSummary/SummaryElementListItems.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementListItems.vue
@@ -1,0 +1,17 @@
+<template>
+  <ul class="list-none">
+    <SummaryElementItem
+      class="mb-2 last:mb-0"
+      v-for="(element, index) in elements"
+      :key="`summary-${objectType}-${index}`"
+      v-model="elements[index]"
+      :objectType="objectType"
+    />
+  </ul>
+</template>
+
+<script setup>
+import SummaryElementItem from "./SummaryElementItem"
+
+defineProps({ objectType: { type: String }, elements: { type: Array } })
+</script>

--- a/frontend/src/components/DeclarationSummary/SummaryElementListTitle.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementListTitle.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="flex">
+    <div :class="`mr-2 self-center justify-center rounded-full size-4 flex`">
+      <v-icon class="self-center" :name="getTypeIcon(objectType)" />
+    </div>
+    <p class="m-0 font-bold capitalize self-center">
+      {{ getTypeInFrench(objectType) }}s
+      <span v-if="elementCount">({{ elementCount }})</span>
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { getTypeIcon, getTypeInFrench } from "@/utils/mappings"
+
+defineProps({ objectType: { type: String }, elementCount: { type: String, default: "" } })
+</script>

--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -27,26 +27,38 @@
       <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(1))" />
     </h3>
 
-    <SummaryElementList objectType="plant" :elements="payload.declaredPlants" />
-    <SummaryElementList objectType="microorganism" :elements="payload.declaredMicroorganisms" />
+    <SummaryElementList :useAccordions="useAccordions" objectType="plant" :elements="payload.declaredPlants" />
+    <SummaryElementList
+      :useAccordions="useAccordions"
+      objectType="microorganism"
+      :elements="payload.declaredMicroorganisms"
+    />
     <SummaryElementList
       objectType="form_of_supply"
+      :useAccordions="useAccordions"
       :elements="getObjectSubTypeList(payload.declaredIngredients, 'form_of_supply')"
     />
-    <SummaryElementList objectType="aroma" :elements="getObjectSubTypeList(payload.declaredIngredients, 'aroma')" />
+    <SummaryElementList
+      :useAccordions="useAccordions"
+      objectType="aroma"
+      :elements="getObjectSubTypeList(payload.declaredIngredients, 'aroma')"
+    />
     <SummaryElementList
       objectType="additive"
+      :useAccordions="useAccordions"
       :elements="getObjectSubTypeList(payload.declaredIngredients, 'additive')"
     />
     <SummaryElementList
       objectType="active_ingredient"
+      :useAccordions="useAccordions"
       :elements="getObjectSubTypeList(payload.declaredIngredients, 'active_ingredient')"
     />
     <SummaryElementList
       objectType="non_active_ingredient"
+      :useAccordions="useAccordions"
       :elements="getObjectSubTypeList(payload.declaredIngredients, 'non_active_ingredient')"
     />
-    <SummaryElementList objectType="substance" :elements="payload.declaredSubstances" />
+    <SummaryElementList objectType="substance" :useAccordions="useAccordions" :elements="payload.declaredSubstances" />
 
     <p class="font-bold mt-8">Substances contenues dans la composition :</p>
     <SubstancesTable v-model="payload" readonly />
@@ -95,7 +107,7 @@ const router = useRouter()
 const { units, populations, conditions, effects, galenicFormulations } = storeToRefs(useRootStore())
 
 const payload = defineModel()
-defineProps({ readonly: Boolean, showArticle: Boolean })
+defineProps({ readonly: Boolean, showArticle: Boolean, useAccordions: Boolean })
 const unitInfo = computed(() => {
   if (!payload.value.unitQuantity) return null
   const unitMeasurement = units.value?.find?.((x) => x.id === payload.value.unitMeasurement)?.name || "-"

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -27,7 +27,13 @@
       </DsfrAlert>
       <DeclarationAlert class="mb-6" v-else-if="!canInstruct" role="instructor" :declaration="declaration" />
       <div v-if="declaration">
-        <DeclarationSummary :showArticle="true" :readonly="true" v-model="declaration" v-if="isAwaitingInstruction" />
+        <DeclarationSummary
+          :showArticle="true"
+          :useAccordions="true"
+          :readonly="true"
+          v-model="declaration"
+          v-if="isAwaitingInstruction"
+        />
 
         <DsfrTabs v-else v-model="selectedTabIndex" ref="tabs" :tab-titles="titles">
           <DsfrTabContent
@@ -41,6 +47,7 @@
               v-model="declaration"
               :externalResults="$externalResults"
               :readonly="true"
+              :useAccordions="true"
               :declarationId="declaration?.id"
               :user="declarant"
               :company="company"

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -23,7 +23,13 @@
       </DsfrAlert>
       <DeclarationAlert role="visor" class="mb-4" v-else :declaration="declaration" />
       <div v-if="declaration">
-        <DeclarationSummary :showArticle="true" :readonly="true" v-model="declaration" v-if="isAwaitingVisa" />
+        <DeclarationSummary
+          :showArticle="true"
+          :useAccordions="true"
+          :readonly="true"
+          v-model="declaration"
+          v-if="isAwaitingVisa"
+        />
 
         <DsfrTabs v-else ref="tabs" :tab-titles="titles" v-model="selectedTabIndex">
           <DsfrTabContent
@@ -39,6 +45,7 @@
               :externalResults="$externalResults"
               :readonly="true"
               :declarationId="declaration?.id"
+              :useAccordions="true"
               :user="declarant"
               :company="company"
               @decision-done="onDecisionDone"


### PR DESCRIPTION
Closes #1218 

## Contexte

Aujourd'hui dans la vue résumé on montre la liste des ingrédients dépliée au dessus de la liste des substances calculées. Pour l'instruction et le visa, seulement les substances calculées sont intéressantes dans la plupart des cas, il est donc souhaitable de faire que les ingrédients prennent moins de place.

## Scope

On utilise un _DsfrAccordion_ pour réduire la taille verticale en mettant dedans les ingrédients : 

https://github.com/user-attachments/assets/d1148470-b257-45e4-8793-68e5331548cf

À noter que pour les déclarant·e·s l'écran reste comme elle était avant.