### PR TITLE
1270 Ajout champs supplémentaires pour le jeu de données en open data "declarations"

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -386,11 +386,11 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
     def get_declared_substances(self, obj):
         return [
             {
-                "nom": declared_substance.new_name,
+                "nom": declared_substance.name,
                 "quantité_par_djr": declared_substance.quantity,
                 "unite": declared_substance.unit.name,
             }
-            if declared_substance.new_name and declared_substance.quantity and declared_substance.unit
+            if declared_substance.name and declared_substance.quantity and declared_substance.unit
             else {}
             for declared_substance in obj.declared_substances.all()
         ]

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -369,7 +369,16 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
         ]
 
     def get_declared_microorganisms(self, obj):
-        return {"nom": obj.declared_plants.name}
+        return [
+            {
+                "genre": declared_microorganism.microorganism.genus,
+                "espece": declared_microorganism.microorganism.species,
+                "souche": declared_microorganism.strain,
+                "quantité_par_djr": declared_microorganism.quantity,
+                "inactive": not declared_microorganism.activated,
+            }
+            for declared_microorganism in obj.declared_microorganisms.all()
+        ]
 
     def get_declared_ingredients(self, obj):
         return {"nom": obj.declared_plants.name}

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -329,6 +329,8 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
             "article",
             "galenic_formulation",
             "daily_recommended_dose",
+            "instructions",
+            "warning",
             "declared_plants",
             "declared_microorganisms",
             "declared_substances",

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -369,20 +369,17 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
             for declared_plant in obj.declared_plants.filter(active=True)
         ]
 
-    def get_declared_microorganisms(self, obj):
+    def get_declared_ingredients(self, obj):
         return [
             {
                 "genre": declared_microorganism.microorganism.genus,
                 "espece": declared_microorganism.microorganism.species,
-                "souche": declared_microorganism.strain,
-                "quantité_par_djr": declared_microorganism.quantity,
+                "souche": declared_microorganism.strain
+                if declared_microorganism.strain
+                else None,  # elle est normalement obligatoire mais quelques entrées ont pu être rentrées avant le required
+                "quantité_par_djr": declared_microorganism.quantity if declared_microorganism.activated else None,
                 "inactive": not declared_microorganism.activated,
             }
-            if declared_microorganism.microorganism
-            and declared_microorganism.strain
-            and declared_microorganism.quantity
-            and declared_microorganism.activated
-            else {}
             for declared_microorganism in obj.declared_microorganisms.all()
         ]
 

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -328,6 +328,7 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
             "gamme",
             "article",
             "galenic_formulation",
+            "daily_recommended_dose",
             "declared_plants",
             "declared_microorganisms",
             "declared_substances",

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -366,10 +366,12 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
                 "quantité_par_djr": declared_plant.quantity,
                 "unite": declared_plant.unit.name,
             }
+            if declared_plant.unit
+            else {}
             for declared_plant in obj.declared_plants.filter(active=True)
         ]
 
-    def get_declared_ingredients(self, obj):
+    def get_declared_microorganisms(self, obj):
         return [
             {
                 "genre": declared_microorganism.microorganism.genus,
@@ -386,11 +388,11 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
     def get_declared_substances(self, obj):
         return [
             {
-                "nom": declared_substance.name,
+                "nom": declared_substance.substance.name,
                 "quantité_par_djr": declared_substance.quantity,
                 "unite": declared_substance.unit.name,
             }
-            if declared_substance.name and declared_substance.quantity and declared_substance.unit
+            if declared_substance.substance.name and declared_substance.quantity and declared_substance.unit
             else {}
             for declared_substance in obj.declared_substances.all()
         ]

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -313,7 +313,6 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
 
     declared_plants = serializers.SerializerMethodField()
     declared_microorganisms = serializers.SerializerMethodField()
-    declared_ingredients = serializers.SerializerMethodField()
     declared_substances = serializers.SerializerMethodField()
 
     modification_date = serializers.DateTimeField(format="%Y-%m-%d")
@@ -332,7 +331,6 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
             "declared_plants",
             "declared_microorganisms",
             "declared_substances",
-            "declared_ingredients",
             "modification_date",
         )
         read_only_fields = fields
@@ -363,7 +361,7 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
                 "partie": declared_plant.used_part.name,
                 "preparation": declared_plant.preparation.name,
                 "quantité_par_djr": declared_plant.quantity,
-                "unit": declared_plant.unit,
+                "unite": declared_plant.unit.name,
             }
             if declared_plant.plant
             and declared_plant.used_part
