### PR TITLE
Triage alphabétique vertical des colonnes avec des checkboxes dans l'onglet produit

### DIFF
--- a/frontend/src/utils/forms.js
+++ b/frontend/src/utils/forms.js
@@ -43,11 +43,11 @@ export const transformArrayByColumn = (arr, numberOfColumns) => {
   Utile pour l'affichage des checkboxes dans des grilles de colonnes.
   */
   const result = []
-  const numRows = Math.ceil(arr.length / numberOfColumns)
+  const numberOfRows = Math.ceil(arr.length / numberOfColumns)
 
-  for (let row = 0; row < numRows; row++) {
+  for (let row = 0; row < numberOfRows; row++) {
     for (let col = 0; col < numberOfColumns; col++) {
-      const index = col * numRows + row
+      const index = col * numberOfRows + row
       if (index < arr.length) result.push(arr[index])
     }
   }

--- a/frontend/src/utils/forms.js
+++ b/frontend/src/utils/forms.js
@@ -24,3 +24,32 @@ export const pushOtherChoiceFieldAtTheEnd = (choices) => {
   }
   return choices
 }
+
+export const transformArrayByColumn = (arr, numberOfColumns) => {
+  /*
+  Transforme l'affichage d'un tableau en son équivalent d'affichage par colonnes. Par exemple,
+  [0, 1, 2, 3, 4, 5] en trois colonnes s'afficherait :
+  ---
+  0, 1, 2
+  3, 4, 5
+  ---
+  En passant par cette fonction, l'output serait :
+  [0, 2, 4, 1, 3, 5], qu'en trois colonnes s'afficherait :
+  ---
+  0, 2, 4
+  1, 3, 5
+  ---
+  Privilégiant ainsi une lecture verticale.
+  Utile pour l'affichage des checkboxes dans des grilles de colonnes.
+  */
+  const result = []
+  const numRows = Math.ceil(arr.length / numberOfColumns)
+
+  for (let row = 0; row < numRows; row++) {
+    for (let col = 0; col < numberOfColumns; col++) {
+      const index = col * numRows + row
+      if (index < arr.length) result.push(arr[index])
+    }
+  }
+  return result
+}

--- a/frontend/src/utils/screen.js
+++ b/frontend/src/utils/screen.js
@@ -1,0 +1,13 @@
+import tailwindConfig from "/tailwind.config.js"
+
+export const getCurrentBreakpoint = () => {
+  /*
+  Retourne le breakpoint actif depuis notre config tailwind. À noter que
+  les breakpoints doivent être triés dans le fichier de configuration.
+  */
+  for (const [key, value] of Object.entries(tailwindConfig.theme.screens)) {
+    const numericValue = parseInt(value.replace("px", ""))
+    if (window.innerWidth < numericValue) return key
+  }
+  return null
+}

--- a/frontend/src/utils/screen.js
+++ b/frontend/src/utils/screen.js
@@ -2,12 +2,10 @@ import tailwindConfig from "/tailwind.config.js"
 
 export const getCurrentBreakpoint = () => {
   /*
-  Retourne le breakpoint actif depuis notre config tailwind. À noter que
-  les breakpoints doivent être triés dans le fichier de configuration.
+  Retourne le breakpoint actif depuis notre config tailwind.
   */
-  for (const [key, value] of Object.entries(tailwindConfig.theme.screens)) {
-    const numericValue = parseInt(value.replace("px", ""))
-    if (window.innerWidth < numericValue) return key
-  }
+  const screensArray = Object.entries(tailwindConfig.theme.screens).map((x) => [x[0], parseInt(x[1].replace("px", ""))])
+  const sortedScreens = screensArray.sort((a, b) => a[1] - b[1])
+  for (const [key, value] of sortedScreens) if (window.innerWidth < value) return key
   return null
 }

--- a/frontend/src/views/ProducerFormPage/ProductTab.vue
+++ b/frontend/src/views/ProducerFormPage/ProductTab.vue
@@ -146,7 +146,7 @@
     <DsfrFieldset legend="Population cible" legendClass="fr-label">
       <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
         <div
-          v-for="population in populations"
+          v-for="population in orderedPopulations"
           :key="`effect-${population.id}`"
           class="flex col-span-6 sm:col-span-3 lg:col-span-2"
         >
@@ -168,7 +168,7 @@
     >
       <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
         <div
-          v-for="condition in conditions"
+          v-for="condition in orderedConditions"
           :key="`condition-${condition.id}`"
           class="flex col-span-6 sm:col-span-3 lg:col-span-2"
         >
@@ -197,7 +197,11 @@
     <SectionTitle title="Objectifs / effets" class="!mt-10" sizeTag="h6" icon="ri-focus-2-fill" />
     <DsfrFieldset>
       <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
-        <div v-for="effect in effects" :key="`effect-${effect.id}`" class="flex col-span-6 sm:col-span-3 lg:col-span-2">
+        <div
+          v-for="effect in orderedEffects"
+          :key="`effect-${effect.id}`"
+          class="flex col-span-6 sm:col-span-3 lg:col-span-2"
+        >
           <input :id="`effect-${effect.id}`" type="checkbox" v-model="payload.effects" :value="effect.id" />
           <label :for="`effect-${effect.id}`" class="fr-label ml-2">{{ effect.name }}</label>
         </div>
@@ -249,13 +253,16 @@ import { computed, watch, ref } from "vue"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import { useVuelidate } from "@vuelidate/core"
-import { firstErrorMsg } from "@/utils/forms"
+import { firstErrorMsg, transformArrayByColumn } from "@/utils/forms"
+import { getCurrentBreakpoint } from "@/utils/screen"
 import { pushOtherChoiceFieldAtTheEnd, getAllIndexesOfRegex } from "@/utils/forms"
 import CountryField from "@/components/fields/CountryField.vue"
 import OtherChoiceField from "@/components/fields/OtherChoiceField"
 import SectionTitle from "@/components/SectionTitle"
 import NumberField from "@/components/NumberField"
+import { useWindowSize } from "@vueuse/core"
 
+const { width } = useWindowSize()
 const payload = defineModel()
 const props = defineProps(["externalResults"])
 
@@ -341,6 +348,25 @@ watch(selectedCompany, () => {
 
 // S'il n'y a qu'une entreprise on l'assigne par défaut
 if (companies.value?.length === 1) payload.value.company = companies.value[0].id
+
+const numberOfColumns = ref()
+watch(
+  width,
+  () => {
+    const checkboxColumnNumbers = {
+      sm: 1,
+      md: 2,
+      lg: 2,
+      xl: 3,
+    }
+    numberOfColumns.value = checkboxColumnNumbers[getCurrentBreakpoint()] || 1
+  },
+  { immediate: true }
+)
+
+const orderedPopulations = computed(() => transformArrayByColumn(populations.value, numberOfColumns.value))
+const orderedConditions = computed(() => transformArrayByColumn(conditions.value, numberOfColumns.value))
+const orderedEffects = computed(() => transformArrayByColumn(effects.value, numberOfColumns.value))
 </script>
 
 <style scoped>


### PR DESCRIPTION
Lié à #994 

## Contexte

L'ordre alphabétique des checkboxes a été rémonté comme problème plusieurs fois. Aujourd'hui la lecture est horizontale alors que les personnes s'attendent à l'avoir en vertical. Capture d'écran aujourd'hui : 

![image](https://github.com/user-attachments/assets/6f1ced38-7b65-472d-b3ea-68d83dc28e64)

## Scope

Le placement d'éléments côté HTML se fait de façon horizontale, donc on doit manipuler le tableau pour que le placement change.

Par exemple, le tableau trié `[0, 1, 2, 3, 4, 5, 6, 7, 8]` en trois colonnes s'afficherait :

```
0, 1, 2
3, 4, 5
6, 7, 8
```

Or, il faudrait transformer ce tableau à `[0, 3, 6, 1, 4, 7, 2, 5, 8]` pour pouvoir l'afficher en lecture verticale :

```
0, 3, 6
1, 4, 7
2, 5, 8
```

La fonction `transformArrayByColumn` se charge de ceci.

De plus, il faut savoir sur quel breakpoint on se trouve pour connaître le nombre de colonnes et donc transformer correctement le tableau. La fonction `getCurrentBreakpoint` se charge de cela.

En alimentant cette fonction dans le watcher pour la dimension de la fenêtre, on affiche le bon ordre même lorsque la fenêtre est redimensionnée. 

## Démo

![image](https://github.com/user-attachments/assets/5ea7be2e-ccc1-47a5-b455-e142c9d4effa)
