### PR TITLE
Affichage des entreprises representées dans l'admin

### DIFF
--- a/data/admin/company.py
+++ b/data/admin/company.py
@@ -1,16 +1,106 @@
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import format_html, format_html_join, mark_safe
 
 from ..models.company import Company, DeclarantRole, SupervisorRole
 
 
+class SupervisionInline(admin.TabularInline):
+    model = Company.supervisors.through
+    extra = 0
+
+
+class DeclarantInline(admin.TabularInline):
+    model = Company.declarants.through
+    extra = 0
+
+
 @admin.register(Company)
 class CompanyAdmin(admin.ModelAdmin):
+    filter_horizontal = ("mandated_companies",)
+    readonly_fields = ("display_represented_companies",)
+
     search_fields = (
         "social_name",
         "commercial_name",
         "vat",
         "siret",
     )
+
+    fieldsets = (
+        (
+            "",
+            {
+                "fields": (
+                    "social_name",
+                    "commercial_name",
+                    "siret",
+                    "vat",
+                    "activities",
+                )
+            },
+        ),
+        (
+            "Contact",
+            {
+                "fields": (
+                    "phone_number",
+                    "email",
+                    "website",
+                )
+            },
+        ),
+        (
+            "Adresse",
+            {
+                "fields": (
+                    "address",
+                    "additional_details",
+                    "postal_code",
+                    "city",
+                    "cedex",
+                    "country",
+                )
+            },
+        ),
+        (
+            "Mandats",
+            {
+                "fields": (
+                    "mandated_companies",
+                    "display_represented_companies",
+                )
+            },
+        ),
+    )
+
+    inlines = (
+        SupervisionInline,
+        DeclarantInline,
+    )
+
+    def display_represented_companies(self, obj):
+        """
+        Affiche la relation inversé de `mandated_companies`, çad `represented_companies`
+        en tant que liste formatée
+        """
+        represented = obj.represented_companies.all()
+        if represented.exists():
+            list_items = format_html_join(
+                mark_safe(""),
+                '<li><a href="{}">{}</a></li>',
+                (
+                    (
+                        reverse("admin:data_company_change", args=(company.id,)),
+                        f"{company.social_name or company.commercial_name} ({company.siret or company.vat})",
+                    )
+                    for company in represented
+                ),
+            )
+            return format_html('<ul style="margin-left:0;">{}</ul>', list_items)
+        return "Cette entreprise peut seulement déclarer pour elle-même."
+
+    display_represented_companies.short_description = "Entreprises representées"
 
 
 @admin.register(SupervisorRole)


### PR DESCRIPTION
Closes #1365 

## Contexte

Depuis la feature des entreprises mandataires, le modèle `Company` a une relation m2m avec lui même, d'un côté avec `mandated_companies` (les compagnies pouvant déclarer à son nom), et la relation inverse `represented_companies` (les compagnies pour lesquelles elle peut déclarer).

Seulement la première relation (`mandated_companies`) est visible dans l'admin aujourd'hui.

## Scope

- J'ai refactoré légèrement l'admin du modèle _Company_ pour introduire les _fieldsets_ et mieux organiser les champs.
- J'ai profité pour ajouter des champs pour les rôles déclarant·e et gestionnaire
- J'ai changé le contrôle HTML des `mandated_companies` pour le rendre plus clair
- J'ai ajouté la liste des `represented_companies` avec un lien vers la page admin de la compagnie en question

## Démo

La section « _Mandats_ » affiche désormais les deux relations de l'entreprise _Guichard_ : 

![image](https://github.com/user-attachments/assets/c8f514a9-7b5a-45a4-a93b-a798057ef18f)

Dans cet exemple, si je clique sur l'entreprise _Mercier_ je vois donc _Guichard_ dans la première relation.

![image](https://github.com/user-attachments/assets/5e1229ec-7977-4a85-94bd-80fe4ab170cd)

Finalement, les autres champs sont mieux organisés et les rôles déclarant·e et gestion sont aussi affichées

![image](https://github.com/user-attachments/assets/ab46ce21-c002-4513-8ee5-53e852501d9f)

