### PR TITLE
[API] Permettre le remplacement d'une demande avec un ingrédient d'autre type

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -107,9 +107,17 @@ DECLARED_ELEMENT_SHARED_FIELDS = ADDABLE_ELEMENT_FIELDS + ("type",)
 
 
 class DeclaredElementNestedField:
+    # DRF ne gère pas automatiquement la création des nested-fields :
+    # https://www.django-rest-framework.org/api-guide/serializers/#writable-nested-representations
     def create(self, validated_data):
-        # DRF ne gère pas automatiquement la création des nested-fields :
-        # https://www.django-rest-framework.org/api-guide/serializers/#writable-nested-representations
+        self._set_element(validated_data)
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        self._set_element(validated_data)
+        return super().update(instance, validated_data)
+
+    def _set_element(self, validated_data):
         element = validated_data.pop(self.nested_field_name, None)
         if element:
             id = element.get("id")
@@ -121,8 +129,6 @@ class DeclaredElementNestedField:
                         f"declared_{self.nested_field_name}s": f"L'ingrédient avec l'id « {id} » spécifiée n'existe pas."
                     }
                 )
-
-        return super().create(validated_data)
 
 
 class DeclaredIngredientCommonSerializer(DeclaredElementNestedField, PrivateFieldsSerializer):

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -90,17 +90,20 @@ class DeclaredListSerializer(serializers.ListSerializer):
 
 
 ADDABLE_ELEMENT_FIELDS = (
+    "new",
+    "new_name",
+    "new_description",
     "authorization_mode",
     "fr_reason",
     "fr_details",
     "eu_reference_country",
     "eu_legal_source",
     "eu_details",
-    "new_description",
-    "new",
-    "request_private_notes",
     "request_status",
+    "request_private_notes",
 )
+
+DECLARED_ELEMENT_SHARED_FIELDS = ADDABLE_ELEMENT_FIELDS + ("type",)
 
 
 class DeclaredElementNestedField:
@@ -137,17 +140,15 @@ class DeclaredPlantSerializer(DeclaredIngredientCommonSerializer):
 
     class Meta:
         model = DeclaredPlant
