### PR TITLE
Afficher le statut de la demande dans le tableau

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -609,6 +609,7 @@ class DeclaredElementSerializer(serializers.Serializer):
     type = serializers.CharField()
     authorization_mode = serializers.CharField()
     declaration = DeclarationShortSerializer()
+    request_status = serializers.CharField()
 
     def get_name(self, obj):
         return str(obj)

--- a/frontend/src/views/NewElementsPage/NewElementsTable.vue
+++ b/frontend/src/views/NewElementsPage/NewElementsTable.vue
@@ -46,49 +46,32 @@ const rows = computed(() =>
 )
 
 const getRequestStatusTagForCell = (request) => {
-  // TODO: ideally reuse the DSFR icons used in the alerts, but unsure if those classes are working
   const status = {
     REQUESTED: {
       label: "Nouvelle",
-      icon: "ri-todo-fill",
-      class: "info",
+      type: "info",
     },
     INFORMATION: {
       label: "Information",
-      icon: "ri-time-line",
-      class: "warning",
+      type: "warning",
     },
     REJECTED: {
       label: "Refusé",
-      icon: "ri-error-warning-line",
-      class: "error",
+      type: "error",
     },
   }[request.requestStatus]
 
-  return status
-    ? {
-        ...status,
-        component: "DsfrTag",
-      }
-    : {}
+  return (
+    status && {
+      ...status,
+      component: "DsfrBadge",
+    }
+  )
 }
 </script>
 
 <style scoped>
 .fr-table :deep(td) {
   width: calc(100% / 6);
-}
-
-:deep(.info) {
-  color: var(--info-425-625);
-  background-color: var(--info-950-100);
-}
-:deep(.error) {
-  color: var(--error-425-625);
-  background-color: var(--error-950-100);
-}
-:deep(.warning) {
-  color: var(--warning-425-625);
-  background-color: var(--warning-950-100);
 }
 </style>

--- a/frontend/src/views/NewElementsPage/NewElementsTable.vue
+++ b/frontend/src/views/NewElementsPage/NewElementsTable.vue
@@ -24,6 +24,7 @@ const headers = [
   "Authorisation marché FR ou EU",
   "Date de demande d'ajout",
   "Statut de la déclaration",
+  "Statut de la demande",
   "",
 ]
 const rows = computed(() =>
@@ -34,6 +35,7 @@ const rows = computed(() =>
       getAuthorizationModeInFrench(x.authorizationMode),
       x.declaration.creationDate && isoToPrettyDate(x.declaration.creationDate),
       getStatusTagForCell(x.declaration.status),
+      getRequestStatusTagForCell(x),
       {
         component: "router-link",
         text: "Contrôler l'ingrédient",
@@ -42,10 +44,51 @@ const rows = computed(() =>
     ],
   }))
 )
+
+const getRequestStatusTagForCell = (request) => {
+  // TODO: ideally reuse the DSFR icons used in the alerts, but unsure if those classes are working
+  const status = {
+    REQUESTED: {
+      label: "Nouvelle",
+      icon: "ri-todo-fill",
+      class: "info",
+    },
+    INFORMATION: {
+      label: "Information",
+      icon: "ri-time-line",
+      class: "warning",
+    },
+    REJECTED: {
+      label: "Refusé",
+      icon: "ri-error-warning-line",
+      class: "error",
+    },
+  }[request.requestStatus]
+
+  return status
+    ? {
+        ...status,
+        component: "DsfrTag",
+      }
+    : {}
+}
 </script>
 
 <style scoped>
 .fr-table :deep(td) {
   width: calc(100% / 6);
+}
+
+:deep(.info) {
+  color: var(--info-425-625);
+  background-color: var(--info-950-100);
+}
+:deep(.error) {
+  color: var(--error-425-625);
+  background-color: var(--error-950-100);
+}
+:deep(.warning) {
+  color: var(--warning-425-625);
+  background-color: var(--warning-950-100);
 }
 </style>


### PR DESCRIPTION
Je trouve que c'est difficile d'utiliser le tableau sans statut de demande alors je l'ai ajouté même si c'est pas prio.

[Maquette originelle](https://www.figma.com/design/0pv6zTHf7IW3wbxmmScSUh/Nouvel-ingr%C3%A9dient?node-id=54-9512&t=Fg2QcEiuhyVzliAv-0)

![Screenshot 2025-01-21 at 14-05-59 Nouveaux ingrédients - Compl'Alim](https://github.com/user-attachments/assets/cbedb16c-40ef-4e8a-a6cf-8587b4387128)

J'ai décidé de le mettre dans une nouvelle colonne pour la simplicité et peut-être dans l'avenir on voudrait avoir l'option de trier et filtrer par statut.

J'ai simplifié le texte dans le badge pour avoir plus d'espace.




