### PR TITLE
Aide pour éviter la création de mauvais nouveaux ingrédients

### DIFF
--- a/frontend/src/views/ProducerFormPage/NewElementModal.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementModal.vue
@@ -1,6 +1,14 @@
 <template>
   <DsfrButton label="Créer un nouvel ingrédient" secondary size="sm" @click="opened = true" ref="modalOrigin" />
+  <DsfrTooltip class="whitespace-pre-wrap" :content="simpleDescription" />
   <DsfrModal :actions="actions" ref="modal" @close="close" :opened="opened" title="Nouvel ingrédient">
+    <DsfrAlert
+      type="info"
+      title="Avant de créer un nouvel ingrédient"
+      :description="model.objectType == 'plant' ? simpleDescription + ' ' + plantDescription : simpleDescription"
+      title-tag="h2"
+      small="true"
+    />
     <DsfrInputGroup :error-message="firstErrorMsg(v$, 'objectType')">
       <DsfrSelect
         label="Quel type d'ingrédient souhaitez-vous créer ?"
@@ -109,6 +117,9 @@ const rules = computed(() => {
 })
 
 const v$ = useVuelidate(rules, model)
+const simpleDescription = "Avant de créer un nouvel ingrédient, vérifiez qu'il n'existe pas déjà sous un autre nom."
+const plantDescription =
+  "Les plantes doivent être recherchées par leur nom scientifique, sans précision sur la préparation ou la partie utilisée."
 </script>
 
 <style>


### PR DESCRIPTION
## Message d'aide pour éviter les créations de nouveaux ingrédients non légitimes

### La proposition d' @amandinegueg 

![image](https://github.com/user-attachments/assets/eb077e54-3077-40ea-8ae6-248e2ec8563c)

Le formatting n'est pas possible dans les composants DsfrAlert et DsfrTooltip.
Je simplifie un peu la proposition pour qu'elle n'ait pas besoin de formattage.

### La réalisation, dans le Tooltip à droite du bouton "Créer un nouvel ingrédient"
![image](https://github.com/user-attachments/assets/00dfa3f8-f2cb-44ec-afde-f3dd64595f1f)

### La réalisation, dans le DsfrAlert de type info, dans la modal. Le texte est augmenté si c'est une plante qui est choisie.
![image](https://github.com/user-attachments/assets/eccd502a-1017-433a-b19b-0f4d66aaa91c)
