### PR TITLE
Corrige la regression pour les paramètres de filtrage après une décision d'instruction

### DIFF
--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -126,7 +126,8 @@ import DeclarationFromTeleicareAlert from "@/components/History/DeclarationFromT
 
 const router = useRouter()
 const route = useRoute()
-const previousRoute = router.getPreviousRoute()
+const previousQueryParams =
+  router.getPreviousRoute().value.name === "InstructionDeclarations" ? router.getPreviousRoute().value.query : {}
 
 const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
@@ -227,8 +228,7 @@ const instructDeclaration = async () => {
 }
 
 const onDecisionDone = () => {
-  const previousQuery = previousRoute.value.name === "InstructionDeclarations" ? previousRoute.value.query : {}
-  router.push({ name: "InstructionDeclarations", query: previousQuery })
+  router.push({ name: "InstructionDeclarations", query: previousQueryParams })
 }
 </script>
 


### PR DESCRIPTION
Closes #1590 

## Contexte

Après la décision des instructrices on doit retourner à la page listant les déclarations avec les filtres précédemment choisis activés.

Or, depuis la release 1.55.0 ce n'est plus le cas.

## Cause de la régression

On utilisait la ligne `const previousRoute = router.getPreviousRoute()` pour sauvegarder la route d'où _frontend/src/views/InstructionPage/index.vue_ venait.  Cette ligne assigne une `ref` réactive à la constante `previousRoute`.

Ceci marchait car à l'intérieur de `InstructionPage` on ne changait pas de route, donc au moment d'obtenir le `.value` de ladite ref, on obtenait toujours la valeur qui nous intéresse.

Or, depuis le changement qui ajoute des éléments à l'historique lors qu'on change d'onglets, l'évaluation de `previousRoute.value` arrivait trop tard. La route précédente n'était plus la liste de déclarations mais un autre onglet.

## Solution

C'est plus simple de stocker dans la constante directement les queryparams de la page précédente (si cette page est bien la liste de déclarations). En évaluant `.value` à la racine du _script setup_ on est sur qu'on est au bon moment.

```javascript
const previousQueryParams =
  router.getPreviousRoute().value.name === "InstructionDeclarations" ? router.getPreviousRoute().value.query : {}
```