### PR TITLE
Change la colonne « date de modification » par « date de création » dans le tableau des pros

### DIFF
--- a/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
@@ -20,7 +20,7 @@ import HistoryBadge from "@/components/History/HistoryBadge.vue"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 
-const headers = ["ID", "Nom du produit", "Entreprise", "Auteur", "État", "Date de création", "Date de modification"]
+const headers = ["ID", "Nom du produit", "Entreprise", "Auteur", "État", "Date de création"]
 const rows = computed(() =>
   props.data?.results?.map((x) => ({
     rowData: [
@@ -39,7 +39,6 @@ const rows = computed(() =>
       x.author ? `${x.author.firstName} ${x.author.lastName}` : "",
       getStatusTagForCell(x.status, true),
       timeAgo(x.creationDate),
-      timeAgo(x.modificationDate),
     ],
   }))
 )

--- a/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
+++ b/frontend/src/views/DeclarationsHomePage/DeclarationsTable.vue
@@ -24,7 +24,7 @@ const emit = defineEmits("open")
 // Les données pour la table
 const headers = computed(() => {
   if (useShortTable.value) return ["Nom", "État"]
-  return ["ID", "Nom du produit", "Entreprise", "Déclarant·e", "État", "Date de modification", ""]
+  return ["ID", "Nom du produit", "Entreprise", "Déclarant·e", "État", "Date de création", ""]
 })
 
 const rows = computed(() => {
@@ -54,7 +54,7 @@ const rows = computed(() => {
       },
       d.author ? `${d.author.firstName} ${d.author.lastName}` : "",
       getStatusTagForCell(d.status, true),
-      timeAgo(d.modificationDate),
+      timeAgo(d.creationDate),
       d.teleicareId
         ? ""
         : {


### PR DESCRIPTION
Closes #1558 

## Scope

Changement simple de la colonne « date de modification » par « date de création ».

@HeleneDubourdieu par la suite on pourrait envisager d'avoir le même système de triage que celui pour l'instruction (par nom, par type, etc).

![image](https://github.com/user-attachments/assets/b44a3eb2-8e40-4e66-859e-50fc840c6ba7)
