### PR TITLE
Fix de l'erreur Sentry concernant la génération du nom d'utilisateur·ice

### DIFF
--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -327,3 +327,8 @@ class TestGenerateUsername(ProjectAPITestCase):
         response = self.get(self.url() + "?first_name=jean&last_name=dupon")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {"username": "jean.dupon"})
+
+    def test_special_chars(self):
+        response = self.get(self.url() + "?first_name=S.L.&last_name=UNIK%20HEALTH&NUTRITION")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"username": "sl.unik-health"})

--- a/api/views/user.py
+++ b/api/views/user.py
@@ -126,7 +126,11 @@ class SendNewSignupVerificationEmailView(APIView):
 
 class GenerateUsernameView(APIView):
     def get(self, request, *args, **kwargs):
-        return Response({"username": User.generate_username(**request.query_params)})
+        first_name = request.query_params.get("first_name")
+        last_name = request.query_params.get("last_name")
+        if not first_name or not last_name:
+            raise ProjectAPIException(global_error="Les champs nom et prénom doivent être remplis.")
+        return Response({"username": User.generate_username(first_name, last_name)})
 
 
 class VerifyEmailView(APIView):

--- a/frontend/src/views/SignupPage.vue
+++ b/frontend/src/views/SignupPage.vue
@@ -135,7 +135,8 @@ const submit = async () => {
 // Username Pre-fill
 const usernameInput = ref(null)
 const urlPF = computed(
-  () => `/api/v1/generate-username?first_name=${state.value.firstName}&last_name=${state.value.lastName}`
+  () =>
+    `/api/v1/generate-username?first_name=${encodeURIComponent(state.value.firstName)}&last_name=${encodeURIComponent(state.value.lastName)}`
 )
 const { data: dataPF, execute: executePF, isFetching: isFetchingPF } = useFetch(urlPF, {}, { immediate: false }).json()
 


### PR DESCRIPTION
Closes #1292 

La génération automatique du nom d'utilisateur·ice avait quelques soucis : 

## Contexte

https://sentry.incubateur.net/organizations/betagouv/issues/132185/?project=146&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=6

## Scope

- Côté frontend, le paramètres n'étaient pas encodé en tant que _URIComponent_, donc si le nom contenait un `&`, celui-ci était passé tel que, faisant donc que le backend l’interprétait comme un autre query param.
- Côté backend, la view passait tous les paramètres de la requête dynamiquement vers la fonction de génération de username, sans vérifier que les paramètres correspondent à la signature de la méthode.