-        fields = ADDABLE_ELEMENT_FIELDS + (
+        fields = DECLARED_ELEMENT_SHARED_FIELDS + (
             "id",
             "declaration",
             "element",
-            "new_name",
             "active",
             "used_part",
-            "unit",
             "quantity",
+            "unit",
             "preparation",
-            "type",
         )
 
 
@@ -160,18 +161,16 @@ class DeclaredMicroorganismSerializer(DeclaredIngredientCommonSerializer):
 
     class Meta:
         model = DeclaredMicroorganism
-        fields = ADDABLE_ELEMENT_FIELDS + (
+        fields = DECLARED_ELEMENT_SHARED_FIELDS + (
             "id",
             "declaration",
             "element",
-            "new_name",
-            "new_species",
-            "new_genre",
             "active",
             "activated",
+            "new_species",
+            "new_genre",
             "strain",
             "quantity",
-            "type",
         )
 
 
@@ -185,16 +184,14 @@ class DeclaredIngredientSerializer(DeclaredIngredientCommonSerializer):
 
     class Meta:
         model = DeclaredIngredient
-        fields = ADDABLE_ELEMENT_FIELDS + (
+        fields = DECLARED_ELEMENT_SHARED_FIELDS + (
             "id",
             "declaration",
             "element",
-            "new_name",
-            "new_type",
             "active",
+            "new_type",
             "quantity",
             "unit",
-            "type",
         )
 
 
@@ -207,15 +204,13 @@ class DeclaredSubstanceSerializer(DeclaredIngredientCommonSerializer):
 
     class Meta:
         model = DeclaredSubstance
-        fields = ADDABLE_ELEMENT_FIELDS + (
+        fields = DECLARED_ELEMENT_SHARED_FIELDS + (
             "id",
             "declaration",
             "element",
-            "new_name",
             "active",
             "quantity",
             "unit",
-            "type",
         )
 
 

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -2064,12 +2064,9 @@ class TestDeclaredElementsApi(APITestCase):
         self.assertEqual(declared_plant.request_status, DeclaredPlant.AddableStatus.REPLACED)
         self.assertFalse(declared_plant.new)
 
-        # est-ce que l'espèce + genre sont copiés dans le champ nom ?
-        self.assertEqual(declared_plant.new_name, "test testing")
-        # est-ce que les nouveaux champs sont sauvegardés ?
-        self.assertEqual(declared_plant.unit, unit)
         # est-ce que les anciens champs sont sauvegardés ?
         self.assertEqual(declared_plant.new_description, "Test description")
+        self.assertEqual(declared_plant.unit, unit)
 
     @authenticate
     def test_can_add_synonym_on_replace(self):

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -2270,14 +2270,17 @@ class TestDeclaredElementsApi(APITestCase):
         self.assertEqual(DeclaredPlant.objects.count(), 0)
 
     @authenticate
-    def test_id_ignored_in_additional_fields_replace(self):
+    def test_id_ignored_in_replace(self):
         """
-        Verifier qu'on n'a pas d'erreur de création, ou comportement inattendu, si un identifiant est donné
+        Vérifier que l'id d'un nouvel ingrédient déclaré est généré automatiquement, et non pas avec les données passées
         """
         InstructionRoleFactory(user=authenticate.user)
 
         declaration = DeclarationFactory()
-        declared_microorganism = DeclaredMicroorganismFactory(declaration=declaration, new_species="test", new=True)
+        declared_microorganism = DeclaredMicroorganismFactory(
+            id=66, declaration=declaration, new_species="test", new=True
+        )
+        self.assertEqual(declared_microorganism.id, 66)
         plant = PlantFactory()
         unit = SubstanceUnitFactory()
 
@@ -2295,4 +2298,5 @@ class TestDeclaredElementsApi(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
         new_declared_plant = DeclaredPlant.objects.first()
         self.assertEqual(new_declared_plant.unit, unit)
+        self.assertNotEqual(new_declared_plant.id, 66)
         self.assertNotEqual(new_declared_plant.id, 99)

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -1934,7 +1934,7 @@ class TestDeclaredElementsApi(APITestCase):
 
         declaration = DeclarationFactory()
         declared_plant = DeclaredPlantFactory(
-            declaration=declaration, new_name="Test plant", new_description="Test description", new=True
+            declaration=declaration, new_name="Test plant", new_description="Test description", new=True, quantity=10
         )
         self.assertEqual(declared_plant.request_status, DeclaredPlant.AddableStatus.REQUESTED)
         microorganism = MicroorganismFactory()
@@ -1946,6 +1946,7 @@ class TestDeclaredElementsApi(APITestCase):
                 "additional_fields": {
                     "strain": "Test strain",
                     "activated": False,
+                    "quantity": 90,
                 },
             },
             format="json",
@@ -1962,6 +1963,7 @@ class TestDeclaredElementsApi(APITestCase):
         # test new fields saved
         self.assertEqual(declared_microorganism.strain, "Test strain")
         self.assertEqual(declared_microorganism.activated, False)
+        self.assertEqual(declared_microorganism.quantity, 90)
         # test old fields copied over
         self.assertEqual(declared_microorganism.new_description, "Test description")
         self.assertEqual(declared_microorganism.request_status, DeclaredMicroorganism.AddableStatus.REPLACED)

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -1949,7 +1949,7 @@ class TestDeclaredElementsApi(APITestCase):
         declared_ingredient = DeclaredIngredientFactory(
             declaration=declaration,
             new=True,
-            new_type=IngredientType.NON_ACTIVE_INGREDIENT,
+            new_type=IngredientType.NON_ACTIVE_INGREDIENT.label,
             active=False,
             quantity=None,
             unit=None,
@@ -1970,6 +1970,7 @@ class TestDeclaredElementsApi(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
         declared_ingredient.refresh_from_db()
         self.assertEqual(declared_ingredient.ingredient, active_ingredient)
+        self.assertEqual(declared_ingredient.new_type, IngredientType.NON_ACTIVE_INGREDIENT.label)  # pas changé
         self.assertTrue(declared_ingredient.active)
         self.assertEqual(declared_ingredient.quantity, 20)
         self.assertEqual(declared_ingredient.unit, unit)

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -2120,8 +2120,8 @@ class TestDeclaredElementsApi(APITestCase):
     @authenticate
     def test_can_add_synonym_on_replace(self):
         """
-        C'est possible d'envoyer une liste avec un nouvel element pour
-        ajouter un synonyme et laisser des synonymes existantes non-modifiées
+        C'est possible d'envoyer une liste avec un element pour ajouter un synonyme
+        et laisser des synonymes existantes non-modifiées
         """
         InstructionRoleFactory(user=authenticate.user)
 
@@ -2186,13 +2186,12 @@ class TestDeclaredElementsApi(APITestCase):
     @authenticate
     def test_cannot_add_duplicate_synonyms(self):
         """
-        C'est possible d'envoyer une liste avec un nouvel element pour
-        ajouter un synonyme et laisser des synonymes existantes non-modifiées
+        Ignorer les synonymes qui matchent des synonymes existantes
         """
         InstructionRoleFactory(user=authenticate.user)
 
         declaration = DeclarationFactory()
-        declared_plant = DeclaredPlantFactory(declaration=declaration, new=True)
+        declared_plant = DeclaredPlantFactory(declaration=declaration)
         plant = PlantFactory()
         synonym = PlantSynonymFactory.create(name="Eucalyptus Plant", standard_name=plant)
 
@@ -2278,9 +2277,7 @@ class TestDeclaredElementsApi(APITestCase):
         InstructionRoleFactory(user=authenticate.user)
 
         declaration = DeclarationFactory()
-        declared_microorganism = DeclaredMicroorganismFactory(
-            id=66, declaration=declaration, new_species="test", new=True
-        )
+        declared_microorganism = DeclaredMicroorganismFactory(id=66, declaration=declaration, new_species="test")
         self.assertEqual(declared_microorganism.id, 66)
         plant = PlantFactory()
         unit = SubstanceUnitFactory()

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -83,6 +83,7 @@ TYPE_MAPPING = {
         "element_model": Ingredient,
         "synonym_model": IngredientSynonym,
         "serializer": DeclaredIngredientSerializer,
+        "attribute": "ingredient",
     },
 }
 
@@ -115,6 +116,10 @@ class ElementMappingMixin:
     @property
     def synonym_model(self):
         return self.type_info["synonym_model"]
+
+    @property
+    def type_attribute(self):
+        return self.type_info["attribute"] or self.element_type
 
 
 class DeclaredElementView(RetrieveAPIView, ElementMappingMixin):
@@ -177,7 +182,7 @@ class DeclaredElementReplaceView(DeclaredElementActionAbstractView):
             raise ParseError(detail=f"No {self.element_type} exists with id {replacement_element_id}")
 
         if replacement_type == self.element_type:
-            setattr(declared_element, self.element_type, replacement_element)
+            setattr(declared_element, self.type_attribute, replacement_element)
         else:
             # créer le nouveau element a partir des champs de l'ancien et champs donnés par la requête
             new_declared_element_fields = self.type_serializer(declared_element).data

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -156,7 +156,7 @@ class DeclaredElementReplaceView(DeclaredElementActionAbstractView):
         except KeyError:
             raise ParseError(detail="Must provide a dict 'element' with id and type")
 
-        # create a serialized dict of values to update
+        # utiliser les valeurs serialisées pour MAJ ou créer l'element déclaré
         element_data = self.type_serializer(declared_element).data
         additional_fields = request.data.get("additional_fields", {})
         element_data.update(additional_fields)
@@ -170,7 +170,7 @@ class DeclaredElementReplaceView(DeclaredElementActionAbstractView):
 
         new_type = TYPE_MAPPING[replacement_type]
         if replacement_type != self.element_type:
-            # gerer le difference en nom entre microorganismes et les autres types
+            # gérer le difference en nom entre microorganismes et les autres types
             if replacement_type == "microorganism":
                 element_data["new_species"] = declared_element.new_name
             elif self.element_type == "microorganism":
@@ -188,8 +188,6 @@ class DeclaredElementReplaceView(DeclaredElementActionAbstractView):
             serializer = self.type_serializer(declared_element, data=element_data, partial=True)
             serializer.is_valid(raise_exception=True)
             declared_element = serializer.save()
-
-        # TODO: always show in the front the possibility to update fields even without type change
 
         replacement_synonym_model = new_type["synonym_model"]
         synonyms = request.data.get("synonyms", [])

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -185,8 +185,6 @@ class DeclaredElementReplaceView(DeclaredElementActionAbstractView):
             declared_element.delete()
             declared_element = new_declared_element
         else:
-            # other_type_changed = self.element_type == "other-ingredient" and replacement_type == "other-ingredient" and declared_element.new_type != replacement_element.object_type
-            # TODO: add test for changing new_type?
             serializer = self.type_serializer(declared_element, data=element_data, partial=True)
             serializer.is_valid(raise_exception=True)
             declared_element = serializer.save()

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -177,18 +177,20 @@ class DeclaredElementReplaceView(DeclaredElementActionAbstractView):
             raise ParseError(detail=f"No {self.element_type} exists with id {replacement_element_id}")
 
         if replacement_element_type != self.element_type:
+            # TODO: should there be a limit to which fields are overrideable?
             additional_fields = request.data.get("additional_fields", {})
             replacement_declaration_model = new_type["model"]
             old_fields = [field.name for field in self.type_model._meta.get_fields()]
             new_fields = [field.name for field in replacement_declaration_model._meta.get_fields()]
             same_fields = set(old_fields).intersection(set(new_fields))
 
-            new_declared_element_fields = (
-                additional_fields  # TODO: should there be a limit to which fields are overrideable?
-            )
+            new_declared_element_fields = {}
+            # initialiser avec les anciennes valeurs qui sont toujours valides
             for field in same_fields:
                 new_declared_element_fields[field] = getattr(element, field)
-                # TODO: this means existing same fields would override provided fields
+            # ajouter ou remplacer avec les valeurs données
+            for field in additional_fields:
+                new_declared_element_fields[field] = additional_fields[field]
 
             if self.element_type != "microorganism" and replacement_element_type == "microorganism":
                 new_declared_element_fields["new_species"] = element.new_name

--- a/data/admin/ingredient.py
+++ b/data/admin/ingredient.py
@@ -38,8 +38,8 @@ class IngredientAdmin(ElementAdminWithChangeReason):
         SubstanceInlineAdmin,
         IngredientSynonymInline,
     )
-    list_display = ("name", "is_obsolete", "status", "is_risky", "novel_food")
-    list_filter = ("is_obsolete", "status", "is_risky", "novel_food")
+    list_display = ("name", "is_obsolete", "status", "is_risky", "novel_food", "has_linked_substances")
+    list_filter = ("is_obsolete", "status", "is_risky", "novel_food", "ingredient_type")
     show_facets = admin.ShowFacets.NEVER
     readonly_fields = (
         "name",
@@ -49,3 +49,6 @@ class IngredientAdmin(ElementAdminWithChangeReason):
         "siccrf_private_comments",
     )
     search_fields = ["id", "name"]
+
+    def has_linked_substances(self, obj):
+        return "Oui" if obj.substances.count() else "Non"

--- a/data/admin/ingredient.py
+++ b/data/admin/ingredient.py
@@ -51,4 +51,4 @@ class IngredientAdmin(ElementAdminWithChangeReason):
     search_fields = ["id", "name"]
 
     def has_linked_substances(self, obj):
-        return "Oui" if obj.substances.count() else "Non"
+        return "Oui" if obj.substances.exists() else "Non"

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -640,12 +640,17 @@ class DeclaredMicroorganism(Historisable, Addable):
 
     def __str__(self):
         if self.new:
-            return f"-NEW- {self.new_species} {self.new_genre}"
+            return f"-NEW- {self.new_name}"
         return f"{self.microorganism.species} {self.microorganism.genus}"
 
     @property
     def type(self):
         return "microorganism"
+
+    @property
+    def new_name(self):
+        if self.new:
+            return f"{self.new_species} {self.new_genre}"
 
 
 class DeclaredIngredient(Historisable, Addable):


### PR DESCRIPTION
On ne copie pas en ce moment le champ `first_ocurrence` car ce n'est pas inclut dans les serializers. Je crois qu'on s'est dit que c'est un champ pas utilisé en ce moment alors pas grâve, mais je me demande si je modifie les serializers pour l'inclure pour être complèt et coherent ?