### PR TITLE
Ajouter un lien vers page création ingrédient depuis tableau de demandes d'ajout

### DIFF
--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -211,7 +211,10 @@ const router = useRouter()
 const pageTitle = "Nouvel ingrédient" // eventually will be computed on the action (create/modify)
 
 const breadcrumbLinks = computed(() => {
-  const links = [{ to: { name: "DashboardPage" }, text: "Tableau de bord" }]
+  const links = [
+    { to: { name: "DashboardPage" }, text: "Tableau de bord" },
+    { to: { name: "NewElementsPage" }, text: "Ingrédients pour ajout" },
+  ]
   links.push({ text: pageTitle })
   return links
 })

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -7,6 +7,9 @@
         :links="[{ to: { name: 'DashboardPage' }, text: 'Tableau de bord' }, { text: 'Ingrédients pour ajout' }]"
       />
       <h1 class="fr-h4">Liste des demandes en attente d’ajout d’ingrédients</h1>
+      <router-link :to="{ name: 'ElementForm' }" class="fr-btn fr-btn--secondary fr-btn--sm">
+        Créer un nouvel ingrédient
+      </router-link>
       <NewElementActionInfo />
       <div v-if="isFetching" class="flex justify-center my-10">
         <ProgressSpinner />


### PR DESCRIPTION
Petite PR pour rendre la page création ingrédient découvrable.

![Screenshot 2025-02-21 at 10-48-45 Nouveaux ingrédients - Compl'Alim](https://github.com/user-attachments/assets/f90a3621-b409-45ae-8f3f-e56ceeff41f1)
