### PR TITLE
Affichage des entreprises representées dans la UI

### DIFF
--- a/api/serializers/company.py
+++ b/api/serializers/company.py
@@ -35,6 +35,7 @@ class CompanySerializer(serializers.ModelSerializer):
     phone_number = PhoneNumberField()
     country_label = serializers.CharField(read_only=True, source="get_country_display")
     mandated_companies = MinimalCompanySerializer(read_only=True, many=True)
+    represented_companies = MinimalCompanySerializer(read_only=True, many=True)
 
     class Meta:
         model = Company
@@ -56,6 +57,11 @@ class CompanySerializer(serializers.ModelSerializer):
             "email",
             "website",
             "mandated_companies",
+            "represented_companies",
+        )
+        readonly_fields = (
+            "mandated_companies",
+            "represented_companies",
         )
 
     def to_internal_value(self, data):

--- a/api/serializers/company.py
+++ b/api/serializers/company.py
@@ -59,7 +59,7 @@ class CompanySerializer(serializers.ModelSerializer):
             "mandated_companies",
             "represented_companies",
         )
-        readonly_fields = (
+        read_only_fields = (
             "mandated_companies",
             "represented_companies",
         )

--- a/frontend/src/views/MandatedCompaniesPage/RepresentedCompaniesList.vue
+++ b/frontend/src/views/MandatedCompaniesPage/RepresentedCompaniesList.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <DsfrTable
+      ref="table"
+      class="w-full"
+      title="Entreprises representées"
+      :headers="headers"
+      :rows="rows"
+      :no-caption="true"
+      :pagination="false"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue"
+
+const props = defineProps({ companies: Array })
+const orderedCompanies = computed(() => [...props.companies].sort((a, b) => a.socialName.localeCompare(b.socialName)))
+
+const getRow = (c) => ({ rowData: [c.socialName, c.siret || "—", c.vat || "—"] })
+
+const headers = ["Entreprise", "SIRET", "Numéro de TVA"]
+const rows = computed(() => orderedCompanies.value.map(getRow))
+</script>
+
+<style scoped>
+.fr-table :deep(table) {
+  @apply !table;
+}
+</style>

--- a/frontend/src/views/MandatedCompaniesPage/index.vue
+++ b/frontend/src/views/MandatedCompaniesPage/index.vue
@@ -25,6 +25,12 @@
       <div>
         <NewMandateModal @confirm="addMandate" />
       </div>
+      <div v-if="company.representedCompanies?.length">
+        <hr class="mt-10" />
+        <h2 class="fr-h5">Entreprises representées par {{ company.socialName }}</h2>
+        <p>Ces entreprises ont donné un mandat de déclaration à {{ company.socialName }}.</p>
+        <RepresentedCompaniesList :companies="company.representedCompanies" />
+      </div>
     </div>
     <div v-else class="flex justify-center items-center min-h-60">
       <ProgressSpinner />
@@ -56,6 +62,7 @@ import { onMounted } from "vue"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import NewMandateModal from "./NewMandateModal"
 import MandatedCompaniesList from "./MandatedCompaniesList"
+import RepresentedCompaniesList from "./RepresentedCompaniesList"
 
 const route = useRoute()
 const missingCompanyModalOpened = ref(false)


### PR DESCRIPTION
Closes #1344 
Lié à #1302 

## Contexte

Une entreprise peut mandater d'autres entreprises pour déclarer en son nom. L'entreprise mandatée représente donc une ou plusieurs entreprises. Jusqu'à là, on n'affichait cette information nulle parte dans la UI.

## Scope

Une section est affichée dans « Entreprises mandataires » si l'entreprise en cours représente d'autres entreprises.

![image](https://github.com/user-attachments/assets/eb156a1c-1e66-40b6-b47a-a1a6f6d25e19)
