### PR TITLE
Définir des flags pour éviter un warning dans le console du navigateur

### DIFF
--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -24,6 +24,17 @@ module.exports = defineConfig({
 
     config.resolve.alias.set("__STATIC__", "static")
 
+    // il faut specifier __VUE_PROD_HYDRATION_MISMATCH_DETAILS__ pour éviter un warning dans le console
+    // https://vuejs.org/api/compile-time-flags#vue-cli
+    config.plugin("define").tap((definitions) => {
+      Object.assign(definitions[0], {
+        __VUE_OPTIONS_API__: "true",
+        __VUE_PROD_DEVTOOLS__: "false",
+        __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "false",
+      })
+      return definitions
+    })
+
     config.devServer
       .host("0.0.0.0")
       .port(8080)


### PR DESCRIPTION
Normalement ça change rien du comportement de l'application. Je voudrais simplement supprimer un warning inutile.

Plus d'info

https://stackoverflow.com/questions/77752897/feature-flag-vue-prod-hydration-mismatch-details-is-not-explicitly-defined

https://vuejs.org/api/compile-time-flags#vue-cli

Le warning a souligné `__VUE_PROD_HYDRATION_MISMATCH_DETAILS__` mais je me suis dit pourquoi pas suivre l'exemple dans le code et definir les trois