### PR TITLE
Rend visible le snapshot d'acceptation de visa aux pros

### DIFF
--- a/api/views/snapshot.py
+++ b/api/views/snapshot.py
@@ -22,7 +22,6 @@ class DeclarationSnapshotListView(ListAPIView):
                 action__in=[
                     Snapshot.SnapshotActions.REQUEST_VISA,
                     Snapshot.SnapshotActions.TAKE_FOR_VISA,
-                    Snapshot.SnapshotActions.ACCEPT_VISA,
                     Snapshot.SnapshotActions.REFUSE_VISA,
                 ]
             )


### PR DESCRIPTION
Closes #1421

## Contexte

Les pros n'avaient pas la visibilité des snapshots d'acceptation de visa dans l'onglet historique (captures d'écran dans #1421).

## Fix

Il suffisait simplement enlever le filtre erronée. J'ai également ajouté un test pour s'assurer que ce type de snapshots sont bien transmis aux pros.