### PR TITLE
Permet de calculer l'article même quand celui-ci est en brouillon

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -651,18 +651,39 @@ class DeclarationSerializer(serializers.ModelSerializer):
         )
         return queryset
 
+    @property
+    def should_calculate_article(self):
+        """
+        Pour ne pas calculer l'article à chaque changement, nous le calculons seulement si
+        le queryparam force-article-calculation=true est présent dans l'URL de la requête
+        """
+        request = self.context.get("request")
+        return request and request.query_params.get("force-article-calculation", "").lower() == "true"
+
+    def calculate_article(self, declaration):
+        declaration.refresh_from_db()  # Besoin de ce refresh pour prendre en compte les changements sur la compo
+        declaration.assign_calculated_article()
+        declaration.save()
+        declaration.refresh_from_db()  # Besoin de ce refresh pour le generated field "article"
+
     def create(self, validated_data):
         # DRF ne gère pas automatiquement la création des nested-fields :
         # https://www.django-rest-framework.org/api-guide/serializers/#writable-nested-representations
         if self.context.get("request"):
             validated_data["author"] = self.context.get("request").user
 
-        return self._assign_declared_items(None, validated_data)
+        declaration = self._assign_declared_items(None, validated_data)
+        if self.should_calculate_article:
+            self.calculate_article(declaration)
+        return declaration
 
     def update(self, instance, validated_data):
         # DRF ne gère pas automatiquement la création des nested-fields :
         # https://www.django-rest-framework.org/api-guide/serializers/#writable-nested-representations
-        return self._assign_declared_items(instance, validated_data)
+        declaration = self._assign_declared_items(instance, validated_data)
+        if self.should_calculate_article:
+            self.calculate_article(declaration)
+        return declaration
 
     def _assign_declared_items(self, instance, validated_data):
         """

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -264,6 +264,55 @@ class TestDeclarationApi(APITestCase):
         self.assertEqual(new_declared_plant.preparation.name, "Autre macérât")
 
     @authenticate
+    def test_create_declaration_calculate_article(self):
+        """
+        Il est possible d'ajouter un query_param pour forcer le calcul de l'article
+        dans la sauvegarde
+        """
+        declarant_role = DeclarantRoleFactory(user=authenticate.user)
+        company = declarant_role.company
+
+        plant = PlantFactory()
+        plant_part = PlantPartFactory()
+        plant.plant_parts.add(plant_part)
+        unit = SubstanceUnitFactory()
+        preparation_autre = PreparationFactory(ca_name="Autre macérât")
+
+        payload = {
+            "name": "Name",
+            "company": company.id,
+            "declaredPlants": [
+                {
+                    "newName": "New plant name",
+                    "newDescription": "New plant description",
+                    "new": True,
+                    "active": True,
+                    "usedPart": plant_part.id,
+                    "quantity": "890",
+                    "preparation": preparation_autre.id,
+                    "unit": unit.id,
+                },
+            ],
+        }
+        # Une requête normale ne calculera pas l'article
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id}), payload, format="json"
+        )
+        declaration = Declaration.objects.get(pk=response.json()["id"])
+        self.assertIsNone(declaration.article)
+
+        # Maintenant on fait une requête mais en spécifiant qu'on veut recalculer l'article avec
+        # le query parameter force-article-calculation=true
+        response = self.client.post(
+            reverse("api:list_create_declaration", kwargs={"user_pk": authenticate.user.id})
+            + "?force-article-calculation=true",
+            payload,
+            format="json",
+        )
+        declaration = Declaration.objects.get(pk=response.json()["id"])
+        self.assertEqual(declaration.article, Declaration.Article.ARTICLE_16)
+
+    @authenticate
     def test_create_declaration_unknown_plant(self):
         """
         Si la plante spécifié n'existe pas, on doit lever une erreur
