### PR TITLE
Bug fix : supprimer une erreur dans le console quand on remplace une demande

### DIFF
--- a/frontend/src/views/DeclaredElementPage/index.vue
+++ b/frontend/src/views/DeclaredElementPage/index.vue
@@ -100,6 +100,7 @@ const openModal = (type) => {
 const replacement = ref()
 const synonyms = ref()
 watch(replacement, () => {
+  if (!replacement.value?.synonyms) return
   synonyms.value = JSON.parse(JSON.stringify(replacement.value.synonyms)) // initialise synonyms that might be updated
 })
 


### PR DESCRIPTION
Grâce aux plusieurs emits, `replacement` et `replacement.value.synonyms` ne sont pas tjs définits. Il y a des erreurs dans le console en staging, et en dev ça bloque.

(ligne avec les emits : https://github.com/betagouv/complements-alimentaires/blob/c799437bda836bc42f7c71c76edf0a517c1bb9c3/frontend/src/views/DeclaredElementPage/ReplacementSearch.vue#L31)