### PR TITLE
Ajustement de la logique des permissions pour vérifier `is_authenticated`

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -93,6 +93,8 @@ class CanAccessIndividualDeclaration(permissions.BasePermission):
     message = "Vous n'avez pas accès à cette déclaration"
 
     def has_object_permission(self, request, view, obj):  # obj: Declaration
+        if not request.user.is_authenticated:
+            return False
         is_author = IsDeclarationAuthor().has_object_permission(request, view, obj)
         is_from_same_company = obj.company in request.user.declarable_companies.all()
         is_agent = IsInstructor().has_permission(request, view) or IsVisor().has_permission(request, view)
@@ -108,6 +110,8 @@ class CanTakeAuthorship(permissions.BasePermission):
     message = "Vous ne pouvez pas vous assigner cette déclaration"
 
     def has_object_permission(self, request, view, obj):  # obj: Declaration
+        if not request.user.is_authenticated:
+            return False
         is_from_same_company = obj.company in request.user.declarable_companies.all()
         is_declarant = IsDeclarant().has_object_permission(request, view, obj)
 


### PR DESCRIPTION
Closes #1293 

## Issue Sentry

https://sentry.incubateur.net/organizations/betagouv/issues/124081/?project=146&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=10

## Scope

Dans le cas de perte de session ou requête anonyme, on doit d'abord vérifier si l'utilisateur·ice n'est pas une instance de `AnonymousUser`, car ce modèle n'a pas de propriétés tels que `declarable_companies`.