### PR TITLE
Affichage du badge « Non autorisé » pour les ingrédients concernés pour les instructrices et viseuses

### DIFF
--- a/frontend/src/components/DeclarationSummary/SummaryElementItem.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementItem.vue
@@ -10,6 +10,12 @@
             </p>
           </div>
 
+          <ElementStatusBadge
+            :text="model.element.status"
+            v-if="showElementAuthorization && model.element?.status === 'non autorisé'"
+            class="self-center ml-2"
+          />
+
           <DsfrBadge v-if="novelFood" label="Novel Food" type="new" class="self-center ml-2" small />
           <DsfrBadge v-if="model.new" label="Nouvel ingrédient" type="info" class="self-center ml-2" small />
           <DsfrBadge v-if="!model.active" label="Non-actif" type="none" class="self-center ml-2" small />
@@ -38,13 +44,14 @@ import { getElementName } from "@/utils/elements"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import ElementCommentModal from "@/components/ElementCommentModal"
+import ElementStatusBadge from "@/components/ElementStatusBadge"
 
 const { plantParts, units, preparations, loggedUser } = storeToRefs(useRootStore())
 
 const isInstructor = computed(() => loggedUser.value?.globalRoles.some((x) => x.name === "InstructionRole"))
 
 const model = defineModel()
-const props = defineProps({ objectType: { type: String } })
+const props = defineProps({ objectType: { type: String }, showElementAuthorization: { type: Boolean } })
 
 const plantPartName = computed(() => plantParts.value?.find((x) => x.id === model.value.usedPart)?.name || "Aucune")
 const unitName = computed(() => units.value?.find((x) => x.id === model.value.unit)?.name || "")

--- a/frontend/src/components/DeclarationSummary/SummaryElementList.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementList.vue
@@ -5,13 +5,21 @@
       <template v-slot:title>
         <SummaryElementListTitle :objectType="objectType" :elementCount="`${elements.length}`" />
       </template>
-      <SummaryElementListItems :objectType="objectType" :elements="elements" />
+      <SummaryElementListItems
+        :showElementAuthorization="showElementAuthorization"
+        :objectType="objectType"
+        :elements="elements"
+      />
     </DsfrAccordion>
 
     <!-- Affichage sans les accordéons, tous les ingrédients sont affichés -->
     <div v-else>
       <SummaryElementListTitle class="mt-6 mb-3" :objectType="objectType" />
-      <SummaryElementListItems :objectType="objectType" :elements="elements" />
+      <SummaryElementListItems
+        :showElementAuthorization="showElementAuthorization"
+        :objectType="objectType"
+        :elements="elements"
+      />
     </div>
   </div>
 </template>
@@ -20,5 +28,10 @@
 import SummaryElementListTitle from "./SummaryElementListTitle"
 import SummaryElementListItems from "./SummaryElementListItems"
 
-defineProps({ objectType: { type: String }, elements: { type: Array }, useAccordions: { type: Boolean } })
+defineProps({
+  objectType: { type: String },
+  elements: { type: Array },
+  useAccordions: { type: Boolean },
+  showElementAuthorization: { type: Boolean },
+})
 </script>

--- a/frontend/src/components/DeclarationSummary/SummaryElementListItems.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementListItems.vue
@@ -6,6 +6,7 @@
       :key="`summary-${objectType}-${index}`"
       v-model="elements[index]"
       :objectType="objectType"
+      :showElementAuthorization="showElementAuthorization"
     />
   </ul>
 </template>
@@ -13,5 +14,5 @@
 <script setup>
 import SummaryElementItem from "./SummaryElementItem"
 
-defineProps({ objectType: { type: String }, elements: { type: Array } })
+defineProps({ objectType: { type: String }, elements: { type: Array }, showElementAuthorization: { type: Boolean } })
 </script>

--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -27,38 +27,54 @@
       <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(1))" />
     </h3>
 
-    <SummaryElementList :useAccordions="useAccordions" objectType="plant" :elements="payload.declaredPlants" />
     <SummaryElementList
       :useAccordions="useAccordions"
+      :showElementAuthorization="showElementAuthorization"
+      objectType="plant"
+      :elements="payload.declaredPlants"
+    />
+    <SummaryElementList
+      :useAccordions="useAccordions"
+      :showElementAuthorization="showElementAuthorization"
       objectType="microorganism"
       :elements="payload.declaredMicroorganisms"
     />
     <SummaryElementList
       objectType="form_of_supply"
       :useAccordions="useAccordions"
+      :showElementAuthorization="showElementAuthorization"
       :elements="getObjectSubTypeList(payload.declaredIngredients, 'form_of_supply')"
     />
     <SummaryElementList
       :useAccordions="useAccordions"
+      :showElementAuthorization="showElementAuthorization"
       objectType="aroma"
       :elements="getObjectSubTypeList(payload.declaredIngredients, 'aroma')"
     />
     <SummaryElementList
       objectType="additive"
       :useAccordions="useAccordions"
+      :showElementAuthorization="showElementAuthorization"
       :elements="getObjectSubTypeList(payload.declaredIngredients, 'additive')"
     />
     <SummaryElementList
       objectType="active_ingredient"
       :useAccordions="useAccordions"
