### PR TITLE
Fixes some issues when declarations have no author

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -131,7 +131,9 @@ class CanTakeAuthorship(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):  # obj: Declaration
         if not request.user.is_authenticated:
             return False
-        is_from_same_company = obj.company in request.user.declarable_companies.all()
+        declarable_companies = request.user.declarable_companies.all()
+        is_from_same_company = obj.company in declarable_companies
+        is_from_mandated_company = obj.mandated_company and obj.mandated_company in declarable_companies
         is_declarant = IsDeclarant().has_object_permission(request, view, obj)
 
-        return is_from_same_company and is_declarant
+        return (is_from_same_company or is_from_mandated_company) and is_declarant

--- a/frontend/src/components/IdentityTab.vue
+++ b/frontend/src/components/IdentityTab.vue
@@ -25,10 +25,15 @@
       </span>
     </p>
     <SectionTitle class="!mt-8" title="Déclarant ou déclarante" icon="ri-user-fill" />
-    <p>{{ user.firstName }} {{ user.lastName }}</p>
-    <p>
-      Adresse email :
-      <a :href="`mailto:${user.email}`" target="_blank">{{ user.email }}</a>
+    <div v-if="user">
+      <p>{{ user.firstName }} {{ user.lastName }}</p>
+      <p>
+        Adresse email :
+        <a :href="`mailto:${user.email}`" target="_blank">{{ user.email }}</a>
+      </p>
+    </div>
+    <p v-else>
+      Cette déclaration n'a pas de déclarant ou déclarante assigné. Le compte a probablement été supprimé depuis.
     </p>
   </div>
 </template>

--- a/frontend/src/components/SnapshotItem.vue
+++ b/frontend/src/components/SnapshotItem.vue
@@ -67,7 +67,10 @@ const isAdministrativeAction = computed(() => {
   return instructionActions.indexOf(props.snapshot.action) > -1
 })
 
-const initials = computed(() => `${props.snapshot.user?.firstName?.[0]}${props.snapshot.user?.lastName?.[0]}`)
+const initials = computed(() => {
+  if (!props.snapshot.user) return "?"
+  return `${props.snapshot.user.firstName?.[0]}${props.snapshot.user.lastName?.[0]}`
+})
 const date = computed(
   () => `${isoToPrettyDate(props.snapshot.creationDate)} à ${isoToPrettyTime(props.snapshot.creationDate)}`
 )
@@ -75,7 +78,8 @@ const modalOpened = ref(false)
 const isInValidationState = computed(() => props.snapshot.status === "AWAITING_VISA")
 const fullName = computed(() => {
   if (props.hideInstructionDetails && isAdministrativeAction.value) return "L'administration"
-  return `${props.snapshot.user?.firstName} ${props.snapshot.user?.lastName}`
+  if (!props.snapshot.user) return "Une personne"
+  return `${props.snapshot.user.firstName} ${props.snapshot.user.lastName}`
 })
 const actionText = computed(() => {
   const mapping = {

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -19,7 +19,16 @@
 
       <DsfrAlert
         class="mb-4"
-        v-if="payload.author && payload.author !== loggedUser.id"
+        v-if="payload.id && !payload.author"
+        type="info"
+        title="Cette déclaration n'est gérée par personne"
+      >
+        <p>Vous pouvez néanmoins vous l'assigner en cliquant ci-dessous</p>
+        <DsfrButton class="mt-2" label="Prendre cette déclaration" tertiary @click="takeDeclaration" />
+      </DsfrAlert>
+      <DsfrAlert
+        class="mb-4"
+        v-else-if="payload.author && payload.author !== loggedUser.id"
         type="info"
         title="Cette déclaration est gérée par une autre personne"
       >


### PR DESCRIPTION
Closes #1366

## Contexte

Il est possible qu'une déclaration n'ait pas une personne assignée en tant que `author` - soit à cause de la suppression du compte soit car l'auteur·ice a été enlevé·e depuis l'admin.

## Scope

Cette PR ajuste certains composants de la UI qui ne marchaient pas sans la propriété `author` de la déclaration. Les cas sont expliqués dans l'issue #1366 