### PR TITLE
Logs : downgrader les logs pour les cas prévus

### DIFF
--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -83,7 +83,7 @@ class CertificateView(PdfView):
                 .creation_date
             )
         except Snapshot.DoesNotExist:
-            logger.log(
+            logger.info(
                 f"Error obtaining certificate date for declaration {declaration.id}, falling back to creation date"
             )
             date = declaration.creation_date
@@ -98,7 +98,7 @@ class CertificateView(PdfView):
                 declaration.snapshots.filter(action__in=submission_actions).latest("creation_date").creation_date
             )
         except Snapshot.DoesNotExist:
-            logger.log(
+            logger.info(
                 f"Error obtaining last submission date for declaration {declaration.id}, falling back to creation date"
             )
             last_submission_date = declaration.creation_date

--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -82,9 +82,10 @@ class CertificateView(PdfView):
                 .latest("creation_date")
                 .creation_date
             )
-        except Exception as e:
-            logger.error(f"Error obtaining certificate date for declaration {declaration.id}")
-            logger.exception(e)
+        except Snapshot.DoesNotExist:
+            logger.log(
+                f"Error obtaining certificate date for declaration {declaration.id}, falling back to creation date"
+            )
             date = declaration.creation_date
 
         try:
@@ -96,9 +97,10 @@ class CertificateView(PdfView):
             last_submission_date = (
                 declaration.snapshots.filter(action__in=submission_actions).latest("creation_date").creation_date
             )
-        except Exception as e:
-            logger.error(f"Error obtaining last submission date for declaration {declaration.id}")
-            logger.exception(e)
+        except Snapshot.DoesNotExist:
+            logger.log(
+                f"Error obtaining last submission date for declaration {declaration.id}, falling back to creation date"
+            )
             last_submission_date = declaration.creation_date
 
         return {


### PR DESCRIPTION
J'imagine c'est prévu que certaines déclarations n'ont pas les bons snapshots pour retrouver les dates pour le certificat.

Avant, le code a soulevé deux erreurs pour la même exception (`logger.exception` et après `logger.error`) alors j'ai enlevé ça.

Aussi, vu que c'est un cas prévu je me suis dit que c'est plus pertinant de simplement soulevé un log (retrouvable avec kibana) que de remonter une erreur avec sentry. J'ai quand même elevé la précision de l'erreur pour que les autres exceptions sont toujours remontées dans sentry (et le certificat est plus généré si c'est le cas)