### PR TITLE
Changement du message d'erreur en cas de token CSRF pas à jour

### DIFF
--- a/frontend/src/utils/error-handling.js
+++ b/frontend/src/utils/error-handling.js
@@ -26,10 +26,11 @@ export const handleError = async (response) => {
   // Handle display of the errors (directly on the form or in a toast)
   // https://vuelidate-next.netlify.app/advanced_usage.html#config-with-composition-api
   const backErrorData = await response.value.json()
-  if (backErrorData.globalError) {
-    // show an error toast
-    addErrorMessage(backErrorData.globalError)
-  }
+  const isCsrfError = backErrorData.globalError?.indexOf?.("CSRF Failed") > -1
+
+  if (isCsrfError) addErrorMessage("Veuillez rafraîchir la page pour mettre à jour votre session.")
+  else if (backErrorData.globalError) addErrorMessage(backErrorData.globalError)
+
   // Return other errors to be handled by Vuelidate directly (and "extra" parameters to get additional data)
   // If you don't have a form and expect global errors only, just ignore the result of this function when called.
   return {

--- a/frontend/src/views/DeclaredElementPage/ElementSynonyms.vue
+++ b/frontend/src/views/DeclaredElementPage/ElementSynonyms.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from "vue"
+import { computed } from "vue"
 import { getElementName } from "@/utils/elements"
 
 const props = defineProps({ initialSynonyms: Array, requestElement: Object })

--- a/frontend/src/views/NewElementsPage/ElementLink.vue
+++ b/frontend/src/views/NewElementsPage/ElementLink.vue
@@ -12,5 +12,5 @@
 </template>
 
 <script setup>
-const props = defineProps({ element: Object })
+defineProps({ element: Object })
 </script>

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -235,11 +235,15 @@ const savePayload = async (successMessage = "Votre démarche a été sauvegardé
   const { response, data } = await useFetch(url, { headers: headers() })[httpMethod](payload).json()
   requestInProgress.value = false
   $externalResults.value = await handleError(response)
-  if ($externalResults.value) {
-    useToaster().addErrorMessage(
-      "Merci de vérifier que les champs obligatoires, signalés par une astérix *, ont bien été remplis pour pouvoir changer d'onglet"
-    )
-    window.scrollTo(0, 0)
+  const hasError = !!$externalResults.value
+  if (hasError) {
+    const fieldErrors = $externalResults.value.fieldErrors
+    if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+      useToaster().addErrorMessage(
+        "Merci de vérifier que les champs obligatoires, signalés par une astérix *, ont bien été remplis pour pouvoir changer d'onglet"
+      )
+      window.scrollTo(0, 0)
+    }
     return false
   } else {
     payload.value = data.value


### PR DESCRIPTION
Closes #1504 

## Contexte

Le message d'erreur en cas de token CSRF pas à jour n'était pas compréhensible ni donnait une piste sur comment le régler.

## Scope

Avec @HeleneDubourdieu on a décidé de mettre un message invitant à l'utilisateur·ice à rafraîchir la page.

Étant un `globalError` la gestion de ce message se trouve dans _frontend/src/utils/error-handling.js_.

Une modification a du être effectuée aussi dans _frontend/src/views/ProducerFormPage/index.vue_ pour montrer l'erreur sur les champs obligatoires seulement si `fieldErrors` n'était pas vide.

## Démo


https://github.com/user-attachments/assets/9ef5c334-37c3-4ab0-8893-b5a379ec8b9f

