### PR TITLE
Ensures full article name is displayed in the article row component

### DIFF
--- a/frontend/src/components/DeclarationSummary/ArticleInfoRow.vue
+++ b/frontend/src/components/DeclarationSummary/ArticleInfoRow.vue
@@ -13,7 +13,7 @@
     </DsfrModal>
 
     <DsfrBadge type="warning" label="Article inconnu" v-if="!payload.article" />
-    <DsfrBadge no-icon v-else :label="articleOptions.find((x) => x.value === payload.article)?.text" />
+    <DsfrBadge no-icon v-else :label="articleOptionsWith15Subtypes.find((x) => x.value === payload.article)?.text" />
     <DsfrButton
       size="sm"
       tertiary

--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -231,7 +231,7 @@ export const articleOptionsWith15Subtypes = [
   { value: "ART_15_WARNING", text: "Article 15 vigilance", shortText: "15 vig." },
   { value: "ART_15_HIGH_RISK_POPULATION", text: "Article 15 population à risque", shortText: "15 pop." },
   { value: "ART_16", text: "Article 16", shortText: "16" },
-  { value: "ANSES_REFERAL", text: "Saisine ANSES", shortText: "saisine ANSES" },
+  { value: "ANSES_REFERAL", text: "Saisine ANSES", shortText: "Saisine ANSES" },
 ]
 
 export const articleOptions = [
@@ -239,7 +239,7 @@ export const articleOptions = [
   { value: "ART_15_WARNING", text: "Article 15", shortText: "15" },
   { value: "ART_15_HIGH_RISK_POPULATION", text: "Article 15", shortText: "15" },
   { value: "ART_16", text: "Article 16", shortText: "16" },
-  { value: "ANSES_REFERAL", text: "Saisine ANSES", shortText: "saisine ANSES" },
+  { value: "ANSES_REFERAL", text: "Saisine ANSES", shortText: "Saisine ANSES" },
 ]
 
 export const typeOptions = [


### PR DESCRIPTION
Closes #1371 

## Contexte

Les instructrices et viseuses voient un bandeau contenant l'article de la déclaration visualisée ainsi qu'une option permettant le modifier : 

![image](https://github.com/user-attachments/assets/2e75dc73-6aa6-438b-8267-41a024412d20)

Le problème est qu'aujourd'hui on affiche un nom d'article « simplifié », çad pour un article 15 on ne spécifie pas si c'est _vigilance_ ou _pop. à risques_.

## Fix

Il suffit d'utiliser le mapping `articleOptionsWith15Subtypes` pour afficher le nom complet de l'article.

![image](https://github.com/user-attachments/assets/6451c1e1-ffa9-4148-a079-dcfa40e088db)

J'en ai profité pour changer le casing du texte « Saisine ANSEES » pour faire en sorte que la « S » initiale soit en majuscule (comme c'est le cas pour les autres articles).

![image](https://github.com/user-attachments/assets/fe1ad656-d0be-43c0-bbee-2e278c3a8b96)
