### PR TITLE
Changement de comportement des cercles "visa refusée" et "le pro a répondu"

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -309,6 +309,7 @@ class SimpleDeclarationSerializer(serializers.ModelSerializer):
             "visor",
             "response_limit_date",
             "visa_refused",
+            "has_pending_pro_responses",
             "article",
         )
         read_only_fields = fields

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -37,7 +37,7 @@ from data.factories import (
     SupervisorRoleFactory,
     VisaRoleFactory,
 )
-from data.models import Attachment, Declaration, DeclaredMicroorganism
+from data.models import Attachment, Declaration, DeclaredMicroorganism, Snapshot
 
 from .utils import authenticate
 
@@ -1585,7 +1585,7 @@ class TestDeclarationApi(APITestCase):
     def test_visa_refusal_field(self):
         VisaRoleFactory(user=authenticate.user)
         declaration = OngoingVisaDeclarationFactory()
-
+        SnapshotFactory(declaration=declaration, action=Snapshot.SnapshotActions.RESPOND_TO_OBJECTION)
         response = self.client.post(reverse("api:refuse_visa", kwargs={"pk": declaration.id}), format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -308,12 +308,48 @@ class Declaration(Historisable, TimeStampable):
 
     @property
     def visa_refused(self):
+        """
+        Vérifie si le dernier refus de visa est effectué après la dernière action du pro.
+        """
         from data.models import Snapshot
 
-        return (
-            self.status == Declaration.DeclarationStatus.AWAITING_INSTRUCTION
-            and self.snapshots.latest("creation_date").action == Snapshot.SnapshotActions.REFUSE_VISA
-        )
+        user_actions = [
+            Snapshot.SnapshotActions.SUBMIT,
+            Snapshot.SnapshotActions.RESPOND_TO_OBJECTION,
+            Snapshot.SnapshotActions.RESPOND_TO_OBSERVATION,
+        ]
+        statuses = [
+            Declaration.DeclarationStatus.AWAITING_INSTRUCTION,
+            Declaration.DeclarationStatus.ONGOING_INSTRUCTION,
+        ]
+
+        if self.status not in statuses:
+            return False
+
+        try:
+            latest_visa_refusal = self.snapshots.filter(action=Snapshot.SnapshotActions.REFUSE_VISA).latest(
+                "creation_date"
+            )
+            latest_user_action = self.snapshots.filter(action__in=user_actions).latest("creation_date")
+        except Snapshot.DoesNotExist as _:
+            return False
+
+        return latest_user_action.creation_date < latest_visa_refusal.creation_date
+
+    @property
+    def has_pending_pro_responses(self):
+        """
+        Vérifie si la déclaration est du côté de l'instruction après au moins un aller-retour avec le pro
+        """
+        from data.models import Snapshot
+
+        statuses = [
+            Declaration.DeclarationStatus.AWAITING_INSTRUCTION,
+            Declaration.DeclarationStatus.ONGOING_INSTRUCTION,
+        ]
+        actions = [Snapshot.SnapshotActions.RESPOND_TO_OBJECTION, Snapshot.SnapshotActions.RESPOND_TO_OBSERVATION]
+
+        return self.status in statuses and self.snapshots.filter(action__in=actions).exists()
 
     @property
     def response_limit_date(self):

--- a/frontend/src/views/InstructionDeclarationsPage/CircleIndicators.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/CircleIndicators.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="flex gap-[1px]">
+    <div class="h-3 w-3 rounded-full bg-red-500" v-if="hasRefusedVisa"></div>
+    <div class="h-3 w-3 rounded-full bg-orange-400" v-if="hasPendingProResponses"></div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue"
+const props = defineProps(["declaration"])
+
+const hasPendingProResponses = computed(() => props.declaration.hasPendingProResponses)
+const hasRefusedVisa = computed(() => props.declaration.visaRefused)
+</script>

--- a/frontend/src/views/InstructionDeclarationsPage/InstructionDeclarationsTable.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/InstructionDeclarationsTable.vue
@@ -18,6 +18,7 @@ import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import { articleOptionsWith15Subtypes } from "@/utils/mappings"
 import CompanyTableCell from "@/components/CompanyTableCell"
+import CircleIndicators from "./CircleIndicators"
 
 const { loggedUser } = storeToRefs(useRootStore())
 
@@ -28,7 +29,10 @@ const rows = computed(() =>
   props.data?.results?.map((x) => ({
     rowAttrs: { class: needsAttention(x) ? "font-bold" : "" },
     rowData: [
-      needsAttention(x) ? { component: "div", class: `h-3 w-3 rounded-full ${circleColor(x)}` } : "",
+      {
+        component: CircleIndicators,
+        declaration: x,
+      },
       x.id,
       {
         component: "router-link",
@@ -54,8 +58,6 @@ const needsAttention = (declaration) =>
   !!declaration.instructor &&
   declaration.instructor.id === loggedUser.value.id &&
   declaration.status === "AWAITING_INSTRUCTION"
-
-const circleColor = (declaration) => (declaration.visaRefused ? "bg-red-500" : "bg-orange-400")
 </script>
 
 <style scoped>


### PR DESCRIPTION
Closes #1364 

## Contexte

Deux pastilles peuvent s'afficher dans la table d'instruction : 
- une orange indiquant que le pro a répondu à une observation ou objection, et
- une rouge indiquant que la viseuse a refusé le visa

Le comportement précédent (décrit dans #1364) n'est pas utile pour les instructrices et certains ajustements sont nécessaires - notamment concernant le fait que la pastille doit rester visible jusqu'à ce que le dossier soit traité.

## Scope

Les propriétés `visa_refused` et `has_pending_pro_responses` sont calculées au backend, et les modifications principales de cette PR se trouvent dans le modèle déclaration. Des tests plus précis concernant les deux propriétés ont été ajoutés.

Une déclaration pourrait être dans les deux cas. Précédemment on affichait seulement la pastille rouge, mais ce comportement a changé pour afficher les deux pastilles (exemple ci-dessous)
![image](https://github.com/user-attachments/assets/e0b610f8-3c22-4f56-bfdd-007136e61bc4)

Cette nouveauté explique l'ajout d'un nouvel composant Vue qui se charge des pastilles.
