### PR TITLE
Admin, pièces jointes : afficher dans la liste si le fichier est manquant

### DIFF
--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -46,6 +46,7 @@ class AttachmentAdmin(SimpleHistoryAdmin):
         "type",
         "declaration__name",
         "declaration__id",
+        "has_file",
     )
 
     search_fields = (
@@ -64,6 +65,11 @@ class AttachmentAdmin(SimpleHistoryAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    # ça devrait pas arriver mais on avait un bug, et ça nous aide de le régler
+    # https://github.com/betagouv/complements-alimentaires/issues/1655
+    def has_file(self, obj):
+        return "✅ Oui" if obj.file else "❌ Non"
 
 
 # Declared Plants inline


### PR DESCRIPTION
![Screenshot 2025-02-20 at 15-07-40 Sélectionnez l’objet pièce jointe à changer Compl'Alim](https://github.com/user-attachments/assets/4615da02-13b3-430c-b448-d4bc2d05e2c8)
