### PR TITLE
Le message de dépassement de dose max ne doit s'afficher que si la dose est > (pas >=)

### DIFF
--- a/frontend/src/components/SubstancesTable.vue
+++ b/frontend/src/components/SubstancesTable.vue
@@ -45,7 +45,7 @@
               '!text-red-marianne-425 font-bold':
                 (payload.computedSubstances[rowIndex].substance.maxQuantity ||
                   payload.computedSubstances[rowIndex].substance.maxQuantity === 0) &&
-                payload.computedSubstances[rowIndex].quantity >=
+                payload.computedSubstances[rowIndex].quantity >
                   payload.computedSubstances[rowIndex].substance.maxQuantity,
             }"
             v-if="props.readonly"
@@ -55,7 +55,7 @@
               v-if="
                 (payload.computedSubstances[rowIndex].substance.maxQuantity ||
                   payload.computedSubstances[rowIndex].substance.maxQuantity === 0) &&
-                payload.computedSubstances[rowIndex].quantity >=
+                payload.computedSubstances[rowIndex].quantity >
                   payload.computedSubstances[rowIndex].substance.maxQuantity
               "
             >


### PR DESCRIPTION
L'affichage front ne correspondait pas à l'algo d'assignation de l'article.
![image](https://github.com/user-attachments/assets/1d7deab0-3943-4bba-99eb-b74bc4a1334d)
