### PR TITLE
Fix du bug d'affichage concernant les unités dans le PDF summary

### DIFF
--- a/web/templates/summary.html
+++ b/web/templates/summary.html
@@ -128,7 +128,7 @@
                         <th scope="row">
                             {{ row.0 }}
                         </th>
-                        <td>{{ row.1 }}</td>
+                        <td class="{{ row.2 }}">{{ row.1 }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/web/views/summary.py
+++ b/web/views/summary.py
@@ -17,24 +17,26 @@ class SummaryView(PdfView):
         return "summary.html"
 
     def get_context(self, declaration):
+        # List avec trois éléments : le titre, la valeur à afficher et éventuellement le nom de la classe
         product_table_rows = (
-            ("Nom du produit", declaration.name),
-            ("Marque", declaration.brand or "Non spécifiée"),
-            ("Gamme", declaration.gamme or "Non spécifiée"),
-            ("Description", declaration.description or "Non spécifiée"),
-            ("Populations cibles", ", ".join(list(declaration.populations.all().values_list("name", flat=True)))),
-            ("Populations à consommation déconseillée", self.get_conditions_string(declaration)),
-            ("Mise en garde et avertissement", declaration.warning or "Non spécifiée"),
+            ("Nom du produit", declaration.name, ""),
+            ("Marque", declaration.brand or "Non spécifiée", ""),
+            ("Gamme", declaration.gamme or "Non spécifiée", ""),
+            ("Description", declaration.description or "Non spécifiée", ""),
+            ("Populations cibles", ", ".join(list(declaration.populations.all().values_list("name", flat=True))), ""),
+            ("Populations à consommation déconseillée", self.get_conditions_string(declaration), ""),
+            ("Mise en garde et avertissement", declaration.warning or "Non spécifiée", ""),
             (
                 "Forme galénique",
                 declaration.galenic_formulation or declaration.other_galenic_formulation or "Non spécifiée",
+                "",
             ),
-            ("Mode d'emploi", declaration.instructions or "Non spécifié"),
-            ("Unité de consommation", self.get_measurement_unit_string(declaration)),
-            ("Dose journalière recommandée", declaration.daily_recommended_dose or "Non spécifiée"),
-            ("Conditionnement", declaration.conditioning or "Non spécifié"),
-            ("Durabilité minimale / DLUO (en mois)", declaration.minimum_duration or "Non spécifiée"),
-            ("Objectifs / effets", self.get_effects_string(declaration)),
+            ("Mode d'emploi", declaration.instructions or "Non spécifié", ""),
+            ("Unité de consommation", self.get_measurement_unit_string(declaration), "unit-font"),
+            ("Dose journalière recommandée", declaration.daily_recommended_dose or "Non spécifiée", ""),
+            ("Conditionnement", declaration.conditioning or "Non spécifié", ""),
+            ("Durabilité minimale / DLUO (en mois)", declaration.minimum_duration or "Non spécifiée", ""),
+            ("Objectifs / effets", self.get_effects_string(declaration), ""),
         )
         try:
             last_submission_snapshot = declaration.snapshots.filter(action=Snapshot.SnapshotActions.SUBMIT).latest(


### PR DESCRIPTION
Closes #1508 

## Contexte

Les unités dans la partie supérieure du PDF summary ne s'affichaient pas.

## Scope

La raison est que le caractère `μ` n'est pas présent dans la police Marianne. De plus, on ne peut pas mettre une police de fallback (type `font-family: 'Marianne', sans-serif;`) car _Marianne_ existe bel et bien, ce sont seulement les caractères spéciaux communément utilisés dans les mesures qui ne s'affichent pas.

On a déjà une classe pour ceci : `class="unit-font"`, qu'on utilise dans la partie composition. Afin de pouvoir l'utiliser, le tableau `product_table_rows` contient maintenant des éléments avec trois items : le titre, la valeur à afficher, et les classes à appliquer. Pour l'instant ça nous sert à mettre la bonne classe pour l'unité, et ça pourrait nous servir par la suite pour différencier certaines lignes de ce tableau (par ex. mettre le nom du produit en bold).

## Démo

![image](https://github.com/user-attachments/assets/cfe31be0-709b-4901-a47a-a275b98d256a)


Avant : 

![image](https://github.com/user-attachments/assets/8338de9d-df05-400e-93ea-d0c0c67b6ae5)
