### PR TITLE
Permettre le filtrage de demandes par statut

### DIFF
--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -41,6 +41,7 @@ from data.factories import (
 from data.models import (
     Attachment,
     Declaration,
+    Addable,
     DeclaredMicroorganism,
     DeclaredPlant,
     DeclaredSubstance,
@@ -1853,6 +1854,35 @@ class TestDeclaredElementsApi(APITestCase):
         response = self.client.get(reverse("api:list_new_declared_elements"), format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    @authenticate
+    def test_filter_by_request_status(self):
+        """
+        La liste de demandes peut être filtrer par un ou plusieurs statuts de la demande
+        """
+        InstructionRoleFactory(user=authenticate.user)
+
+        declaration = DeclarationFactory(status=Declaration.DeclarationStatus.AWAITING_INSTRUCTION)
+        draft = DeclarationFactory(status=Declaration.DeclarationStatus.DRAFT)
+
+        plant = DeclaredPlantFactory(new=True, declaration=declaration, request_status=Addable.AddableStatus.REQUESTED)
+        DeclaredSubstanceFactory(new=True, declaration=declaration, request_status=Addable.AddableStatus.INFORMATION)
+        DeclaredMicroorganismFactory(new=True, declaration=declaration, request_status=Addable.AddableStatus.REJECTED)
+        ingredient = DeclaredIngredientFactory(
+            new=False, declaration=declaration, request_status=Addable.AddableStatus.REPLACED
+        )
+        # don't return ones attached to draft declarations
+        DeclaredIngredientFactory(new=True, declaration=draft, request_status=Addable.AddableStatus.REQUESTED)
+
+        filter_url = f"{reverse('api:list_new_declared_elements')}?requestStatus=REQUESTED,REPLACED"
+        response = self.client.get(filter_url, format="json")
+        results = response.json()
+        self.assertEqual(results["count"], 2)
+        returned_ids = [results["results"][0]["id"], results["results"][1]["id"]]
+        self.assertIn(returned_ids, plant.id)
+        self.assertIn(returned_ids, ingredient.id)
+
+
+class TestSingleDeclaredElementApi(APITestCase):
     @authenticate
     def test_get_single_declared_plant(self):
         InstructionRoleFactory(user=authenticate.user)

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -1878,8 +1878,8 @@ class TestDeclaredElementsApi(APITestCase):
         results = response.json()
         self.assertEqual(results["count"], 2)
         returned_ids = [results["results"][0]["id"], results["results"][1]["id"]]
-        self.assertIn(returned_ids, plant.id)
-        self.assertIn(returned_ids, ingredient.id)
+        self.assertIn(plant.id, returned_ids)
+        self.assertIn(ingredient.id, returned_ids)
 
 
 class TestSingleDeclaredElementApi(APITestCase):

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -1,5 +1,6 @@
 import abc
 from django.db import transaction
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from rest_framework.exceptions import ParseError
 from rest_framework.generics import ListAPIView, RetrieveAPIView
@@ -26,6 +27,7 @@ from api.serializers import (
 )
 from api.permissions import IsInstructor, IsVisor
 from itertools import chain
+from functools import reduce
 
 
 class DeclaredElementsPagination(LimitOffsetPagination):
@@ -39,20 +41,37 @@ class DeclaredElementsView(ListAPIView):
     permission_classes = [(IsInstructor | IsVisor)]
 
     def get_queryset(self):
+        request_statuses = self.request.query_params.get("requestStatus")
+        request_status_filter = Q(new=True)  # by default, only show new elements
+        if request_statuses:
+            request_statuses = request_statuses.split(",")
+            request_status_queries = [DeclaredElementsView.get_query_for_request_status(r) for r in request_statuses]
+            request_status_filter = reduce(lambda x, y: x | y, request_status_queries)
+
         closed_statuses = [
             Declaration.DeclarationStatus.DRAFT,
             Declaration.DeclarationStatus.ABANDONED,
             Declaration.DeclarationStatus.REJECTED,
             Declaration.DeclarationStatus.WITHDRAWN,
         ]
-        return list(
-            chain(
-                DeclaredPlant.objects.filter(new=True).exclude(declaration__status__in=closed_statuses),
-                DeclaredSubstance.objects.filter(new=True).exclude(declaration__status__in=closed_statuses),
-                DeclaredIngredient.objects.filter(new=True).exclude(declaration__status__in=closed_statuses),
-                DeclaredMicroorganism.objects.filter(new=True).exclude(declaration__status__in=closed_statuses),
-            )
-        )
+        querysets = [
+            DeclaredPlant.objects,
+            DeclaredSubstance.objects,
+            DeclaredIngredient.objects,
+            DeclaredMicroorganism.objects,
+        ]
+        filtered_querysets = [
+            queryset.filter(request_status_filter).exclude(declaration__status__in=closed_statuses)
+            for queryset in querysets
+        ]
+        return list(chain(*filtered_querysets))
+
+    @staticmethod
+    def get_query_for_request_status(status):
+        if status == "REQUESTED":
+            return Q(new=True) & Q(request_status=status)
+        else:
+            return Q(request_status=status)
 
 
 TYPE_MAPPING = {

--- a/data/models/__init__.py
+++ b/data/models/__init__.py
@@ -28,6 +28,7 @@ from .declaration import (
     DeclaredSubstance,
     ComputedSubstance,
     Attachment,
+    Addable,
 )
 from .solicitation import SupervisionClaim, CompanyAccessClaim, CollaborationInvitation
 from .snapshot import Snapshot

--- a/frontend/src/components/MultiselectFilter.vue
+++ b/frontend/src/components/MultiselectFilter.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <DsfrModal :opened="opened" @close="opened = false">
+      <DsfrCheckboxSet v-model="selectedOptions" :options="options" />
+    </DsfrModal>
+    <p class="!mb-2">
+      {{ filterTitle }}
+
+      <span v-if="selectedOptions.length">
+        <DsfrTag
+          class="mr-2 mt-1"
+          v-for="option in selectedOptions"
+          :key="`filter-opt-${option}`"
+          :label="findLabel(option)"
+          small
+        />
+      </span>
+    </p>
+    <p>
+      <DsfrButton @click="opened = true" tertiary size="small" label="Changer" />
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { watch, ref, onMounted } from "vue"
+const emit = defineEmits(["updateFilter"])
+
+const props = defineProps({
+  options: { type: Array },
+  selectedString: { type: String, required: false },
+  filterTitle: { type: String },
+})
+const selectedOptions = ref([])
+const opened = ref(false)
+
+onMounted(() => (selectedOptions.value = props.selectedString ? props.selectedString.split(",") : []))
+watch(selectedOptions, () => emit("updateFilter", selectedOptions.value.join(",")))
+
+const findLabel = (value) => {
+  const option = props.options.find((o) => o.value === value)
+  return option?.tagLabel || option?.label
+}
+</script>

--- a/frontend/src/components/MultiselectFilter.vue
+++ b/frontend/src/components/MultiselectFilter.vue
@@ -15,6 +15,9 @@
           small
         />
       </span>
+      <span v-else-if="noFilterText">
+        <DsfrTag class="ml-2 mt-1" label="Toutes les déclarations" small />
+      </span>
     </p>
     <p>
       <DsfrButton @click="opened = true" tertiary size="small" label="Changer" />
@@ -30,6 +33,7 @@ const props = defineProps({
   options: { type: Array },
   selectedString: { type: String, required: false },
   filterTitle: { type: String },
+  noFilterText: { type: String, required: false },
 })
 const selectedOptions = ref([])
 const opened = ref(false)

--- a/frontend/src/components/StatusFilter.vue
+++ b/frontend/src/components/StatusFilter.vue
@@ -1,41 +1,29 @@
 <template>
   <div>
-    <DsfrModal :opened="opened" @close="opened = false">
-      <DsfrCheckboxSet v-model="statuses" :options="options" />
-    </DsfrModal>
-    <p class="!mb-2">
-      Types de déclaration affichés :
-
-      <span v-if="statuses.length">
-        <DsfrTag
-          class="mr-2 mt-1"
-          v-for="status in statuses"
-          :key="`status-${status}`"
-          :label="statusProps[status].label"
-          small
-        />
-      </span>
-      <span v-else>
-        <DsfrTag class="ml-2 mt-1" label="Toutes les déclarations" small />
-      </span>
-    </p>
-    <p>
-      <DsfrButton @click="opened = true" tertiary size="small" label="Changer" />
-    </p>
+    <MultiselectFilter
+      :options="options"
+      :selectedString="statusString"
+      filterTitle="Types de déclaration affichés :"
+      noFilterText="Toutes les déclarations"
+      @updateFilter="emitUpdate"
+    />
   </div>
 </template>
 
 <script setup>
-import { watch, ref, onMounted } from "vue"
+import { ref, onMounted } from "vue"
 import { statusProps } from "@/utils/mappings"
+import MultiselectFilter from "./MultiselectFilter"
 const emit = defineEmits(["updateFilter"])
-const statusString = defineModel()
-const props = defineProps({ exclude: { type: Array, default: Array }, groupInstruction: { type: Boolean } })
+const props = defineProps({
+  exclude: { type: Array, default: Array },
+  groupInstruction: { type: Boolean },
+  statusString: { type: String },
+})
 const statuses = ref([])
-const opened = ref(false)
 
-onMounted(() => (statuses.value = statusString.value ? statusString.value.split(",") : []))
-watch(statuses, () => emit("updateFilter", statuses.value.join(",")))
+onMounted(() => (statuses.value = props.statusString ? props.statusString.split(",") : []))
+const emitUpdate = (v) => emit("updateFilter", v)
 
 const baseFilterOptions = [
   { value: "DRAFT", label: "Brouillon" },
@@ -63,5 +51,5 @@ const statusFilterOptions = props.groupInstruction
 
 const options = statusFilterOptions
   .filter((x) => props.exclude.indexOf(x.value) === -1)
-  .map((x) => ({ label: x.label, value: x.value }))
+  .map((x) => ({ label: x.label, value: x.value, tagLabel: statusProps[x.value].label }))
 </script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -328,9 +328,7 @@ const routes = [
       authenticationRequired: true,
       defaultQueryParams: {
         page: 1,
-        nom: "",
-        type: "",
-        triage: "-creationDate",
+        statut: "REQUESTED,INFORMATION",
         limit: "10",
       },
     },

--- a/frontend/src/views/CompanyDeclarationsPage/index.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/index.vue
@@ -41,7 +41,7 @@
         :exclude="['DRAFT']"
         class="max-w-xl"
         @updateFilter="updateStatusFilter"
-        v-model="filteredStatus"
+        :statusString="filteredStatus"
         :groupInstruction="true"
       />
     </div>

--- a/frontend/src/views/DeclarationsHomePage/index.vue
+++ b/frontend/src/views/DeclarationsHomePage/index.vue
@@ -51,7 +51,7 @@
       <StatusFilter
         class="max-w-lg"
         @updateFilter="updateStatusFilter"
-        v-model="filteredStatus"
+        :statusString="filteredStatus"
         :groupInstruction="true"
       />
     </div>

--- a/frontend/src/views/InstructionDeclarationsPage/index.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/index.vue
@@ -50,7 +50,7 @@
           </DsfrFieldset>
         </div>
       </div>
-      <StatusFilter :exclude="['DRAFT']" @updateFilter="updateStatusFilter" v-model="filteredStatus" />
+      <StatusFilter :exclude="['DRAFT']" @updateFilter="updateStatusFilter" :statusString="filteredStatus" />
       <div class="min-w-96 md:border-l">
         <div class="md:pl-4 min-w-36 flex flex-row gap-4">
           <div class="w-2/4">

--- a/frontend/src/views/NewElementsPage/NewElementsTable.vue
+++ b/frontend/src/views/NewElementsPage/NewElementsTable.vue
@@ -61,6 +61,10 @@ const getRequestStatusTagForCell = (request) => {
       label: "Refusé",
       type: "error",
     },
+    REPLACED: {
+      label: "Remplacé",
+      type: "success",
+    },
   }[request.requestStatus]
 
   return (

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -8,6 +8,14 @@
       />
       <h1 class="fr-h4">Liste des demandes en attente d’ajout d’ingrédients</h1>
       <NewElementActionInfo />
+      <div class="border px-4 pt-4 pb-0 mb-2 sm:flex gap-8 items-baseline filters">
+        <MultiselectFilter
+          filterTitle="Statut de demande :"
+          :options="statusOptions"
+          :selectedString="statusFilter"
+          @updateFilter="(v) => updateQuery({ statut: v })"
+        />
+      </div>
       <div v-if="isFetching" class="flex justify-center my-10">
         <ProgressSpinner />
       </div>
@@ -28,13 +36,14 @@
 
 <script setup>
 import { useFetch } from "@vueuse/core"
-import { computed, watch } from "vue"
+import { computed, ref, watch } from "vue"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import NewElementsTable from "./NewElementsTable"
 import NewElementActionInfo from "./NewElementActionInfo"
 import { useRoute, useRouter } from "vue-router"
 import { getPagesForPagination } from "@/utils/components"
+import MultiselectFilter from "@/components/MultiselectFilter"
 
 const router = useRouter()
 const route = useRoute()
@@ -65,4 +74,11 @@ const fetchSearchResults = async () => {
 }
 
 watch([page, statusFilter, limit], fetchSearchResults)
+
+const statusOptions = [
+  { value: "REQUESTED", label: "Nouvelle" },
+  { value: "INFORMATION", label: "Nécessite plus d'information", tagLabel: "Information" },
+  { value: "REJECTED", label: "Refusé" },
+  { value: "REPLACED", label: "Remplacé" },
+]
 </script>

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -47,9 +47,7 @@ const pages = computed(() => getPagesForPagination(data.value?.count, limit.valu
 
 // Valeurs obtenus du queryparams
 const page = computed(() => parseInt(route.query.page))
-const name = computed(() => route.query.nom)
-const type = computed(() => route.query.type)
-const ordering = computed(() => route.query.triage)
+const statusFilter = computed(() => route.query.statut)
 const limit = computed(() => parseInt(route.query.limit) || 10)
 
 const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...newQuery } })
@@ -58,8 +56,7 @@ const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
 
 // Obtention de la donnée via API
 const url = computed(
-  () =>
-    `/api/v1/new-declared-elements/?limit=${limit.value}&offset=${offset.value}&name=${name.value}&type=${type.value}`
+  () => `/api/v1/new-declared-elements/?limit=${limit.value}&offset=${offset.value}&requestStatus=${statusFilter.value}`
 )
 const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
@@ -67,5 +64,5 @@ const fetchSearchResults = async () => {
   await handleError(response)
 }
 
-watch([page, name, type, ordering, limit], fetchSearchResults)
+watch([page, statusFilter, limit], fetchSearchResults)
 </script>

--- a/frontend/src/views/VisaDeclarationsPage/index.vue
+++ b/frontend/src/views/VisaDeclarationsPage/index.vue
@@ -9,7 +9,7 @@
         :exclude="['DRAFT']"
         class="max-w-2xl"
         @updateFilter="updateStatusFilter"
-        v-model="filteredStatus"
+        :statusString="filteredStatus"
       />
 
       <div class="md:border-l md:pl-4">
@@ -65,7 +65,7 @@ import ProgressSpinner from "@/components/ProgressSpinner"
 import VisaDeclarationsTable from "./VisaDeclarationsTable"
 import { useRoute, useRouter } from "vue-router"
 import { getPagesForPagination } from "@/utils/components"
-import StatusFilter from "@/components/StatusFilter.vue"
+import StatusFilter from "@/components/StatusFilter"
 import { orderingOptions, articleOptionsWith15Subtypes } from "@/utils/mappings"
 import PaginationSizeSelect from "@/components/PaginationSizeSelect"
 


### PR DESCRIPTION
partially closes #1654 

Je voulais copier l'UI du filtre de statut de déclaration sur d'autres pages, mais le composant existant est axé le statut d'une déclaration. Alors j'ai créé un nouveau composant plus générique, `MultiselectFilter` et j'ai refactorisé le composant existant `StatusFilter` pour le réutiliser. `StatusFilter` gère tjs des choses spécifiques aux statuts de déclaration. Ajd on passe un `v-model` aux `StatusFilter`s, mais ça n'a pas du sens car le variable qui est donné est `computed`, et en tout cas `StatusFilter` ne change pas ce variable. Alors je l'ai passé en `prop`.

Côté back, je crois que ce n'est pas possible d'utiliser les aides de DRF, notamment `django_filters` car la liste retourner est une concatenation de plusieurs modèles differents. Alors j'ai écrit la logique de filtrage à la main.

![Screenshot 2025-02-20 at 17-00-47 Nouveaux ingrédients - Compl'Alim](https://github.com/user-attachments/assets/929900a2-68db-4a25-aae9-48350c0b85b1)
