### PR TITLE
Fix(Open-Data): Corriger creation champ schema et l'appel au label des articles

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -402,7 +402,7 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
         ]:
             return "Article 15"
         elif obj.article:
-            return obj.article.label
+            return Declaration.Article(obj.article).label
 
     def get_forme_galenique(self, obj):
         return add_enum_or_personnalized_value(obj.galenic_formulation, obj.other_galenic_formulation)

--- a/data/etl/extractor.py
+++ b/data/etl/extractor.py
@@ -99,7 +99,7 @@ class DECLARATIONS(EXTRACTOR):
     def __init__(self):
         super().__init__()
         self.dataset_name = "declarations"
-        self.schema = json.load(open("data/schemas/schema_declarations.json"))["schema"]
+        self.schema = json.load(open("data/schemas/schema_declarations.json"))
         self.schema_url = (
             "https://github.com/betagouv/complements-alimentaires/blob/staging/data/schemas/schema_declarations.json"
         )


### PR DESCRIPTION
* L'appel au schéma n'était pas compatible avec le nouveau schéma compatible avec TableSchema 
* Une erreur dans la colonne article_procedure, dans laquelle le `.label` n'était pas appelé sur le bon objet