### PR TITLE
Ajouter un synonyme au moment du remplacement

### DIFF
--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -1926,5 +1926,5 @@ class TestDeclaredElementsApi(APITestCase):
         self.assertEqual(declared_plant.request_status, DeclaredPlant.AddableStatus.REPLACED)
         plant.refresh_from_db()
         self.assertEqual(plant.plantsynonym_set.count(), 2)
-        self.assertTrue(plant.plantsynonym_set.get(name="New synonym").exists())
+        self.assertIsNotNone(plant.plantsynonym_set.get(name="New synonym"))
         self.assertEqual(plant.plantsynonym_set.get(id=synonym.id).name, synonym.name)

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -36,6 +36,7 @@ from data.factories import (
     SubstanceUnitFactory,
     SupervisorRoleFactory,
     VisaRoleFactory,
+    PlantSynonymFactory,
 )
 from data.models import Attachment, Declaration, Snapshot, DeclaredMicroorganism, DeclaredPlant
 
@@ -1898,3 +1899,32 @@ class TestDeclaredElementsApi(APITestCase):
         declared_plant.refresh_from_db()
         self.assertEqual(declared_plant.request_status, DeclaredPlant.AddableStatus.REQUESTED)
         self.assertNotEqual(declared_plant.plant, microorganism)