@@ -383,14 +381,25 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
                 "quantité_par_djr": declared_microorganism.quantity,
                 "inactive": not declared_microorganism.activated,
             }
+            if declared_microorganism.microorganism
+            and declared_microorganism.strain
+            and declared_microorganism.quantity
+            and declared_microorganism.activated
+            else {}
             for declared_microorganism in obj.declared_microorganisms.all()
         ]
 
-    def get_declared_ingredients(self, obj):
-        return [declared_ingredient.microorganism.genus for declared_ingredient in obj.declared_ingredients.all()]
-
     def get_declared_substances(self, obj):
-        return {"nom": obj.declared_plants.name}
+        return [
+            {
+                "nom": declared_substance.new_name,
+                "quantité_par_djr": declared_substance.quantity,
+                "unite": declared_substance.unit.name,
+            }
+            if declared_substance.new_name and declared_substance.quantity and declared_substance.unit
+            else {}
+            for declared_substance in obj.declared_substances.all()
+        ]
 
 
 class DeclarationSerializer(serializers.ModelSerializer):

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -366,13 +366,7 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
                 "quantité_par_djr": declared_plant.quantity,
                 "unite": declared_plant.unit.name,
             }
-            if declared_plant.plant
-            and declared_plant.used_part
-            and declared_plant.preparation
-            and declared_plant.quantity
-            and declared_plant.unit
-            else {}
-            for declared_plant in obj.declared_plants.all()
+            for declared_plant in obj.declared_plants.filter(active=True)
         ]
 
     def get_declared_microorganisms(self, obj):

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -365,6 +365,12 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
                 "quantité_par_djr": declared_plant.quantity,
                 "unit": declared_plant.unit,
             }
+            if declared_plant.plant
+            and declared_plant.used_part
+            and declared_plant.preparation
+            and declared_plant.quantity
+            and declared_plant.unit
+            else {}
             for declared_plant in obj.declared_plants.all()
         ]
 
@@ -381,7 +387,7 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
         ]
 
     def get_declared_ingredients(self, obj):
-        return {"nom": obj.declared_plants.name}
+        return [declared_ingredient.microorganism.genus for declared_ingredient in obj.declared_ingredients.all()]
 
     def get_declared_substances(self, obj):
         return {"nom": obj.declared_plants.name}

--- a/data/etl/extractor.py
+++ b/data/etl/extractor.py
@@ -30,6 +30,7 @@ class ETL(ABC):
         self.schema = None
         self.schema_url = ""
         self.dataset_name = ""
+        self.columns = []
 
     def get_schema(self):
         return self.schema

--- a/data/etl/extractor.py
+++ b/data/etl/extractor.py
@@ -97,21 +97,6 @@ class DECLARATIONS(EXTRACTOR):
         self.df = None
         self.columns = [i["name"] for i in self.schema["fields"]]
 
-        self.columns_mapper = {
-            "id": "id",
-            "status": "decision",
-            "name": "nom_commercial",
-            "brand": "marque",
-            "gamme": "gamme",
-            "company": "complet_responsable_mise_sur_marche",
-            "article": "article",
-            "galenic_formulation": "forme_galenique",
-            "declared_plants": "plantes",
-            "declared_microorganisms": "micro_organismes",
-            "declared_substances": "substances",
-            "modification_date": "date_decision",  #  Warning : Se baser sur la du snapshot d'autorisation si la plateforme Compl'Alim permet d'editer la déclaration (ex: abandon)
-        }
-
     def extract_dataset(self):
         open_data_view = OpenDataDeclarationsListView()
         queryset = open_data_view.get_queryset()

