### PR TITLE
Enlève des warnings eslint dans le processus de build frontend

### DIFF
--- a/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
@@ -16,7 +16,6 @@ import { timeAgo } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
 import CompanyTableCell from "@/components/CompanyTableCell"
 import DeclarationName from "@/components/DeclarationName.vue"
-import HistoryBadge from "@/components/History/HistoryBadge.vue"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 

--- a/frontend/src/views/DeclaredElementPage/index.vue
+++ b/frontend/src/views/DeclaredElementPage/index.vue
@@ -69,7 +69,7 @@ const breadcrumbLinks = computed(() => {
 
 // Init
 const url = computed(() => `/api/v1/declared-elements/${getApiType(props.type)}/${props.id}`)
-const onFetchError = ({ error, data, response, context, execute }) => {
+const onFetchError = ({ error, data }) => {
   addErrorMessage("Une erreur est survenu. Merci de réessayer ultérieurement.")
   return { error, data }
 }


### PR DESCRIPTION
Closes #1592 

Enlève les warnings `eslint` :

```bash
 WARNING  Compiled with 1 warning 

[eslint] 
/complements-alimentaires/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
  19:8  warning  'HistoryBadge' is defined but never used  no-unused-vars

/complements-alimentaires/frontend/src/views/DeclaredElementPage/index.vue
  72:38  warning  'response' is defined but never used  no-unused-vars
  72:48  warning  'context' is defined but never used   no-unused-vars
  72:57  warning  'execute' is defined but never used   no-unused-vars

✖ 4 problems (0 errors, 4 warnings)


You may use special comments to disable some warnings.
Use // eslint-disable-next-line to ignore the next line.
Use /* eslint-disable */ to ignore all warnings in a file.
```