+
+    @authenticate
+    def test_can_add_synonym_on_replace(self):
+        """
+        C'est possible d'envoyer une liste avec un nouvel element pour
+        ajouter une synonyme et laisser des synonymes existantes non-modifiées
+        """
+        InstructionRoleFactory(user=authenticate.user)
+
+        declaration = DeclarationFactory()
+        declared_plant = DeclaredPlantFactory(declaration=declaration, new=True)
+        plant = PlantFactory()
+        synonym = PlantSynonymFactory.create(name="Eucalyptus Plant", standard_name=plant)
+
+        response = self.client.post(
+            reverse("api:declared_element_replace", kwargs={"pk": declared_plant.id, "type": "plant"}),
+            {
+                "element": {"id": plant.id, "type": "plant"},
+                "synonyms": [{"id": synonym.id, "name": "Eucalyptus Plant"}, {"name": "New synonym"}],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        declared_plant.refresh_from_db()
+        self.assertEqual(declared_plant.request_status, DeclaredPlant.AddableStatus.REPLACED)
+        plant.refresh_from_db()
+        self.assertEqual(plant.plantsynonym_set.count(), 2)
+        self.assertTrue(plant.plantsynonym_set.get(name="New synonym").exists())
+        self.assertEqual(plant.plantsynonym_set.get(id=synonym.id).name, synonym.name)

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -15,6 +15,10 @@ from data.models import (
     Microorganism,
     Substance,
     Ingredient,
+    PlantSynonym,
+    MicroorganismSynonym,
+    SubstanceSynonym,
+    IngredientSynonym,
 )
 from api.serializers import (
     DeclaredElementSerializer,
@@ -59,21 +63,25 @@ class ElementMappingMixin:
         "plant": {
             "model": DeclaredPlant,
             "element_model": Plant,
+            "synonym_model": PlantSynonym,
             "serializer": DeclaredPlantSerializer,
         },
         "microorganism": {
             "model": DeclaredMicroorganism,
             "element_model": Microorganism,
+            "synonym_model": MicroorganismSynonym,
             "serializer": DeclaredMicroorganismSerializer,
         },
         "substance": {
             "model": DeclaredSubstance,
             "element_model": Substance,
+            "synonym_model": SubstanceSynonym,
             "serializer": DeclaredSubstanceSerializer,
         },
         "ingredient": {
             "model": DeclaredIngredient,
             "element_model": Ingredient,
+            "synonym_model": IngredientSynonym,
             "serializer": DeclaredIngredientSerializer,
         },
     }
@@ -101,6 +109,10 @@ class ElementMappingMixin:
     @property
     def element_model(self):
         return self.type_info["element_model"]
+
+    @property
+    def synonym_model(self):
+        return self.type_info["synonym_model"]
 
 
 class DeclaredElementView(RetrieveAPIView, ElementMappingMixin):
@@ -161,3 +173,14 @@ class DeclaredElementReplaceView(DeclaredElementActionAbstractView):
         setattr(element, self.element_type, existing_element)
         element.request_status = self.type_model.AddableStatus.REPLACED
         element.new = False
+
+        synonyms = request.data.get("synonyms", [])
+
+        for synonym in synonyms:
+            if not synonym.get("id"):
+                # add new synonym
+                try:
+                    name = synonym.get("name")
+                except KeyError:
+                    raise ParseError(detail="Must provide 'name' to create new synonym")
+                self.synonym_model.objects.create(standard_name=existing_element, name=name)

--- a/frontend/src/views/DeclaredElementPage/ManageSynonyms.vue
+++ b/frontend/src/views/DeclaredElementPage/ManageSynonyms.vue
@@ -4,13 +4,13 @@
       label="Ajouter une synonyme (optionnelle)"
       label-visible
       :hint="requestName ? `Le nom de la demande : ${requestName}` : ''"
-      v-model="newSynonym"
       class="mb-2"
+      @update:modelValue="updateNewSynonym"
     />
-    <div v-if="synonyms && synonyms.length" class="mt-4">
+    <div v-if="initialSynonyms && initialSynonyms.length" class="mt-4">
       <p class="mb-1">Les synonymes existantes :</p>
       <ul>
-        <li v-for="s in synonyms" :key="s.id">{{ s.name }}</li>
+        <li v-for="s in initialSynonyms" :key="s.id">{{ s.name }}</li>
       </ul>
     </div>
   </div>
@@ -18,18 +18,20 @@
 
 <script setup>
 // TODO: rename file to be just ReplacementModal or something?
-import { onMounted, ref, computed } from "vue"
+import { ref, computed } from "vue"
 import { getElementName } from "@/utils/elements"
 
-// TODO: define model instead
 const props = defineProps({ initialSynonyms: Array, requestElement: Object })
-const synonyms = ref()
-
-// TODO: check this still works if select, open, cancel, reselect, open
-// or if edit, cancel and come back (should see original list)
-onMounted(() => {
-  synonyms.value = props.initialSynonyms
-})
-
 const requestName = computed(() => getElementName(props.requestElement))
+
+const synonyms = defineModel()
+
+const updateNewSynonym = (value) => {
+  const lastIdx = synonyms.value.length - 1
+  if (synonyms.value[lastIdx].id) {
+    synonyms.value.push({ name: value })
+  } else {
+    synonyms.value.splice(lastIdx, 1, { name: value })
+  }
+}
 </script>

--- a/frontend/src/views/DeclaredElementPage/ManageSynonyms.vue
+++ b/frontend/src/views/DeclaredElementPage/ManageSynonyms.vue
@@ -1,0 +1,38 @@
+<template>
+  <div>
+    <h2>Synonymes</h2>
+    <!-- TODO; what key to use given potential for deletion and adding multiple empty entries? -->
+    <div v-for="(s, idx) in synonyms" :key="idx" class="flex items-center">
+      <DsfrInput label="Synonyme" v-model="s.name" class="mb-2" />
+
+      <DsfrButton
+        :label="`Supprimer synonyme '${s.name}'`"
+        icon="ri-delete-bin-6-line"
+        icon-only
+        tertiary
+        no-outline
+        @click="deleteSynonym(s)"
+      />
+    </div>
+    <DsfrButton label="Ajouter synonyme" icon="ri-add-line" secondary @click="addSynonym" />
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from "vue"
+
+const props = defineProps({ initialSynonyms: Array })
+
+const synonyms = ref()
+
+// TODO: check this still works if select, open, cancel, reselect, open
+onMounted(() => {
+  synonyms.value = props.initialSynonyms
+})
+
+const addSynonym = () => {
+  synonyms.value.push({})
+}
+
+const deleteSynonym = (synonym) => {}
+</script>

--- a/frontend/src/views/DeclaredElementPage/ManageSynonyms.vue
+++ b/frontend/src/views/DeclaredElementPage/ManageSynonyms.vue
@@ -11,7 +11,7 @@
         icon-only
         tertiary
         no-outline
-        @click="deleteSynonym(s)"
+        @click="deleteSynonym(idx)"
       />
     </div>
     <DsfrButton label="Ajouter synonyme" icon="ri-add-line" secondary @click="addSynonym" />
@@ -19,6 +19,7 @@
 </template>
 
 <script setup>
+// TODO: rename file to be just ReplacementModal or something?
 import { onMounted, ref } from "vue"
 
 const props = defineProps({ initialSynonyms: Array })
@@ -34,5 +35,7 @@ const addSynonym = () => {
   synonyms.value.push({})
 }
 
-const deleteSynonym = (synonym) => {}
+const deleteSynonym = (idx) => {
+  synonyms.value.splice(idx, 1)
+}
 </script>

--- a/frontend/src/views/DeclaredElementPage/ManageSynonyms.vue
+++ b/frontend/src/views/DeclaredElementPage/ManageSynonyms.vue
@@ -1,41 +1,35 @@
 <template>
   <div>
-    <h2>Synonymes</h2>
-    <!-- TODO; what key to use given potential for deletion and adding multiple empty entries? -->
-    <div v-for="(s, idx) in synonyms" :key="idx" class="flex items-center">
-      <DsfrInput label="Synonyme" v-model="s.name" class="mb-2" />
-
-      <DsfrButton
-        :label="`Supprimer synonyme '${s.name}'`"
-        icon="ri-delete-bin-6-line"
-        icon-only
-        tertiary
-        no-outline
-        @click="deleteSynonym(idx)"
-      />
+    <DsfrInput
+      label="Ajouter une synonyme (optionnelle)"
+      label-visible
+      :hint="requestName ? `Le nom de la demande : ${requestName}` : ''"
+      v-model="newSynonym"
+      class="mb-2"
+    />
+    <div v-if="synonyms && synonyms.length" class="mt-4">
+      <p class="mb-1">Les synonymes existantes :</p>
+      <ul>
+        <li v-for="s in synonyms" :key="s.id">{{ s.name }}</li>
+      </ul>
     </div>
-    <DsfrButton label="Ajouter synonyme" icon="ri-add-line" secondary @click="addSynonym" />
   </div>
 </template>
 
 <script setup>
 // TODO: rename file to be just ReplacementModal or something?
-import { onMounted, ref } from "vue"
+import { onMounted, ref, computed } from "vue"
+import { getElementName } from "@/utils/elements"
 
-const props = defineProps({ initialSynonyms: Array })
-
+// TODO: define model instead
+const props = defineProps({ initialSynonyms: Array, requestElement: Object })
 const synonyms = ref()
 
 // TODO: check this still works if select, open, cancel, reselect, open
+// or if edit, cancel and come back (should see original list)
 onMounted(() => {
   synonyms.value = props.initialSynonyms
 })
 
-const addSynonym = () => {
-  synonyms.value.push({})
-}
-
-const deleteSynonym = (idx) => {
-  synonyms.value.splice(idx, 1)
-}
+const requestName = computed(() => getElementName(props.requestElement))
 </script>

--- a/frontend/src/views/DeclaredElementPage/ReplacementSearch.vue
+++ b/frontend/src/views/DeclaredElementPage/ReplacementSearch.vue
@@ -28,11 +28,12 @@ const selectedOption = ref()
 
 const selectOption = (option) => {
   selectedOption.value = option // quick and temporary display
+  emit("replacement", option)
   fetchElement(getApiType(option.objectType), option.objectType, option.id).then((item) => {
     selectedOption.value = item
+    emit("replacement", item)
   })
   // TODO: erase search term from search bar?
-  emit("replacement", option)
 }
 
 // TODO: turn into service ? It was taken from another file

--- a/frontend/src/views/DeclaredElementPage/index.vue
+++ b/frontend/src/views/DeclaredElementPage/index.vue
@@ -20,19 +20,7 @@
                   Veuillez contacter l'équipe Compl'Alim pour effectuer la substitution.
                 </p>
                 <div v-else>
-                  <h2>Synonymes</h2>
-                  <div v-for="s in replacement.synonyms" :key="s.id" class="flex items-center">
-                    <DsfrInput label="Synonyme" v-model="s.name" class="mb-2" />
-
-                    <DsfrButton
-                      :label="`Supprimer synonyme '${s.name}'`"
-                      icon="ri-delete-bin-6-line"
-                      icon-only
-                      tertiary
-                      no-outline
-                    />
-                  </div>
-                  <DsfrButton label="Ajouter synonyme" icon="ri-add-line" secondary />
+                  <ManageSynonyms :initialSynonyms="replacement.synonyms" />
                 </div>
               </div>
               <div v-else>
@@ -55,6 +43,7 @@ import { headers } from "@/utils/data-fetching"
 import ElementInfo from "./ElementInfo"
 import ElementAlert from "./ElementAlert"
 import ReplacementSearch from "./ReplacementSearch"
+import ManageSynonyms from "./ManageSynonyms"
 
 const props = defineProps({ type: String, id: String })
 
@@ -92,8 +81,7 @@ watch(element, (newElement) => {
 })
 
 // Actions
-// const modalToOpen = ref(false)
-const modalToOpen = ref("replace")
+const modalToOpen = ref(false)
 const closeModal = () => (modalToOpen.value = false)
 
 const notes = ref()

--- a/frontend/src/views/DeclaredElementPage/index.vue
+++ b/frontend/src/views/DeclaredElementPage/index.vue
@@ -20,7 +20,11 @@
                   Veuillez contacter l'équipe Compl'Alim pour effectuer la substitution.
                 </p>
                 <div v-else>
-                  <ManageSynonyms :initialSynonyms="replacement.synonyms" :requestElement="element" />
+                  <ManageSynonyms
+                    v-model="synonyms"
+                    :requestElement="element"
+                    :initialSynonyms="replacement.synonyms"
+                  />
                 </div>
               </div>
               <div v-else>
@@ -93,13 +97,14 @@ const openModal = (type) => {
   }
 }
 
-// const replacement = ref()
-const replacement = ref({
-  id: 3,
-  name: "Test modal",
-  synonyms: [{ id: 1, name: "My existing synonym" }],
-  objectType: props.type,
+const replacement = ref()
+const synonyms = ref()
+watch(replacement, () => {
+  if (replacement.value.synonyms) {
+    synonyms.value = JSON.parse(JSON.stringify(replacement.value.synonyms)) // initialise synonyms that might be updated
+  }
 })
+
 const cannotReplace = computed(() => replacement.value?.objectType !== element.value.type)
 
 const actionButtons = computed(() => [
@@ -145,6 +150,7 @@ const modals = computed(() => {
           onClick() {
             const payload = {
               element: { id: replacement.value?.id, type: replacement.value?.objectType },
+              synonyms: synonyms.value,
             }
             // TODO: clear search if we stay on page
             updateElement("replace", payload).then(closeModal)

--- a/frontend/src/views/DeclaredElementPage/index.vue
+++ b/frontend/src/views/DeclaredElementPage/index.vue
@@ -20,7 +20,7 @@
                   Veuillez contacter l'équipe Compl'Alim pour effectuer la substitution.
                 </p>
                 <div v-else>
-                  <ManageSynonyms :initialSynonyms="replacement.synonyms" />
+                  <ManageSynonyms :initialSynonyms="replacement.synonyms" :requestElement="element" />
                 </div>
               </div>
               <div v-else>

--- a/frontend/src/views/DeclaredElementPage/index.vue
+++ b/frontend/src/views/DeclaredElementPage/index.vue
@@ -19,6 +19,21 @@
                   Ce n'est pas possible pour l'instant de remplacer une demande avec un ingrédient d'un type different.
                   Veuillez contacter l'équipe Compl'Alim pour effectuer la substitution.
                 </p>
+                <div v-else>
+                  <h2>Synonymes</h2>
+                  <div v-for="s in replacement.synonyms" :key="s.id" class="flex items-center">
+                    <DsfrInput label="Synonyme" v-model="s.name" class="mb-2" />
+
+                    <DsfrButton
+                      :label="`Supprimer synonyme '${s.name}'`"
+                      icon="ri-delete-bin-6-line"
+                      icon-only
+                      tertiary
+                      no-outline
+                    />
+                  </div>
+                  <DsfrButton label="Ajouter synonyme" icon="ri-add-line" secondary />
+                </div>
               </div>
               <div v-else>
                 <DsfrInput v-model="notes" label="Notes" label-visible is-textarea />
@@ -77,7 +92,8 @@ watch(element, (newElement) => {
 })
 
 // Actions
-const modalToOpen = ref(false)
+// const modalToOpen = ref(false)
+const modalToOpen = ref("replace")
 const closeModal = () => (modalToOpen.value = false)
 
 const notes = ref()
@@ -89,7 +105,13 @@ const openModal = (type) => {
   }
 }
 
-const replacement = ref()
+// const replacement = ref()
+const replacement = ref({
+  id: 3,
+  name: "Test modal",
+  synonyms: [{ id: 1, name: "My existing synonym" }],
+  objectType: props.type,
+})
 const cannotReplace = computed(() => replacement.value?.objectType !== element.value.type)
 
 const actionButtons = computed(() => [


### PR DESCRIPTION
Première PR dans le decoupage, cette PR ajoute l'option de donner un synonyme quand on remplace une demande d'ingrédient.

En deuxième temps j'ajouterai :
- l'option de MAJ et supprimer des synonymes existants
- gestion de type de synonyme

![Screenshot 2025-01-13 at 17-08-35 Dog Enby - Compl'Alim](https://github.com/user-attachments/assets/baa7f98b-63a7-4f02-a6ba-fe1b5e46c0ef)
