### PR TITLE
Résolution au bug sur le triage de la date limite de réponse

### DIFF
--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -291,6 +291,9 @@ class InstructionDateOrderingFilter(CamelCaseOrderingFilter):
         """
         Cette fonction vise à réproduire la property "response_limit_date" du modèle Declaration
         mais dans la couche DB (avec des querysets) afin de pouvoir filtrer dessus.
+
+        ⚠️ Attention : Tout changement effectué dans cette fonction doit aussi être reflété dans
+        data/models/declaration.py > response_limit_date
         """
         order_by_response_limit, desc = self.order_by_response_limit(request)
 
@@ -302,6 +305,7 @@ class InstructionDateOrderingFilter(CamelCaseOrderingFilter):
             Snapshot.objects.filter(
                 declaration=OuterRef("pk"), status=Declaration.DeclarationStatus.AWAITING_INSTRUCTION
             )
+            .exclude(action=Snapshot.SnapshotActions.REFUSE_VISA)
             .order_by("-creation_date" if order_by_response_limit else "creation_date")
             .values("creation_date")[:1]
         )

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -357,7 +357,11 @@ class Declaration(Historisable, TimeStampable):
 
         """
         La date limite d'instruction est fixée à deux mois à partir du dernier statut
-        "en attente d'instruction" sauf dans le cas d'un refus de visa
+        "en attente d'instruction" sauf dans le cas d'un refus de visa.
+
+        ⚠️ Attention : Le filtre par date de réponse dans api/views/declaration/declaration.py
+        refait la même logique dans la couche DB. Tout changement effectué dans cette fonction
+        doit aussi être reflété dans InstructionDateOrderingFilter > filter_queryset.
         """
         concerned_statuses = [
             Declaration.DeclarationStatus.AWAITING_INSTRUCTION,


### PR DESCRIPTION
Closes #1445 

## Fix

La date limite de réponse d'une déclaration est calculé dans la propriété `response_limit_date` du fichier `data/models/declaration.py`. Ceci veut dire que le calcul est effectué dans la couche Python et non pas dans la base de données.

Or, les filtres et triages effectués par l'API se basent sur des requêtes SQL. C'est pourquoi on a le `InstructionDateOrderingFilter` dans `api/views/declaration/declaration.py`, censé effectuer le triage dans la couche DB.

Le bug vient du fait que les deux fonctions différaient dans leur calcul de cette date. Pour éviter que ça se reproduise :

- Ajout d'un test incluant un refus de visa
- Ajout du commentaire dans chaque fonction pour signaler le besoin de vérifier l'autre