### PR TITLE
Ajout des checks pour éviter des `KeyError`s lors de la validation de l'email

### DIFF
--- a/api/views/user.py
+++ b/api/views/user.py
@@ -131,7 +131,10 @@ class GenerateUsernameView(APIView):
 
 class VerifyEmailView(APIView):
     def post(self, request, *args, **kwargs):
-        user = MagicLinkToken.run_email_verification(request.data["key"])
+        key = request.data.get("key")
+        if not key:
+            raise ProjectAPIException(global_error="Lien de validation invalide.")
+        user = MagicLinkToken.run_email_verification(key)
         if user:
             # we log the user in to avoid an unnecessary login step
             login(request, user)  # will create the user session

--- a/frontend/src/views/VerifyEmailPage.vue
+++ b/frontend/src/views/VerifyEmailPage.vue
@@ -18,6 +18,10 @@ const { data, response, execute } = useFetch("/api/v1/verify-email/", { headers:
   .json()
 
 onMounted(async () => {
+  if (!route.query?.key) {
+    useToaster().addErrorMessage("Lien de validation invalide.")
+    return
+  }
   await execute()
   await handleError(response)
   if (response.value.ok) {


### PR DESCRIPTION
Closes #1263 

## Contexte
Cette PR adresse l'erreur Sentry https://sentry.incubateur.net/organizations/betagouv/issues/126294/?project=146

## Scope

### Éviter l'envoi automatique de la requête POST dans la vue _VerifyEmailPage.vue_

Aujourd'hui le POST vers le service de validation d'email est fait automatiquement sans prendre en compte si les query-params nécessaires sont présents ou pas.

On change ce comportement pour n'envoyer la requête POST que si la `key` est présente dans l'URL

### Éviter d'accéder `data["key"]` directement dans la view backend

On ne peut pas garantir que le paramètre nécessaire soit présent dans la requête. Afin de ne pas se prendre une erreur 500, on vérifie d'abord la présence de `key` dans la requête et on envoi une erreur pertinente si elle manque.