### PR TITLE
Rend le fond gris clair pour les instructrices

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,22 +1,24 @@
 <template>
-  <AppHeader :logo-text="logoText" />
-  <router-view></router-view>
-  <DsfrFooter
-    :logo-text="logoText"
-    :cookiesLink="{ name: 'CookiesInfoPage' }"
-    :legalLink="{ name: 'LegalNoticesPage' }"
-    :personalDataLink="{ name: 'PrivacyPolicyPage' }"
-    :afterMandatoryLinks="[{ label: 'Conditions générales d’utilisation', to: { name: 'CGUPage' } }]"
-  >
-    <template v-slot:description>
-      <p>Compl'Alim</p>
-    </template>
-  </DsfrFooter>
-  <AppToaster :messages="messages" @close-message="removeMessage($event)" />
+  <div :class="lowContrastMode ? '!bg-[#f6f6f6]' : ''">
+    <AppHeader :logo-text="logoText" />
+    <router-view></router-view>
+    <DsfrFooter
+      :logo-text="logoText"
+      :cookiesLink="{ name: 'CookiesInfoPage' }"
+      :legalLink="{ name: 'LegalNoticesPage' }"
+      :personalDataLink="{ name: 'PrivacyPolicyPage' }"
+      :afterMandatoryLinks="[{ label: 'Conditions générales d’utilisation', to: { name: 'CGUPage' } }]"
+    >
+      <template v-slot:description>
+        <p>Compl'Alim</p>
+      </template>
+    </DsfrFooter>
+    <AppToaster :messages="messages" @close-message="removeMessage($event)" />
+  </div>
 </template>
 
 <script setup>
-import { watch } from "vue"
+import { watch, computed } from "vue"
 import { useRoute } from "vue-router"
 import AppToaster from "@/components/AppToaster.vue"
 import useToaster from "@/composables/use-toaster"
@@ -30,6 +32,8 @@ watch(route, (to) => {
   const suffix = "Compl'Alim"
   document.title = to.meta.title ? to.meta.title + " - " + suffix : suffix
 })
+
+const lowContrastMode = computed(() => route.name === "InstructionPage")
 </script>
 
 <style>


### PR DESCRIPTION
Closes #1557

#### :information_source: Astuce : cacher le whitespace pour ce code-review

## Scope

Suite à la discussion sur les écrans des instructrices, cette PR rend le fond gris clair seulement dans la page d'instruction d'une déclaration.

J'ai du le faire au niveau du App.vue pour éviter que seulement l'encart central soit grisé.

## Démo

![image](https://github.com/user-attachments/assets/5f5a5ffc-cacc-4097-9b18-2a1948c136bb)
