### PR TITLE
Ne permet pas la validation d'une déclaration en saisine ANSES

### DIFF
--- a/frontend/src/views/InstructionPage/DecisionTab.vue
+++ b/frontend/src/views/InstructionPage/DecisionTab.vue
@@ -72,7 +72,21 @@
               v-model="comment"
             />
           </DsfrInputGroup>
-          <DsfrButton class="" label="Soumettre" @click="submitDecision" />
+          <DsfrButton
+            class=""
+            label="Soumettre"
+            @click="submitDecision"
+            :disabled="needsAnsesReferal && decisionCategory === 'approve'"
+          />
+          <div v-if="needsAnsesReferal && decisionCategory === 'approve'" class="mt-2">
+            <hr class="p-0 my-2" />
+            <p class="my-1">
+              <v-icon name="ri-error-warning-line"></v-icon>
+              La déclaration ne peut pas être validée en nécessitant une saisine ANSEES. Merci de changer l'article
+              avant de la valider.
+            </p>
+            <ArticleInfoRow v-model="declaration" v-if="needsAnsesReferal && decisionCategory === 'approve'" />
+          </div>
 
           <div v-if="firstErrorMsg(v$, 'reasons')">{{ firstErrorMsg(v$, "reasons") }}</div>
         </template>
@@ -90,6 +104,7 @@ import { useFetch } from "@vueuse/core"
 import { headers } from "@/utils/data-fetching"
 import useToaster from "@/composables/use-toaster"
 import { handleError } from "@/utils/error-handling"
+import ArticleInfoRow from "@/components/DeclarationSummary/ArticleInfoRow"
 
 const decisionCategory = ref(null)
 watch(decisionCategory, () => (proposal.value = decisionCategory.value === "approve" ? "autorisation" : null))
@@ -124,6 +139,8 @@ watch(proposal, (newProposal) => {
   else if (newProposal === "rejection") delayDays.value = null
   else delayDays.value = 15
 })
+
+const needsAnsesReferal = computed(() => declaration.value?.article === "ANSES_REFERAL")
 
 const decisionCategories = [
   {


### PR DESCRIPTION
Closes #1277

## Contexte
Les déclarations signalées comme ayant besoin d'une saisine ANSES ne doivent pas être validées. Le processus d'instruction doit s'assurer que l'article soit différent à `ANSES_REFERAL`.

## Scope

On réutilise le composant `ArticleInfoRow` pour le changement d'article, accompagné d'un texte expliquant pourquoi on ne peut pas approuver une déclaration en saisine ANSES.

## Démo

https://github.com/user-attachments/assets/10ea2ef8-1090-4586-949d-642e0df5a8f1

Un cas qui ne devrait pas trop arriver est celui d'une déclaration au visa en article ANSES pour autorisation de la déclaration. Ce serait rare car à partir de cette PR l'instruction ne peut pas les autoriser, même avec visa. En tout cas, si cela arrive (par ex une déclaration antérieure à la PR, ou un changement depuis l'admin) voici la UI :

https://github.com/user-attachments/assets/4155f18d-b23c-477e-91d2-99bda4da17f9