@@ -822,6 +871,49 @@ class TestDeclarationApi(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         user_declaration.refresh_from_db()
         self.assertEqual(user_declaration.name, "New name")
+
+    @authenticate
+    def test_update_single_declaration_calculating_article(self):
+        """
+        Il est possible d'ajouter un query_param pour forcer le calcul de l'article
+        dans la sauvegarde
+        """
+        declarant_role = DeclarantRoleFactory(user=authenticate.user)
+        company = declarant_role.company
+        user_declaration = DeclarationFactory(author=authenticate.user, name="Old name", company=company)
+
+        payload = {
+            "name": "New name",
+            "company": user_declaration.company.id,
+            "declaredPlants": [
+                {
+                    "active": True,
+                    "new": True,
+                    "newDescription": "as",
+                    "newName": "as",
+                    "newType": "plant",
+                },
+            ],
+        }
+        # Une requête normale ne calculera pas l'article
+        self.client.put(
+            reverse("api:retrieve_update_destroy_declaration", kwargs={"pk": user_declaration.id}),
+            payload,
+            format="json",
+        )
+        user_declaration.refresh_from_db()
+        self.assertIsNone(user_declaration.article)
+
+        # Maintenant on fait une requête mais en spécifiant qu'on veut recalculer l'article avec
+        # le query parameter force-article-calculation=true
+        self.client.put(
+            reverse("api:retrieve_update_destroy_declaration", kwargs={"pk": user_declaration.id})
+            + "?force-article-calculation=true",
+            payload,
+            format="json",
+        )
+        user_declaration.refresh_from_db()
+        self.assertEqual(user_declaration.article, Declaration.Article.ARTICLE_16)
 
     @authenticate
     def test_update_single_declaration_supervisor(self):
@@ -1915,7 +2007,7 @@ class TestDeclaredElementsApi(APITestCase):
     @authenticate
     def test_fields_hidden_from_declarant(self):
         """
-        La déclaration doit pas contenir les champs statut et notes privés pour des ingrédients
+        La déclaration ne doit pas contenir les champs statut et notes privés pour des ingrédients
         si l'user est un déclarant
         """
         DeclarantRoleFactory(user=authenticate.user)

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -144,10 +144,10 @@ const selectedTabIndex = ref(parseInt(route.query.tab))
 const selectTab = async (index) => {
   if (requestInProgress.value) return
 
-  // Si on vient du `CompositionTab` on calcule l'article. Ceci est un workaround pour éviter
+  // Si va vers le `SummaryTab` on calcule l'article. Ceci est un workaround pour éviter
   // de calculer l'article dans le backend à chaque modification (ça peut être cher en termes
   // de performance).
-  const forceArticleCalculation = components.value[previouslySelectedTabIndex.value] === CompositionTab
+  const forceArticleCalculation = !readonly.value && components.value[index] === SummaryTab
   const allowTransition = readonly.value || (await savePayload({ forceArticleCalculation }))
   if (allowTransition) {
     router.replace({ query: { tab: index } })


### PR DESCRIPTION
Closes #1609 

## Contexte

Le calcul de l'article se faisait précédemment à chaque changement de la déclaration (des champs `declared_`). Ceci était trop cher en termes de performance car la sérialisation des endpoints API déclenchait ce calcul très souvent.

Par la suite, on s'est rendu compte qu'on n'avait pas besoin de l'information de l'article à chaque sauvegarde - seulement lors que la déclaration changait de statut (de _brouillon_ -> _en attente d'instruction_ par exemple). Le pro ne voyait jamais l'article.

Or, depuis une story qui montre l'information de l'article au pro aussi, on a du se re-poser la question de comment calculer l'article sans avoir des soucis de perf.

## Scope

### Workaround : Expliciter dans les endpoints API quand calculer l'article

Le calcul de l'article a du sens seulement lors qu'on affiche l'article au pro. On peut dire que la requête de sauvegarde qui se lance en changeant l'onglet _vers_ le `SummaryTab` doit calculer l'article.

Le workaround consiste à ajouter le queryparam `"?force-article-calculation=true"` à la requête lors qu'on veut ce calcul dans la réponse.

### Serializer

L'endroit idéal pour traiter ce queryparam est le serializer car la vue traite l'instance Déclaration d'un trait. Des modifications à faire _après_ que le serializer ait sauvegardé les changements doivent se faire au niveau du serializer pour qu'ils soient inclus dans la réponse.

### Frontend

La fonction ```const selectTab = async (index) => {...}``` est appelée pourles changements d'onglet. À l'intérieur on peut donc savoir de quel onglet on vient, et à quelle onglet l'usager veut aller.

On peut donc mettre le queryparam `"?force-article-calculation=true"` lors qu'on vient de la composition.

## Démo

https://github.com/user-attachments/assets/8630ffbc-e220-47b7-8b9f-062a25762137

