### PR TITLE
Rend possible l'ajout et la suppression des pièces jointes dans la déclaration

### DIFF
--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 from simple_history.admin import SimpleHistoryAdmin
 
 from data.models import (
+    Attachment,
     ComputedSubstance,
     Declaration,
     DeclaredIngredient,
@@ -22,6 +23,19 @@ class SnapshotInline(admin.TabularInline):
     extra = 0
 
     def has_add_permission(self, request, object):
+        return False
+
+
+class AttachmentInline(admin.TabularInline):
+    model = Attachment
+    can_delete = True
+    fields = ("type", "file", "name")
+    extra = 0
+
+    def has_add_permission(self, request, object):
+        return True
+
+    def has_change_permission(self, request, object):
         return False
 
 
@@ -230,6 +244,7 @@ class DeclarationAdmin(SimpleHistoryAdmin):
         DeclaredSubstanceInline,
         ComputedSubstanceInline,
         SnapshotInline,
+        AttachmentInline,
     )
     search_fields = (
         "name",


### PR DESCRIPTION
Closes #1335 

## Contexte

Depuis l'admin précédemment ce n'était pas possible de voir, ajouter ou supprimer les pièces jointes d'une déclaration.

## Scope

En utilisant un `TabularInline` (comme on le fait pour les Snapshots) on peut ajouter cette possibilité. Il n'est toutefois pas possible de modifier une pièce jointe (par ex remplacer le nom ou le fichier), seulement d'en ajouter ou supprimer. 

## Démo

https://github.com/user-attachments/assets/fccdfb71-bc8b-473f-9a17-91546adbe920



