### PR TITLE
Traitement du warning console : ajout d'un DsfrAccordionGroup dans SummaryElementList

### DIFF
--- a/frontend/src/components/DeclarationSummary/SummaryElementList.vue
+++ b/frontend/src/components/DeclarationSummary/SummaryElementList.vue
@@ -1,17 +1,18 @@
 <template>
   <div v-if="elements.length">
     <!-- Affichage avec les accordéons : les ingrédients sont cachés à l'intérieur -->
-    <DsfrAccordion v-if="useAccordions">
-      <template v-slot:title>
-        <SummaryElementListTitle :objectType="objectType" :elementCount="`${elements.length}`" />
-      </template>
-      <SummaryElementListItems
-        :showElementAuthorization="showElementAuthorization"
-        :objectType="objectType"
-        :elements="elements"
-      />
-    </DsfrAccordion>
-
+    <DsfrAccordionsGroup v-if="useAccordions" v-model="activeAccordion">
+      <DsfrAccordion>
+        <template v-slot:title>
+          <SummaryElementListTitle :objectType="objectType" :elementCount="`${elements.length}`" />
+        </template>
+        <SummaryElementListItems
+          :showElementAuthorization="showElementAuthorization"
+          :objectType="objectType"
+          :elements="elements"
+        />
+      </DsfrAccordion>
+    </DsfrAccordionsGroup>
     <!-- Affichage sans les accordéons, tous les ingrédients sont affichés -->
     <div v-else>
       <SummaryElementListTitle class="mt-6 mb-3" :objectType="objectType" />
@@ -25,6 +26,7 @@
 </template>
 
 <script setup>
+import { ref } from "vue"
 import SummaryElementListTitle from "./SummaryElementListTitle"
 import SummaryElementListItems from "./SummaryElementListItems"
 
@@ -34,4 +36,6 @@ defineProps({
   useAccordions: { type: Boolean },
   showElementAuthorization: { type: Boolean },
 })
+
+const activeAccordion = ref()
 </script>


### PR DESCRIPTION
Closes #1413

## Contexte

Un warning s'affiche toujours en ouvrant une déclaration en tant qu'instructrice ou viseuse.

## Scope

Le warning vient de Vue-Dsfr, plus précisément du [fichier injection-key.ts](https://vue-ds.fr/composants/DsfrAccordion#%E2%9A%99%EF%B8%8F-code-source-du-composant), qui échoue à effectuer l'injection si le composant n'est pas entouré d'un `DsfrAccordionsGroup`.

Dans [la doc](https://vue-ds.fr/composants/DsfrAccordion#%E2%9A%99%EF%B8%8F-code-source-du-composant) d'ailleurs c'est explicité : « _Ce composant peut être utilisé uniquement avec [DsfrAccordionsGroup](https://vue-ds.fr/composants/DsfrAccordionsGroup)._ »

Le problème est que le _DsfrAccordionsGroup_ ne permet qu'un seul accordéon d'être déplié en même temps, ce qui constitue un changement de comportement de ce qu'on a aujourd'hui. Cette PR en ajoute un autour de chaque accordéon pour palier à cette limitation.