### PR TITLE
Changement d'adresse email pour les courriers en PDF

### DIFF
--- a/web/templates/certificates/certificate-base-template.html
+++ b/web/templates/certificates/certificate-base-template.html
@@ -51,7 +51,7 @@
 
                         BEPIAS (Bureau des Etablissements et Produits des<br />
                         Industries Alimentaires Spécialisées)<br />
-                        Mél : <a href="mailto:contact@compl-alim.beta.gouv.fr">contact@compl-alim.beta.gouv.fr</a><br />
+                        Mél : <a href="mailto:bepias.sdssa.dgal@agriculture.gouv.fr">bepias.sdssa.dgal@agriculture.gouv.fr</a><br />
                 </td>
                 <td align="right" style="font-size: 1.2em;">
                     Paris, le {{ date|date:"l j F Y" }}


### PR DESCRIPTION
Closes #1610 

Le changement d'adresse email se fait dans l'entête partagée `certificate-base-template`, de façon à que tous les documents PDF aient la nouvelle adresse : 

![image](https://github.com/user-attachments/assets/9eaa4443-210a-4344-8d37-d3177d7ec9d0)
