### PR TITLE
Améliorations de l'importer de déclarations historiques

### DIFF
--- a/data/etl/teleicare_history/extractor.py
+++ b/data/etl/teleicare_history/extractor.py
@@ -189,6 +189,11 @@ def create_declaration_from_teleicare_history():
     nb_missing_entp = 0
 
     for ica_complement_alimentaire in IcaComplementAlimentaire.objects.all():
+        try:
+            company = Company.objects.get(siccrf_id=ica_complement_alimentaire.etab_id)
+        except Company.DoesNotExist:
+            nb_missing_entp += 1
+            continue
         # retrouve la déclaration la plus à jour correspondant à ce complément alimentaire
         all_ica_declarations = IcaDeclaration.objects.filter(cplalim_id=ica_complement_alimentaire.cplalim_ident)
         # le champ date est stocké en text, il faut donc faire la conversion en python
@@ -213,11 +218,6 @@ def create_declaration_from_teleicare_history():
             ).first()
             # la déclaration a une version finalisée
             if latest_ica_version_declaration:
-                try:
-                    company = Company.objects.get(siccrf_id=ica_complement_alimentaire.etab_id)
-                except Company.DoesNotExist:
-                    nb_missing_entp += 1
-                    continue
                 declaration_creation_date = (
                     convert_str_date(latest_ica_declaration.dcl_date, aware=True)
                     if latest_ica_declaration.dcl_date


### PR DESCRIPTION
L'importer avait quelques soucis : 

- erreurs non catchées
- performances bof

Cette PR améliore un peu les perf mais la création des Déclarations historiques met ~ 1h (j'estime ~3h pour la création de toutes les déclarations historiques mêmes pour les entreprises non connues).

Il est possible d'accélérer ce temps en utilisant `bulk_create` mais cela ne permet pas l'overwrite des champs `modification_date` et `creation_date`

TODO : creuser si une autre solution est possible.


```
+    bulk = []
     # Parcourir tous les compléments alimentaires dont l'entreprise déclarante a été matchée
-    for ica_complement_alimentaire in IcaComplementAlimentaire.objects.filter(
-        etab_id__in=Company.objects.values_list("siccrf_id", flat=True)
+    for index, ica_complement_alimentaire in enumerate(
+        IcaComplementAlimentaire.objects.filter(etab_id__in=Company.objects.values_list("siccrf_id", flat=True))
     ):
         # retrouve la déclaration la plus à jour correspondant à ce complément alimentaire
         all_ica_declarations = IcaDeclaration.objects.filter(cplalim_id=ica_complement_alimentaire.cplalim_ident)
@@ -262,13 +261,14 @@ def create_declaration_from_teleicare_history():
                     if latest_ica_declaration.dcl_date_fin_commercialisation
                     else DECLARATION_STATUS_MAPPING[latest_ica_version_declaration.stattdcl_ident],
                 )
-
-                try:
-                    with suppress_autotime(declaration, ["creation_date", "modification_date"]):
-                        declaration.save()
-                        nb_created_declarations += 1
-                except IntegrityError:
-                    # cette Déclaration a déjà été créée
-                    pass
-
+                bulk.append(declaration)
+                if index % 500 == 0:
+                    with suppress_autotime(Declaration, ["creation_date", "modification_date"]):
+                        Declaration.objects.bulk_create(bulk, ignore_conflicts=True)
+                        logger.info(f"Bulk saving {len(bulk)} déclaration")
+                        nb_created_declarations += len(bulk)
+                        bulk = []
+    Declaration.objects.bulk_create(bulk, ignore_conflicts=True)
+    logger.info(f"Bulk saving {len(bulk)} déclaration")
+    nb_created_declarations += len(bulk)

```