### PR TITLE
Ajustement de permissions pour les snapshots et l'accès aux déclarations

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -100,7 +100,8 @@ class CanAccessIndividualDeclaration(permissions.BasePermission):
         if not request.user.is_authenticated:
             return False
         is_author = IsDeclarationAuthor().has_object_permission(request, view, obj)
-        is_from_same_company = obj.company in request.user.declarable_companies.all()
+        companies = request.user.declarable_companies.all()
+        is_from_same_company = obj.company in companies or (obj.mandated_company and obj.mandated_company in companies)
         is_agent = IsInstructor().has_permission(request, view) or IsVisor().has_permission(request, view)
         is_declarant = IsDeclarant().has_object_permission(request, view, obj)
         is_draft = obj.status == Declaration.DeclarationStatus.DRAFT

--- a/api/views/snapshot.py
+++ b/api/views/snapshot.py
@@ -2,7 +2,7 @@ from django.shortcuts import get_object_or_404
 
 from rest_framework.generics import ListAPIView
 
-from api.permissions import IsDeclarationAuthor, IsInstructor, IsVisor
+from api.permissions import CanAccessIndividualDeclaration, IsInstructor, IsVisor
 from api.serializers import SnapshotSerializer
 from data.models import Declaration, Snapshot
 
@@ -10,7 +10,7 @@ from data.models import Declaration, Snapshot
 class DeclarationSnapshotListView(ListAPIView):
     model = Snapshot
     serializer_class = SnapshotSerializer
-    permission_classes = (IsDeclarationAuthor | IsInstructor | IsVisor,)
+    permission_classes = (CanAccessIndividualDeclaration | IsInstructor | IsVisor,)
 
     def get_queryset(self):
         declaration = get_object_or_404(Declaration, pk=self.kwargs[self.lookup_field])


### PR DESCRIPTION
Lié à #1302.

## Contexte

Sur la PR des entreprises mandataires j'ai oublié de mettre le changement de permission pour le _GET_ individuel des déclarations et pour les snapshots. 

Ceci provoquait qu'on pouvait voir une déclaration, mais au moment de l'ouvrir on avait une erreur 403.