### PR TITLE
:lady_beetle: Fix ProgrammingError à cause du champ id manquant dans les modèles Ica_ sans primary_key

### DIFF
--- a/data/models/teleicare_history/ica_declaration.py
+++ b/data/models/teleicare_history/ica_declaration.py
@@ -100,7 +100,11 @@ class IcaVersionDeclaration(models.Model):
 
 
 class IcaPopulationCibleDeclaree(models.Model):
-    vrsdecl_ident = models.IntegerField()
+    vrsdecl_ident = models.IntegerField(
+        primary_key=True
+    )  # ce champ n'est en réalité pas une primary key, car la primary key est composite.
+    # Django ne permet pas de créer des clés composites et nécessite la création d'un champ id, si ce champ n'est pas spécifié comme primary_key
+    # Comme le modèle est unmanaged, cette contrainte ne change rien en BDD
     popcbl_ident = models.IntegerField()
     vrspcb_popcible_autre = models.TextField(blank=True, null=True)
 
@@ -111,7 +115,7 @@ class IcaPopulationCibleDeclaree(models.Model):
 
 
 class IcaPopulationRisqueDeclaree(models.Model):
-    vrsdecl_ident = models.IntegerField()
+    vrsdecl_ident = models.IntegerField(primary_key=True)  # idem IcaPopulationCibleDeclaree
     poprs_ident = models.IntegerField()
     vrsprs_poprisque_autre = models.TextField(blank=True, null=True)
 
@@ -122,7 +126,7 @@ class IcaPopulationRisqueDeclaree(models.Model):
 
 
 class IcaEffetDeclare(models.Model):
-    vrsdecl_ident = models.IntegerField()
+    vrsdecl_ident = models.IntegerField(primary_key=True)  # idem IcaPopulationCibleDeclaree
     objeff_ident = models.IntegerField()
     vrs_autre_objectif = models.TextField(blank=True, null=True)
 

--- a/data/models/teleicare_history/ica_declaration_composition.py
+++ b/data/models/teleicare_history/ica_declaration_composition.py
@@ -53,7 +53,7 @@ class IcaPreparation(models.Model):
 
 
 class IcaSubstanceDeclaree(models.Model):
-    vrsdecl_ident = models.IntegerField()
+    vrsdecl_ident = models.IntegerField(primary_key=True)  # idem IcaPopulationCibleDeclaree
     sbsact_ident = models.IntegerField()
     sbsact_commentaires = models.TextField(blank=True, null=True)
     sbsactdecl_quantite_par_djr = models.FloatField(blank=True, null=True)


### PR DESCRIPTION
Dans [1482](https://github.com/betagouv/complements-alimentaires/pull/1482), j'ai modifié les modèles générés automatiquement par un `inspectdb` qui faisaient porter la contrainte `primary_key=True` sur un champ unique au lieu que ce soit une primary_key composite.

Les primary_key composites n'existent pas avec Django.
Mais en supprimant cette contrainte Django cherche un champ primary_key par défault `id` qui n'existe pas dans la table -> `ProgrammingError`

Comme c'est un modèle unmanaged, alors l'incohérence entre les contraintes réelles dans PostgreSQL et les modèles Django ne sont pas impactantes.