### PR TITLE
N'affiche pas l'encart "Article Inconnu" pour le pro

### DIFF
--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -5,6 +5,7 @@
       v-model="payload"
       :hideArticle15Subtypes="!allowArticleChange"
       :allowChange="allowArticleChange"
+      v-if="allowArticleChange || payload.article"
       class="mb-2"
     />
     <div v-if="useCompactAttachmentView">


### PR DESCRIPTION
Lié à #1609 

Pour les pros, l'encart sur l'article n'est pas affiché lors que l'article est inconnu : 

![image](https://github.com/user-attachments/assets/3828b4d1-8d85-428a-9145-69e297651b2a)


Dans le cas d'un _Article Inconnu_ pour l'instruction, on voit bien l'encart :

![image](https://github.com/user-attachments/assets/218bdb41-2bea-49ef-ac61-50013e2ad4b8)

----

Par la suite on pourrait déclencher le calcul de l'article avant de sorte à l'afficher dans l'onglet résumé même quand la déclaration est en état brouillon.  