### PR TITLE
Améliorations de la fonction d'extraction des déclarations historiques

### DIFF
--- a/data/etl/teleicare_history/README.md
+++ b/data/etl/teleicare_history/README.md
@@ -7,8 +7,8 @@ for f in *.csv; do iconv -f UTF-16 -t UTF-8 "$f" | sed 's/""//g' > "${f%.*}_utf8
 ~~~
 3. Copy all data from csv with
 ~~~
-for f in *_UTF8.csv; do
-    table_name=${f%_UTF8.csv}
+for f in *_utf8.csv; do
+    table_name=${f%_utf8.csv}
     echo "-> Import des données de $f"
     psql postgresql://<user>:<passwd>@<ip>:<port>/<database>  -c "\copy $table_name from $f delimiter ',' csv header;";
 done


### PR DESCRIPTION
Permet notamment de catcher certaines erreurs spécifiques :
* ingrédients qui n'existent pas en base
* integrityerror qui ne sont pas liées à une déclaration déjà présente en BDD

Permet aussi de créer le snapshot même si la déclaration existe déjà