### PR TITLE
S'assurer qu'on ne sauvegarde pas de pièce jointe sans fichier

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -238,7 +238,7 @@ class ComputedSubstanceSerializer(DeclaredElementNestedField, serializers.ModelS
 
 
 class AttachmentSerializer(IdPassthrough, serializers.ModelSerializer):
-    file = Base64FileField(required=False, allow_null=True)
+    file = Base64FileField()
 
     class Meta:
         model = Attachment
@@ -253,9 +253,6 @@ class AttachmentSerializer(IdPassthrough, serializers.ModelSerializer):
         read_only_fields = ("file",)
 
     def validate_file(self, file):
-        if not file:
-            return None
-
         size_limit = 1048576 * 2
         if file.size > size_limit:
             raise ProjectAPIException(

--- a/frontend/src/views/ProducerFormPage/AttachmentTab.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentTab.vue
@@ -95,7 +95,7 @@ const addFiles = async (files, container, resetModel, defaultData) => {
         ...defaultData,
       })
     } else {
-      window.alert("Une erreur est survenu lors du téléversement du fichier. Merci de réessayer.")
+      window.alert("Une erreur est survenue lors du téléversement du fichier. Merci de réessayer.")
     }
   }
   resetModel.value = null

--- a/frontend/src/views/ProducerFormPage/AttachmentTab.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentTab.vue
@@ -86,13 +86,17 @@ const addFiles = async (files, container, resetModel, defaultData) => {
       continue
     }
     const base64 = await toBase64(files[i])
-    container.push({
-      ...{
-        file: base64,
-        name: files[i].name,
-      },
-      ...defaultData,
-    })
+    if (base64) {
+      container.push({
+        ...{
+          file: base64,
+          name: files[i].name,
+        },
+        ...defaultData,
+      })
+    } else {
+      window.alert("Une erreur est survenu lors du téléversement du fichier. Merci de réessayer.")
+    }
   }
   resetModel.value = null
 }


### PR DESCRIPTION
related #1655 

pas certain comment ça arrive, mais c'est possible que `FileReader` produit une erreur : https://w3c.github.io/FileAPI/#ErrorAndException

Je crois qu'on n'a pas géré ce cas côté front, alors cette PR ajoute un alert dans le cas où on n'arrive pas à avoir les données du fichier.

Côté back, j'ai changé le serializer pour ne pas permettre des fichiers vides. Je n'ai pas fait le changement côté modèle pour le moment car on a tjs les fichiers vides en prod.

J'ai testé le code front en changeant la ligne : `reader.onload = () => resolve(reader.result)` à `reader.onload = () => resolve()`