### PR TITLE
Envoi une chaîne vide au lieu de null dans l'API pour le champ request_private_notes

### DIFF
--- a/frontend/src/views/DeclaredElementPage/index.vue
+++ b/frontend/src/views/DeclaredElementPage/index.vue
@@ -113,7 +113,7 @@ const modals = {
         onClick() {
           updateElement({
             requestStatus: "INFORMATION",
-            requestPrivateNotes: notes.value,
+            requestPrivateNotes: notes.value || "",
           }).then(closeModal)
         },
       },
@@ -127,7 +127,7 @@ const modals = {
         onClick() {
           updateElement({
             requestStatus: "REJECTED",
-            requestPrivateNotes: notes.value,
+            requestPrivateNotes: notes.value || "",
           }).then(closeModal)
         },
       },


### PR DESCRIPTION
Closes #1386 

## Scope

Même si le bug n'est plus arrivé depuis le 10 décembre, le seul endroit où ça aurait pu arriver me semble le call UI. Si par hasard `notes.value` est à `null`, donc le serializer lève l'erreur.

Pour être sur de l'éviter j'ai ajouté un simple `|| ""` de sorte qu'on peuple le paramètre `request_private_notes` avec une chaîne de caractères vide au lieu du `null`.