### PR TITLE
Supprimer une erreur dans le console quand on commence une nouvelle déclaration

### DIFF
--- a/frontend/src/utils/forms.js
+++ b/frontend/src/utils/forms.js
@@ -43,6 +43,7 @@ export const transformArrayByColumn = (arr, numberOfColumns) => {
   Utile pour l'affichage des checkboxes dans des grilles de colonnes.
   */
   const result = []
+  if (!arr) return result
   const fullRows = Math.floor(arr.length / numberOfColumns) // Les rangées pleines
   const remainingItems = arr.length % numberOfColumns // Les éléments qui resterons dans une dernière rangée
 


### PR DESCRIPTION
Il y a une erreur quand cette méthode est utilisé dans PopulationsCheckboxes


```
Uncaught (in promise) TypeError: arr is undefined
    transformArrayByColumn forms.js:46
    populationsSections PopulationsCheckboxes.vue:39
```