### PR TITLE
Encodage ASCII des noms des fichiers PDF

### DIFF
--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -98,7 +98,7 @@ class CertificateView(GenericAPIView):
         # Le load-balancer Sozu a du mal avec les noms de fichier pdf contenant des caractères non-ASCII
         # https://github.com/betagouv/complements-alimentaires/issues/1367
         name = declaration.name.encode("ascii", "ignore")
-        return f"attestation-{name}.pdf"
+        return f"attestation-{name.decode()}.pdf"
 
     @staticmethod
     def link_callback(uri, rel):

--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -95,7 +95,10 @@ class CertificateView(GenericAPIView):
         }
 
     def get_pdf_file_name(self, declaration):
-        return f"attestation-{declaration.name}.pdf"
+        # Le load-balancer Sozu a du mal avec les noms de fichier pdf contenant des caractères non-ASCII
+        # https://github.com/betagouv/complements-alimentaires/issues/1367
+        name = declaration.name.encode("ascii", "ignore")
+        return f"attestation-{name}.pdf"
 
     @staticmethod
     def link_callback(uri, rel):


### PR DESCRIPTION
Closes #1367 

## Contexte

Le load-balancer Sozu (utilisé par clevercloud dans nos instances prod et staging) n'a pas de support pour les caractères non-ASCII dans les noms de fichiers.