### PR TITLE
Cache les commentaires au pro dans l'historique pour les éléments du refus de visa

### DIFF
--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -719,7 +719,7 @@ class TestDeclarationFlow(APITestCase):
         latest_snapshot = declaration.snapshots.latest("creation_date")
         self.assertEqual(declaration.status, Declaration.DeclarationStatus.AWAITING_INSTRUCTION)
         self.assertEqual(latest_snapshot.status, Declaration.DeclarationStatus.AWAITING_INSTRUCTION)
-        self.assertEqual(latest_snapshot.comment, None)
+        self.assertEqual(latest_snapshot.comment, "")
         self.assertEqual(latest_snapshot.expiration_days, None)
         self.assertEqual(latest_snapshot.blocking_reasons, None)
 

--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -686,7 +686,7 @@ class TestDeclarationFlow(APITestCase):
         declaration.refresh_from_db()
         latest_snapshot = declaration.snapshots.latest("creation_date")
         self.assertEqual(declaration.status, Declaration.DeclarationStatus.OBSERVATION)
-        self.assertEqual(declaration.comment, "overridden comment")
+        self.assertEqual(latest_snapshot.comment, "overridden comment")
         self.assertEqual(latest_snapshot.status, Declaration.DeclarationStatus.OBSERVATION)
         self.assertEqual(latest_snapshot.expiration_days, 6)
         self.assertEqual(latest_snapshot.blocking_reasons, ["a", "b"])

--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -686,7 +686,7 @@ class TestDeclarationFlow(APITestCase):
         declaration.refresh_from_db()
         latest_snapshot = declaration.snapshots.latest("creation_date")
         self.assertEqual(declaration.status, Declaration.DeclarationStatus.OBSERVATION)
-        self.assertEqual(latest_snapshot.comment, "overridden comment")
+        self.assertEqual(declaration.comment, "overridden comment")
         self.assertEqual(latest_snapshot.status, Declaration.DeclarationStatus.OBSERVATION)
         self.assertEqual(latest_snapshot.expiration_days, 6)
         self.assertEqual(latest_snapshot.blocking_reasons, ["a", "b"])
@@ -718,8 +718,8 @@ class TestDeclarationFlow(APITestCase):
         declaration.refresh_from_db()
         latest_snapshot = declaration.snapshots.latest("creation_date")
         self.assertEqual(declaration.status, Declaration.DeclarationStatus.AWAITING_INSTRUCTION)
-        self.assertEqual(latest_snapshot.comment, "À authoriser")
         self.assertEqual(latest_snapshot.status, Declaration.DeclarationStatus.AWAITING_INSTRUCTION)
+        self.assertEqual(latest_snapshot.comment, None)
         self.assertEqual(latest_snapshot.expiration_days, None)
         self.assertEqual(latest_snapshot.blocking_reasons, None)
 

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -637,7 +637,6 @@ class DeclarationRefuseVisaView(VisaDecisionView):
         declaration.create_snapshot(
             user=request.user,
             action=self.get_snapshot_action(request, declaration),
-            comment=declaration.post_validation_producer_message,
             post_validation_status=self.get_snapshot_post_validation_status(request, declaration),
         )
 

--- a/frontend/src/components/SnapshotItem.vue
+++ b/frontend/src/components/SnapshotItem.vue
@@ -19,7 +19,7 @@
     <div class="max-w-xl">
       <div :class="`flex ${rightSide ? 'justify-end' : 'justify-start'}`">
         <div
-          v-if="snapshot.comment"
+          v-if="showComment"
           :class="`comment italic mb-2 rounded-xl p-4 ${rightSide ? 'rounded-tr-none' : 'rounded-tl-none'}`"
         >
           {{ snapshot.comment }}
@@ -66,6 +66,8 @@ const isAdministrativeAction = computed(() => {
   ]
   return instructionActions.indexOf(props.snapshot.action) > -1
 })
+
+const showComment = computed(() => props.snapshot?.comment && props.snapshot?.action !== "REFUSE_VISA")
 
 const initials = computed(() => {
   if (!props.snapshot.user) return "?"


### PR DESCRIPTION
Closes #1519 

## Contexte

Les snapshots du refus de visa contiennent le commentaire à destination du pro que l'instructrice suggère d'ajouter. Lors d'un refus de visa, ce commentaire était affiché comme si c'était la viseuse qui l'avait mis.

## Fix

### Backend

Le problème venait de base de `DeclarationRefuseVisaView`. Lors de la création du snapshot pour le refus de visa on mettait dedant le commentaire de l'instructrice alors qu'il n'y a pas besoin. Ceci n'a pas d'autres conséquences car on ne s'en sert jamais, mais j'ai enlevé le commentaire de la création de ces snapshots.

### UI

Pour les déclarations qui ont déjà vu leur visa refusé j'ai ajouté une condition pour ne pas afficher le commentaire dans le front.

![image](https://github.com/user-attachments/assets/1b720703-01e7-427c-ad4d-851c17371331)