--- a/data/etl/extractor.py
+++ b/data/etl/extractor.py
@@ -52,6 +52,13 @@ class ETL(ABC):
 
     def clean_dataset(self):
         self.df = self.df.loc[:, ~self.df.columns.duplicated()]
+        ## Code temporaire en attendant d'avoir tous les champs du schéma
+        columns_to_keep = []
+        for col in self.columns:
+            if col in self.df.columns:
+                columns_to_keep.append(col)
+        # ---------------------------------------------------
+        self.df = self.df[columns_to_keep]
         self.filter_dataframe_with_schema_cols()
 
     def is_valid(self) -> bool:

--- a/data/etl/extractor.py
+++ b/data/etl/extractor.py
@@ -103,7 +103,7 @@ class DECLARATIONS(EXTRACTOR):
             "name": "nom_commercial",
             "brand": "marque",
             "gamme": "gamme",
-            "company": "responsable_mise_sur_marche",
+            "company": "complet_responsable_mise_sur_marche",
             "article": "article",
             "galenic_formulation": "forme_galenique",
             "declared_plants": "plantes",

--- a/data/etl/extractor.py
+++ b/data/etl/extractor.py
@@ -108,7 +108,6 @@ class DECLARATIONS(EXTRACTOR):
             "galenic_formulation": "forme_galenique",
             "declared_plants": "plantes",
             "declared_microorganisms": "micro_organismes",
-            "declared_ingredients": "ingredients_inactifs",
             "declared_substances": "substances",
             "modification_date": "date_decision",  #  Warning : Se baser sur la du snapshot d'autorisation si la plateforme Compl'Alim permet d'editer la déclaration (ex: abandon)
         }

--- a/data/etl/transformer_loader.py
+++ b/data/etl/transformer_loader.py
@@ -51,10 +51,9 @@ class ETL_OPEN_DATA_DECLARATIONS(DECLARATIONS, OPEN_DATA):
             "name": "nom_commercial",
             "brand": "marque",
             "gamme": "gamme",
-            "company": "complet_responsable_mise_sur_marche",
             "article": "article",
             "galenic_formulation": "forme_galenique",
-            "quantity": "dose_journaliere",
+            "daily_recommended_dose": "dose_journaliere",
             "instructions": "mode_emploi",
             "warning": "mises_en_garde",
             "declared_plants": "plantes",
@@ -65,8 +64,6 @@ class ETL_OPEN_DATA_DECLARATIONS(DECLARATIONS, OPEN_DATA):
 
     def transform_dataset(self):
         self.df = self.df.rename(columns=self.columns_mapper)
-        self.df["responsable_mise_sur_marche"] = self.df["complet_responsable_mise_sur_marche"].apply(lambda x: x[0])
-        self.df["siret_responsable_mise_sur_marche"] = self.df["complet_responsable_mise_sur_marche"].apply(
-            lambda x: x[1]
-        )
+        self.df["responsable_mise_sur_marche"] = self.df["company"].apply(lambda x: x[0])
+        self.df["siret_responsable_mise_sur_marche"] = self.df["company"].apply(lambda x: x[1])
         self.clean_dataset()

--- a/data/etl/transformer_loader.py
+++ b/data/etl/transformer_loader.py
@@ -54,6 +54,7 @@ class ETL_OPEN_DATA_DECLARATIONS(DECLARATIONS, OPEN_DATA):
             "company": "complet_responsable_mise_sur_marche",
             "article": "article",
             "galenic_formulation": "forme_galenique",
+            "quantity": "dose_journaliere",
             "declared_plants": "plantes",
             "declared_microorganisms": "micro_organismes",
             "declared_substances": "substances",

--- a/data/etl/transformer_loader.py
+++ b/data/etl/transformer_loader.py
@@ -55,6 +55,8 @@ class ETL_OPEN_DATA_DECLARATIONS(DECLARATIONS, OPEN_DATA):
             "article": "article",
             "galenic_formulation": "forme_galenique",
             "quantity": "dose_journaliere",
