### PR TITLE
Shows mandated company in the table of declarations

### DIFF
--- a/frontend/src/components/CompanyTableCell.vue
+++ b/frontend/src/components/CompanyTableCell.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <p>{{ company || "Inconnue" }}</p>
+    <p v-if="mandatedCompany" class="italic text-sm">Représentée par {{ mandatedCompany }}</p>
+  </div>
+</template>
+
+<script setup>
+defineProps({ company: String, mandatedCompany: String })
+</script>

--- a/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
@@ -14,6 +14,7 @@
 import { computed } from "vue"
 import { timeAgo } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
+import CompanyTableCell from "@/components/CompanyTableCell"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 
@@ -27,7 +28,11 @@ const rows = computed(() =>
         text: x.name,
         to: { name: "DeclarationPage", params: { id: x.id } }, // TODO Change to a more enteprisey view
       },
-      x.company.socialName,
+      {
+        component: CompanyTableCell,
+        company: x.company?.socialName,
+        mandatedCompany: x.mandatedCompany?.socialName,
+      },
       `${x.author.firstName} ${x.author.lastName}`,
       getStatusTagForCell(x.status, true),
       timeAgo(x.creationDate),

--- a/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
+++ b/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
@@ -14,6 +14,7 @@
 import { computed, ref } from "vue"
 import { timeAgo } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
+import CompanyTableCell from "@/components/CompanyTableCell"
 import { useResizeObserver, useDebounceFn } from "@vueuse/core"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
@@ -44,7 +45,11 @@ const rows = computed(() => {
         class: "font-medium",
         to: { name: "DeclarationPage", params: { id: d.id } },
       },
-      d.company?.socialName || "Inconnue",
+      {
+        component: CompanyTableCell,
+        company: d.company?.socialName,
+        mandatedCompany: d.mandatedCompany?.socialName,
+      },
       d.author ? `${d.author.firstName} ${d.author.lastName}` : "",
       getStatusTagForCell(d.status, true),
       timeAgo(d.modificationDate),

--- a/frontend/src/views/InstructionDeclarationsPage/InstructionDeclarationsTable.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/InstructionDeclarationsTable.vue
@@ -17,6 +17,7 @@ import { getStatusTagForCell } from "@/utils/components"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import { articleOptionsWith15Subtypes } from "@/utils/mappings"
+import CompanyTableCell from "@/components/CompanyTableCell"
 
 const { loggedUser } = storeToRefs(useRootStore())
 
@@ -34,7 +35,11 @@ const rows = computed(() =>
         text: x.name,
         to: { name: "InstructionPage", params: { declarationId: x.id } },
       },
-      x.company.socialName,
+      {
+        component: CompanyTableCell,
+        company: x.company?.socialName,
+        mandatedCompany: x.mandatedCompany?.socialName,
+      },
       getStatusTagForCell(x.status),
       x.responseLimitDate && isoToPrettyDate(x.responseLimitDate),
       x.instructor

--- a/frontend/src/views/VisaDeclarationsPage/VisaDeclarationsTable.vue
+++ b/frontend/src/views/VisaDeclarationsPage/VisaDeclarationsTable.vue
@@ -15,6 +15,7 @@ import { computed } from "vue"
 import { isoToPrettyDate } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
 import { articleOptionsWith15Subtypes } from "@/utils/mappings"
+import CompanyTableCell from "@/components/CompanyTableCell"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 
@@ -37,7 +38,11 @@ const rows = computed(() =>
         text: x.name,
         to: { name: "VisaPage", params: { declarationId: x.id } },
       },
-      x.company.socialName,
+      {
+        component: CompanyTableCell,
+        company: x.company?.socialName,
+        mandatedCompany: x.mandatedCompany?.socialName,
+      },
       getStatusTagForCell(x.status),
       x.responseLimitDate && isoToPrettyDate(x.responseLimitDate),
       x.instructor


### PR DESCRIPTION
Closes #1340 
## Contexte

Une fois la feature des entreprises mandataires en place, on aura des déclarations ayant été créées par des entreprises mandatées. C'est utile d'avoir cette information dans les tables de déclaration.

## Scope

Un composant a été créé pour remplir la cellule de la table concernant l'entreprise. Dans le cas où la déclaration est mandatée, l'entreprise mandatée est affichée en bas de l'entreprise du complément : 
![image](https://github.com/user-attachments/assets/3fc0c8fa-3076-48ae-9899-83ca555f8daf)
