### PR TITLE
Rend obligatoire le remplissage du commentaire par le pro lors d'un retour d'observation ou objection

### DIFF
--- a/frontend/src/views/ProducerFormPage/SummaryTab.vue
+++ b/frontend/src/views/ProducerFormPage/SummaryTab.vue
@@ -2,8 +2,8 @@
   <div>
     <SectionTitle title="Votre démarche" sizeTag="h6" icon="ri-file-text-line" />
     <DeclarationSummary v-model="payload" :readonly="readonly" />
-    <hr />
-    <h2>Soumettre</h2>
+    <hr v-if="!readonly" />
+    <h2 v-if="!readonly">Soumettre</h2>
     <DsfrAlert v-if="!readonly">
       <DsfrInputGroup>
         <DsfrInput

--- a/frontend/src/views/ProducerFormPage/SummaryTab.vue
+++ b/frontend/src/views/ProducerFormPage/SummaryTab.vue
@@ -5,7 +5,7 @@
     <hr v-if="!readonly" />
     <h2 v-if="!readonly">Soumettre</h2>
     <DsfrAlert v-if="!readonly">
-      <DsfrInputGroup>
+      <DsfrInputGroup :error-message="firstErrorMsg(v$, 'comment')">
         <DsfrInput
           class="!max-w-lg"
           label="Commentaires à destination de l'administration"
@@ -27,20 +27,36 @@
           </template>
         </DsfrCheckbox>
       </DsfrInputGroup>
-      <DsfrButton :disabled="!conformityEngaged" @click="emit('submit', comment)" label="Soumettre ma démarche" />
+      <DsfrButton :disabled="!conformityEngaged" @click="submitDeclaration" label="Soumettre ma démarche" />
     </DsfrAlert>
   </div>
 </template>
 
 <script setup>
-import { ref } from "vue"
+import { ref, computed } from "vue"
 import DeclarationSummary from "@/components/DeclarationSummary"
 import SectionTitle from "@/components/SectionTitle"
+import { useVuelidate } from "@vuelidate/core"
+import { errorRequiredField, firstErrorMsg } from "@/utils/forms"
 
 const conformityEngaged = ref(false)
 
 const payload = defineModel()
 const emit = defineEmits(["submit"])
 const comment = ref("")
+
+const rules = computed(() => {
+  if (payload.value.status === "DRAFT") return {}
+  return { comment: errorRequiredField }
+})
+const $externalResults = ref({})
+const v$ = useVuelidate(rules, { comment }, { $externalResults })
+
+const submitDeclaration = () => {
+  v$.value.$reset()
+  v$.value.$validate()
+  if (!v$.value.$error) emit("submit", comment.value)
+}
+
 defineProps({ readonly: Boolean })
 </script>


### PR DESCRIPTION
Closes #1165 
Closes #1396 

## Contexte
Le champ "commentaire" est facultatif pour le pro. Néanmoins, on aimerait qu'il devienne obligatoire lors que la déclaration est en observation ou objection.

## Scope
J'ai ajouté une validation dynamique qui n'est pas appliquée pour les déclarations en brouillon.

J'en au profité pour fermer #1396, un tout petit fix qui permet de cacher le sous-titre "Soumission" lors qu'on est en lecture seule.