+      :showElementAuthorization="showElementAuthorization"
       :elements="getObjectSubTypeList(payload.declaredIngredients, 'active_ingredient')"
     />
     <SummaryElementList
       objectType="non_active_ingredient"
       :useAccordions="useAccordions"
+      :showElementAuthorization="showElementAuthorization"
       :elements="getObjectSubTypeList(payload.declaredIngredients, 'non_active_ingredient')"
     />
-    <SummaryElementList objectType="substance" :useAccordions="useAccordions" :elements="payload.declaredSubstances" />
+    <SummaryElementList
+      objectType="substance"
+      :useAccordions="useAccordions"
+      :showElementAuthorization="showElementAuthorization"
+      :elements="payload.declaredSubstances"
+    />
 
     <p class="font-bold mt-8">Substances contenues dans la composition :</p>
     <SubstancesTable v-model="payload" readonly />
@@ -107,7 +123,7 @@ const router = useRouter()
 const { units, populations, conditions, effects, galenicFormulations } = storeToRefs(useRootStore())
 
 const payload = defineModel()
-defineProps({ readonly: Boolean, showArticle: Boolean, useAccordions: Boolean })
+defineProps({ readonly: Boolean, showArticle: Boolean, useAccordions: Boolean, showElementAuthorization: Boolean })
 const unitInfo = computed(() => {
   if (!payload.value.unitQuantity) return null
   const unitMeasurement = units.value?.find?.((x) => x.id === payload.value.unitMeasurement)?.name || "-"

--- a/frontend/src/components/ElementStatusBadge.vue
+++ b/frontend/src/components/ElementStatusBadge.vue
@@ -1,6 +1,6 @@
 <template>
   <DsfrBadge v-if="text === 'autorisé'" :label="text" small type="success" />
-  <DsfrBadge v-if="text === 'non autorisé'" :label="text" small type="error" />
+  <DsfrBadge v-else-if="text === 'non autorisé'" :label="text" small type="error" />
 </template>
 
 <script setup>

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -30,6 +30,7 @@
         <DeclarationSummary
           :showArticle="true"
           :useAccordions="true"
+          :showElementAuthorization="true"
           :readonly="true"
           v-model="declaration"
           v-if="isAwaitingInstruction"
@@ -48,6 +49,7 @@
               :externalResults="$externalResults"
               :readonly="true"
               :useAccordions="true"
+              :showElementAuthorization="true"
               :declarationId="declaration?.id"
               :user="declarant"
               :company="company"

--- a/frontend/src/views/ProducerFormPage/ElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/ElementCard.vue
@@ -9,6 +9,9 @@
           <div v-if="synonyms">
             {{ synonyms }}
           </div>
+          <div v-if="model.element?.status === 'non autorisé'">
+            <ElementStatusBadge :text="model.element.status" />
+          </div>
           <div v-if="model.new" class="self-center mt-1">
             <DsfrBadge label="Nouvel ingrédient" type="info" />
           </div>
@@ -126,6 +129,7 @@ import { computed, watch } from "vue"
 import { getElementName } from "@/utils/elements"
 import { getActivityReadonlyByType } from "@/utils/mappings"
 import ElementCommentModal from "@/components/ElementCommentModal"
+import ElementStatusBadge from "@/components/ElementStatusBadge"
 
 const model = defineModel()
 const store = useRootStore()

--- a/frontend/src/views/ProducerFormPage/ElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/ElementCard.vue
@@ -9,9 +9,6 @@
           <div v-if="synonyms">
             {{ synonyms }}
           </div>
-          <div v-if="model.element?.status === 'non autorisé'">
-            <ElementStatusBadge :text="model.element.status" />
-          </div>
           <div v-if="model.new" class="self-center mt-1">
             <DsfrBadge label="Nouvel ingrédient" type="info" />
           </div>
@@ -129,7 +126,6 @@ import { computed, watch } from "vue"
 import { getElementName } from "@/utils/elements"
 import { getActivityReadonlyByType } from "@/utils/mappings"
 import ElementCommentModal from "@/components/ElementCommentModal"
-import ElementStatusBadge from "@/components/ElementStatusBadge"
 
 const model = defineModel()
 const store = useRootStore()

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -26,6 +26,7 @@
         <DeclarationSummary
           :showArticle="true"
           :useAccordions="true"
+          :showElementAuthorization="true"
           :readonly="true"
           v-model="declaration"
           v-if="isAwaitingVisa"
@@ -46,6 +47,7 @@
               :readonly="true"
               :declarationId="declaration?.id"
               :useAccordions="true"
+              :showElementAuthorization="true"
               :user="declarant"
               :company="company"
               @decision-done="onDecisionDone"


### PR DESCRIPTION
Closes #1363 

## Contexte
Certains ingrédients (par exemple la plante _Agapanthus inapertus_) ont un statut « non autorisé ». On affiche bien ce statut dans les résultats de la recherche mais pas dans les pages instruction et visa.

## Scope

On réutilise le composant `showElementAuthorization` dans le composant _SummaryElementItem.vue_. 

Un paramètre est passé pour spécifier quand est-ce qu'on veut afficher ce badge. Pour l'instant c'est seulement pour les instructrices et viseuses (comme spécifié dans #1363).

## Démo

![image](https://github.com/user-attachments/assets/99904a33-f838-43f0-818a-463460eb9a09)
