### PR TITLE
Ne pas couper la liste d'ingrédients quand il y a pas d'autre ingrédient

### DIFF
--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -50,6 +50,7 @@
         :tab-titles="titles"
         v-model="selectedTabIndex"
         @update:modelValue="selectTab"
+        class="allow-overflow"
       >
         <div class="absolute opacity-50 bg-slate-200 inset-0 z-10 flex justify-center pt-20" v-if="requestInProgress">
           <ProgressSpinner />
@@ -363,3 +364,9 @@ const performDuplication = (originalDeclaration) => {
   payload.value.computedSubstances.forEach((x) => delete x.id)
 }
 </script>
+
+<style scoped>
+.allow-overflow {
+  overflow: visible;
+}
+</style>


### PR DESCRIPTION
Closes #964 

Problème : `.fr-tabs` a le style `overflow: hidden;`

Firefox :
![Screenshot from 2025-01-24 17-31-06](https://github.com/user-attachments/assets/74f7992e-762a-4b3b-843f-cb76124aade0)

