### PR TITLE
Permet à une instructrice de s'attribuer une déclaration attribuée à une autre instructrice

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -149,6 +149,11 @@ urlpatterns = {
         views.DeclarationTakeAuthorshipView.as_view(),
         name="take_authorship",
     ),
+    path(
+        "declarations/<int:pk>/assign-instruction/",
+        views.DeclarationAssignInstruction.as_view(),
+        name="assign_instruction",
+    ),
     # Flow de la déclaration (state machine)
     path("declarations/<int:pk>/submit/", views.DeclarationSubmitView.as_view(), name="submit_declaration"),
     path(

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -21,6 +21,7 @@ from .declaration.declaration import (
     DeclarationAcceptVisaView,
     DeclarationWithdrawView,
     DeclarationTakeAuthorshipView,
+    DeclarationAssignInstruction,
     ArticleChangeView,
 )
 from .declaration.declared_element import (

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -390,6 +390,27 @@ class DeclarationTakeAuthorshipView(GenericAPIView):
         return Response(serializer.data)
 
 
+class DeclarationAssignInstruction(GenericAPIView):
+    """
+    Contrairement à `DeclarationTakeForInstructionView`, cette view ne change pas
+    le statut de la déclaration, elle sert simplement à transférer l'instruction d'un
+    dossier à l'instrutrice faisant la requête
+    """
+
+    serializer_class = SimpleDeclarationSerializer
+    permission_classes = [IsInstructor]
+    queryset = Declaration.objects.all()
+
+    def post(self, request, pk):
+        declaration = self.get_object()
+
+        declaration.instructor = request.user.instructionrole
+        declaration.save()
+        declaration.refresh_from_db()
+        serializer = self.get_serializer(declaration)
+        return Response(serializer.data)
+
+
 class ArticleChangeView(GenericAPIView):
     permission_classes = [(IsInstructor | IsVisor)]
     serializer_class = DeclarationSerializer

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -25,6 +25,15 @@
         <p>Vous pouvez vous assigner cette déclaration pour instruction</p>
         <DsfrButton class="mt-2" label="Instruire" tertiary @click="instructDeclaration" />
       </DsfrAlert>
+      <DsfrAlert
+        class="mb-4"
+        v-else-if="declaration.instructor && declaration.instructor.id !== loggedUser.id"
+        type="info"
+        :title="`Cette déclaration est assignée à ${declaration.instructor.firstName} ${declaration.instructor.lastName}`"
+      >
+        <p>Vous pouvez vous assigner cette déclaration pour instruction</p>
+        <DsfrButton class="mt-2" label="M'assigner cette déclaration" tertiary @click="assignInstruction" />
+      </DsfrAlert>
       <DeclarationAlert
         class="mb-6"
         v-else-if="!canInstruct && !declaration.siccrfId"
@@ -123,6 +132,7 @@ import DeclarationAlert from "@/components/DeclarationAlert"
 import { tabTitles } from "@/utils/mappings"
 import { useRouter, useRoute } from "vue-router"
 import DeclarationFromTeleicareAlert from "@/components/History/DeclarationFromTeleicareAlert.vue"
+import useToaster from "@/composables/use-toaster"
 
 const router = useRouter()
 const route = useRoute()
@@ -216,6 +226,17 @@ const titles = computed(() => tabTitles(components.value))
 
 const selectedTabIndex = ref(parseInt(route.query.tab))
 const selectTab = async (index) => router.replace({ query: { tab: index } })
+
+const assignInstruction = async () => {
+  const url = `/api/v1/declarations/${props.declarationId}/assign-instruction/`
+  const { response } = await useFetch(url, { headers: headers() }).post({}).json()
+  $externalResults.value = await handleError(response)
+
+  if (response.value.ok) {
+    await executeDeclarationFetch()
+    useToaster().addSuccessMessage("La déclaration vous a été assignée")
+  }
+}
 
 const instructDeclaration = async () => {
   const url = `/api/v1/declarations/${props.declarationId}/take-for-instruction/`


### PR DESCRIPTION
Closes #1289

## Context

Une instructrice peut faire l'instruction d'une déclaration assignée à quelqu'une d'autre. À la suite de ceci, la déclaration sera assignée à la dernière instructrice ayant effectué une action sur la déclaration.

Par contre, ce n'est pas aujourd'hui possible de s'assigner une déclaration sans effectuer une action du flow dessus.

Cette PR ajoute cette fonctionnalité : une instructrice peut reprendre une instruction assignée à une autre sans changer le statut de la déclaration.

## Scope

Cette feature est très similaire à la vue `DeclarationTakeAuthorshipView`, ou un·e pro peut prendre le dossier d'un collègue.

### Backend

Cette PR crée donc la vue API `DeclarationAssignInstruction`, disponible seulement pour les instructrices.

### Frontend

Une alerte est affichée lors que la déclaration a déjà une instructrice mais que cette instructrice est différente à la personne identifiée. Le bouton appelle simplement la nouvelle vue API.

## Démo

https://github.com/user-attachments/assets/95329ac6-7088-4f50-b96a-2ec3b6a490b5