+            "instructions": "mode_emploi",
+            "warning": "mises_en_garde",
             "declared_plants": "plantes",
             "declared_microorganisms": "micro_organismes",
             "declared_substances": "substances",

--- a/data/etl/transformer_loader.py
+++ b/data/etl/transformer_loader.py
@@ -43,6 +43,23 @@ class OPEN_DATA(TRANSFORMER_LOADER):
 
 
 class ETL_OPEN_DATA_DECLARATIONS(DECLARATIONS, OPEN_DATA):
+    def __init__(self):
+        super().__init__()
+        self.columns_mapper = {
+            "id": "id",
+            "status": "decision",
+            "name": "nom_commercial",
+            "brand": "marque",
+            "gamme": "gamme",
+            "company": "complet_responsable_mise_sur_marche",
+            "article": "article",
+            "galenic_formulation": "forme_galenique",
+            "declared_plants": "plantes",
+            "declared_microorganisms": "micro_organismes",
+            "declared_substances": "substances",
+            "modification_date": "date_decision",  #  Warning : Se baser sur la du snapshot d'autorisation si la plateforme Compl'Alim permet d'editer la déclaration (ex: abandon)
+        }
+
     def transform_dataset(self):
         self.df = self.df.rename(columns=self.columns_mapper)
         self.df["responsable_mise_sur_marche"] = self.df["complet_responsable_mise_sur_marche"].apply(lambda x: x[0])

--- a/data/etl/transformer_loader.py
+++ b/data/etl/transformer_loader.py
@@ -45,6 +45,8 @@ class OPEN_DATA(TRANSFORMER_LOADER):
 class ETL_OPEN_DATA_DECLARATIONS(DECLARATIONS, OPEN_DATA):
     def transform_dataset(self):
         self.df = self.df.rename(columns=self.columns_mapper)
-        self.df["responsable_mise_sur_marche"] = self.df["responsable_mise_sur_marche"].apply(lambda x: x[0])
-        self.df["siret_responsable_mise_sur_marche"] = self.df["responsable_mise_sur_marche"].apply(lambda x: x[1])
+        self.df["responsable_mise_sur_marche"] = self.df["complet_responsable_mise_sur_marche"].apply(lambda x: x[0])
+        self.df["siret_responsable_mise_sur_marche"] = self.df["complet_responsable_mise_sur_marche"].apply(
+            lambda x: x[1]
+        )
         self.clean_dataset()

--- a/data/schemas/schema_declarations.json
+++ b/data/schemas/schema_declarations.json
@@ -68,10 +68,10 @@
         "constraints": {
           "required": "True"
         },
-        "description": "Nom de l'entreprise ayant fabriqué le complément alimentaire",
-        "example": "",
-        "name": "nom_fabricant",
-        "title": "Nom fabricant",
+        "description": "Nom de l'entreprise responsable de la mise sur le marché du complément alimentaire",
+        "example": "Compl Corp",
+        "name": "responsable_mise_sur_marche",
+        "title": "Responsable de la mise sur le marché",
         "type": "string"
       },
       {
@@ -79,9 +79,10 @@
           "pattern": "^[0-9]{14}$",
           "required": true
         },
+        "description": "Siret de l'entreprise responsable de la mise sur le marché du complément alimentaire",
         "example": "11007001800012",
-        "name": "siret_fabricant",
-        "title": "Siret fabricant",
+        "name": "siret_responsable_mise_sur_marche",
+        "title": "Siret responsable de la mise sur le marché",
         "type": "integer"
       },
       {


### PR DESCRIPTION
* Ajout des champs substances, micro-organismes, mode_emploi, dose_journalière, mise en garde
* Correction Siret responsable mise sur marché
* Correction : `unit.name` au lieu d'`unit`
* Correction : Ajout de conditions pour plantes, micro-organismes et substances afin de fonctionner même en cas de manque de données

Je n'ai pas mis les colonnes autres_ingrédients_actifs et ingredients_inactifs car je ne les comprend pas assez

Il faut encore clarifier l'utilisation de certain `param_new` ; exemple dans plantes : `name` / `new_name` ou les deux ?