### PR TITLE
Permet le téléchargement de l'attestation des déclarations en abandon

### DIFF
--- a/frontend/src/components/DeclarationAlert.vue
+++ b/frontend/src/components/DeclarationAlert.vue
@@ -84,7 +84,7 @@ const declarantDisplayData = computed(() => {
     case "AUTHORIZED":
       return { type: "success", title: "Attestation de déclaration", body: null, canDownloadCertificate: true }
     case "ABANDONED":
-      return { type: "warning", title: "Ce dossier est abandonné", body: null, canDownloadCertificate: false }
+      return { type: "warning", title: "Ce dossier est abandonné", body: null, canDownloadCertificate: true }
     case "REJECTED":
       return {
         type: "warning",
@@ -140,7 +140,7 @@ const instructorDisplayData = computed(() => {
     case "AUTHORIZED":
       return { type: "success", title: "Cette déclaration a été autorisée", body: null, canDownloadCertificate: true }
     case "ABANDONED":
-      return { type: "warning", title: "Ce dossier est abandonné", body: null, canDownloadCertificate: false }
+      return { type: "warning", title: "Ce dossier est abandonné", body: null, canDownloadCertificate: true }
     case "REJECTED":
       return {
         type: "warning",
@@ -196,7 +196,7 @@ const visorDisplayData = computed(() => {
     case "AUTHORIZED":
       return { type: "success", title: "Cette déclaration a été autorisée", body: null, canDownloadCertificate: true }
     case "ABANDONED":
-      return { type: "warning", title: "Ce dossier est abandonné", body: null, canDownloadCertificate: false }
+      return { type: "warning", title: "Ce dossier est abandonné", body: null, canDownloadCertificate: true }
     case "REJECTED":
       return {
         type: "warning",

--- a/frontend/src/components/DeclarationAlert.vue
+++ b/frontend/src/components/DeclarationAlert.vue
@@ -16,7 +16,7 @@
 <script setup>
 import { computed } from "vue"
 import { isoToPrettyDate } from "@/utils/date"
-const props = defineProps({ declaration: Object, role: { type: String, default: "declarant" } })
+const props = defineProps({ declaration: Object, role: { type: String, default: "declarant" }, snapshots: Array })
 
 const displayData = computed(() => {
   switch (props.role) {
@@ -30,6 +30,12 @@ const displayData = computed(() => {
       console.error(`Role ${props.role} not supported`)
       return null
   }
+})
+
+const canDownloadAbandonedCertificate = computed(() => {
+  if (!props.snapshots) return false
+  const latestSnapshot = [...props.snapshots].sort((a, b) => b.creationDate.localeCompare(a.creationDate))?.[0]
+  return latestSnapshot?.status === "OBJECTION"
 })
 
 const declarantDisplayData = computed(() => {
@@ -84,7 +90,12 @@ const declarantDisplayData = computed(() => {
     case "AUTHORIZED":
       return { type: "success", title: "Attestation de déclaration", body: null, canDownloadCertificate: true }
     case "ABANDONED":
-      return { type: "warning", title: "Ce dossier est abandonné", body: null, canDownloadCertificate: true }
+      return {
+        type: "warning",
+        title: "Ce dossier est abandonné",
+        body: null,
+        canDownloadCertificate: canDownloadAbandonedCertificate.value,
+      }
     case "REJECTED":
       return {
         type: "warning",
@@ -140,7 +151,12 @@ const instructorDisplayData = computed(() => {
     case "AUTHORIZED":
       return { type: "success", title: "Cette déclaration a été autorisée", body: null, canDownloadCertificate: true }
     case "ABANDONED":
-      return { type: "warning", title: "Ce dossier est abandonné", body: null, canDownloadCertificate: true }
+      return {
+        type: "warning",
+        title: "Ce dossier est abandonné",
+        body: null,
+        canDownloadCertificate: canDownloadAbandonedCertificate.value,
+      }
     case "REJECTED":
       return {
         type: "warning",
@@ -196,7 +212,12 @@ const visorDisplayData = computed(() => {
     case "AUTHORIZED":
       return { type: "success", title: "Cette déclaration a été autorisée", body: null, canDownloadCertificate: true }
     case "ABANDONED":
-      return { type: "warning", title: "Ce dossier est abandonné", body: null, canDownloadCertificate: true }
+      return {
+        type: "warning",
+        title: "Ce dossier est abandonné",
+        body: null,
+        canDownloadCertificate: canDownloadAbandonedCertificate.value,
+      }
     case "REJECTED":
       return {
         type: "warning",

--- a/frontend/src/components/HistoryTab.vue
+++ b/frontend/src/components/HistoryTab.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="isFetching" class="flex justify-center items-center min-h-60">
+    <div v-if="!snapshots" class="flex justify-center items-center min-h-60">
       <ProgressSpinner />
     </div>
     <div v-if="snapshots && snapshots.length" class="flex flex-col gap-6">
@@ -19,20 +19,11 @@
 </template>
 
 <script setup>
-import { useFetch } from "@vueuse/core"
-import { onMounted, computed } from "vue"
-import { handleError } from "@/utils/error-handling"
+import { computed } from "vue"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import SnapshotItem from "@/components/SnapshotItem"
 
-const props = defineProps(["declarationId", "hideInstructionDetails"])
-
-const { response, data, execute, isFetching } = useFetch(
-  () => `/api/v1/declarations/${props.declarationId}/snapshots/`,
-  { immediate: false }
-)
-  .get()
-  .json()
+const props = defineProps(["snapshots", "declarationId", "hideInstructionDetails"])
 
 const snapshots = computed(() => {
   if (props.hideInstructionDetails) {
@@ -46,14 +37,9 @@ const snapshots = computed(() => {
       "WITHDRAW",
       "ABANDON",
     ]
-    return data.value?.filter((x) => allowedActions.indexOf(x.action) > -1)
+    return props.snapshots?.filter((x) => allowedActions.indexOf(x.action) > -1)
   }
-  return data.value
-})
-
-onMounted(async () => {
-  await execute()
-  handleError(response)
+  return props.snapshots
 })
 
 const showOnRight = (snapshot) => {

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -25,7 +25,13 @@
         <p>Vous pouvez vous assigner cette déclaration pour instruction</p>
         <DsfrButton class="mt-2" label="Instruire" tertiary @click="instructDeclaration" />
       </DsfrAlert>
-      <DeclarationAlert class="mb-6" v-else-if="!canInstruct" role="instructor" :declaration="declaration" />
+      <DeclarationAlert
+        class="mb-6"
+        v-else-if="!canInstruct"
+        role="instructor"
+        :declaration="declaration"
+        :snapshots="snapshots"
+      />
       <div v-if="declaration">
         <DeclarationSummary
           :showArticle="true"
@@ -53,6 +59,7 @@
               :declarationId="declaration?.id"
               :user="declarant"
               :company="company"
+              :snapshots="snapshots"
               @decision-done="onDecisionDone"
               :showArticle="true"
             ></component>
@@ -155,6 +162,14 @@ const {
   .get()
   .json()
 
+const {
+  response: snapshotsResponse,
+  data: snapshots,
+  execute: executeSnapshotsFetch,
+} = useFetch(() => `/api/v1/declarations/${props.declarationId}/snapshots/`, { immediate: false })
+  .get()
+  .json()
+
 // Sauvegarde du commentaire privé
 const saveComment = useDebounceFn(async () => {
   const { response } = await useFetch(() => `/api/v1/declarations/${declaration.value?.id}`, {
@@ -181,6 +196,8 @@ onMounted(async () => {
   handleError(declarantResponse)
   await executeCompanyFetch()
   handleError(companyResponse)
+  await executeSnapshotsFetch()
+  handleError(snapshotsResponse)
   isFetching.value = false
 })
 

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -15,7 +15,7 @@
     </div>
 
     <div v-else class="mb-4">
-      <DeclarationAlert v-if="payload" role="declarant" :declaration="payload" class="mb-4" />
+      <DeclarationAlert v-if="payload" role="declarant" :declaration="payload" :snapshots="snapshots" class="mb-4" />
 
       <DsfrAlert
         class="mb-4"
@@ -61,6 +61,7 @@
               :externalResults="$externalResults"
               :readonly="readonly"
               :declarationId="id"
+              :snapshots="snapshots"
               @withdraw="onWithdrawal"
               :hideInstructionDetails="true"
             ></component>
@@ -159,9 +160,19 @@ const { response, data, isFetching, execute } = useFetch(`/api/v1/declarations/$
   .get()
   .json()
 
+const {
+  response: snapshotsResponse,
+  data: snapshots,
+  execute: executeSnapshotsFetch,
+} = useFetch(() => `/api/v1/declarations/${props.id}/snapshots/`, { immediate: false })
+  .get()
+  .json()
+
 if (!isNewDeclaration.value || route.query.duplicate) execute()
+if (!isNewDeclaration.value && !route.query.duplicate) executeSnapshotsFetch()
 
 watch(response, () => handleError(response))
+watch(snapshotsResponse, () => handleError(snapshotsResponse))
 watch(data, () => {
   const shouldDuplicate = route.query.duplicate && !props.id
   if (shouldDuplicate) {

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -21,7 +21,7 @@
         <p>Vous pouvez vous assigner cette déclaration pour visa / signature</p>
         <DsfrButton class="mt-2" label="Prendre pour validation" tertiary @click="takeDeclaration" />
       </DsfrAlert>
-      <DeclarationAlert role="visor" class="mb-4" v-else :declaration="declaration" />
+      <DeclarationAlert role="visor" class="mb-4" v-else :declaration="declaration" :snapshots="snapshots" />
       <div v-if="declaration">
         <DeclarationSummary
           :showArticle="true"
@@ -50,6 +50,7 @@
               :showElementAuthorization="true"
               :user="declarant"
               :company="company"
+              :snapshots="snapshots"
               @decision-done="onDecisionDone"
             ></component>
           </DsfrTabContent>
@@ -150,6 +151,14 @@ const {
   .get()
   .json()
 
+const {
+  response: snapshotsResponse,
+  data: snapshots,
+  execute: executeSnapshotsFetch,
+} = useFetch(() => `/api/v1/declarations/${props.declarationId}/snapshots/`, { immediate: false })
+  .get()
+  .json()
+
 const privateNotesInstruction = ref(declaration.value?.privateNotesInstruction || "")
 const privateNotesVisa = ref(declaration.value?.privateNotesVisa || "")
 onMounted(async () => {
@@ -168,6 +177,8 @@ onMounted(async () => {
   handleError(declarantResponse)
   await executeCompanyFetch()
   handleError(companyResponse)
+  await executeSnapshotsFetch()
+  handleError(snapshotsResponse)
   isFetching.value = false
 })
 

--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -55,11 +55,11 @@ class CertificateView(GenericAPIView):
             return f"certificates/certificate-submitted-art-{article}.html"
 
         template_status = declaration.status
+
+        # La mise en abandon ne produit pas de Snapshot (car pas effectué en tant qu'action usager).
+        # On vérifie donc le status du dernier snapshot pour calculer le template
         if template_status == status.ABANDONED:
-            pre_abandon_statuses = [status.OBJECTION, status.OBSERVATION]
-            template_status = (
-                declaration.snapshots.filter(status__in=pre_abandon_statuses).latest("creation_date").status
-            )
+            template_status = declaration.snapshots.latest("creation_date").status
 
         if template_status in [status.AUTHORIZED, status.WITHDRAWN]:
             return f"certificates/certificate-art-{article}.html"

--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -11,7 +11,7 @@ from rest_framework.generics import GenericAPIView
 from xhtml2pdf import pisa
 
 from api.permissions import CanAccessIndividualDeclaration
-from data.models import Declaration
+from data.models import Declaration, Snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -53,11 +53,19 @@ class CertificateView(GenericAPIView):
             status.ONGOING_VISA,
         ]:
             return f"certificates/certificate-submitted-art-{article}.html"
-        if declaration.status in [status.AUTHORIZED, status.WITHDRAWN]:
+
+        template_status = declaration.status
+        if template_status == status.ABANDONED:
+            pre_abandon_statuses = [status.OBJECTION, status.OBSERVATION]
+            template_status = (
+                declaration.snapshots.filter(status__in=pre_abandon_statuses).latest("creation_date").status
+            )
+
+        if template_status in [status.AUTHORIZED, status.WITHDRAWN]:
             return f"certificates/certificate-art-{article}.html"
-        if declaration.status == status.OBJECTION:
+        if template_status == status.OBJECTION:
             return "certificates/certificate-objected.html"
-        if declaration.status == status.REJECTED:
+        if template_status == status.REJECTED:
             return "certificates/certificate-rejected.html"
 
         raise NotFound()
@@ -65,17 +73,26 @@ class CertificateView(GenericAPIView):
     def get_context(self, declaration):
         status = Declaration.DeclarationStatus
         date_statuses = [status.AWAITING_INSTRUCTION, status.AUTHORIZED, status.REJECTED]
-
         try:
-            date = declaration.snapshots.filter(status__in=date_statuses).latest("creation_date").creation_date
+            date = (
+                declaration.snapshots.filter(status__in=date_statuses)
+                .exclude(action=Snapshot.SnapshotActions.REFUSE_VISA)
+                .latest("creation_date")
+                .creation_date
+            )
         except Exception as e:
             logger.error(f"Error obtaining certificate date for declaration {declaration.id}")
             logger.exception(e)
             date = declaration.creation_date
 
         try:
+            submission_actions = [
+                Snapshot.SnapshotActions.SUBMIT,
+                Snapshot.SnapshotActions.RESPOND_TO_OBJECTION,
+                Snapshot.SnapshotActions.RESPOND_TO_OBSERVATION,
+            ]
             last_submission_date = (
-                declaration.snapshots.filter(status=status.AWAITING_INSTRUCTION).latest("creation_date").creation_date
+                declaration.snapshots.filter(action__in=submission_actions).latest("creation_date").creation_date
             )
         except Exception as e:
             logger.error(f"Error obtaining last submission date for declaration {declaration.id}")


### PR DESCRIPTION
Closes #1266

## Contexte

Ce n'était pas possible de télécharger l'attestation des déclarations en abandon. L'état pré-abandon (observation ou objection) pouvait être utilisé pour avoir l'attestation.

## Scope

Pour le calcul du template on utilisait seulement le statut de la déclaration. Cette PR fait un calcul supplémentaire si la déclaration se trouve en abandon : 

```python
template_status = declaration.status
        if template_status == status.ABANDONED:
            pre_abandon_statuses = [status.OBJECTION, status.OBSERVATION]
            template_status = (
                declaration.snapshots.filter(status__in=pre_abandon_statuses).latest("creation_date").status
            )
```

#### Bug fixes

J'en ai profité pour régler un petit bug que j'ai remarqué concernant les dates de l'attestation. Précédemment on calculait ces dates à partir du statut des snapshots, considérant par exemple qu'un snapshot avec le statut `AWAITING_INSTRUCTION` venait forcément d'une soumission de l'usager. Ceci n'est pas le cas car un refus de visa peut aussi générer un snapshot `AWAITING_INSTRUCTION`, néanmoins ce n'est pas celui là qu'on doit utiliser pour la date.

J'ai donc ajouté des filtres pour l'action du snapshot, histoire d'ignorer les refus de visa (ce sont les changements de la fonction `get_context`)

## Démo

https://github.com/user-attachments/assets/175ca3e6-3387-4be4-9028-418e01313b13

