### PR TITLE
Logs : remplacer l'exception avec un log quand l'autor n'existe pas pour l'envoie du mail

### DIFF
--- a/config/tasks.py
+++ b/config/tasks.py
@@ -117,6 +117,9 @@ def expire_declarations():
 
 
 def send_automatic_validation_email(declaration):
+    if not declaration.author:
+        logger.log(f"Email not sent on automatic validation of declaration {declaration.id}: no author")
+        return
     brevo_template_id = 6
     try:
         email.send_sib_template(


### PR DESCRIPTION
Je me demande si c'est la bonne résolution.

Dans ce cas spécifique, le compte utilisateur a été supprimé entre la soumission et l'autorisation automatique. AMA c'est un cas previsible alors pas besoin de remonter une exception dans sentry. Je vois dans `expire_declarations` qu'on fait un check sur `declaration.author` avant essayer d'envoyer un mail, alors ça me paraît cohérent de faire le check ici aussi.

Autrement:

Je veux mieux comprendre notre processus de suppression de comptes, et si c'est un pb quand il y a pas d'autor en général pour les déclarations. Je vois qu'il y a pas mal dans un état finalisé, j'imagine au cause d'imports.

https://compl-alim-metabase.cleverapps.io/question/322-declarations-sans-autor