### PR TITLE
Sélection automatique de l'option "Autoriser" dans l'onglet décision de l'instruction

### DIFF
--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -92,7 +92,7 @@ import useToaster from "@/composables/use-toaster"
 import { handleError } from "@/utils/error-handling"
 
 const decisionCategory = ref(null)
-watch(decisionCategory, () => (proposal.value = decisionCategory.value === "approve" ? "approve" : null))
+watch(decisionCategory, () => (proposal.value = decisionCategory.value === "approve" ? "autorisation" : null))
 
 const rules = computed(() => {
   if (decisionCategory.value !== "modify") return {}


### PR DESCRIPTION
Closes #1317

## Scope

L'option "Autoriser" est la seule dans le _select_ lors qu'une instructrice choisit d'autoriser la déclaration. Donc c'est raisonnable de présélectionner cette option unique pour éviter de faire des clics supplémentaires.

Cette fonctionnalité était déjà censée être présente, mais un bug (coquille) empêchait le _select_ de mettre l'option d'autorisation.

## Démo

https://github.com/user-attachments/assets/6c11ccdc-ece7-4ad1-afce-ba3262dde7df

