### PR TITLE
Tableau de demandes : trier par date limite de réponse

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -30,6 +30,7 @@ from .declaration import (
     DeclaredMicroorganismSerializer,
     DeclaredSubstanceSerializer,
     DeclaredIngredientSerializer,
+    DeclaredElementDeclarationSerializer,
 )
 from .company import CompanySerializer, MinimalCompanySerializer
 from .solicitation import CollaborationInvitationSerializer, CompanyAccessClaimSerializer, AddNewCollaboratorSerializer

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -23,7 +23,7 @@ from data.models import (
     SubstanceUnit,
 )
 
-from .company import SimpleCompanySerializer
+from .company import SimpleCompanySerializer, MinimalCompanySerializer
 from .ingredient import IngredientSerializer
 from .microorganism import MicroorganismSerializer
 from .plant import PlantSerializer
@@ -741,12 +741,21 @@ class DeclarationShortSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class DeclaredElementDeclarationSerializer(serializers.ModelSerializer):
+    company = MinimalCompanySerializer(read_only=True)
+
+    class Meta:
+        model = Declaration
+        fields = ("id", "status", "author", "company", "name", "response_limit_date")
+        read_only_fields = fields
+
+
 class DeclaredElementSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     name = serializers.SerializerMethodField()
     type = serializers.CharField()
     authorization_mode = serializers.CharField()
-    declaration = DeclarationShortSerializer()
+    declaration = DeclaredElementDeclarationSerializer()
     request_status = serializers.CharField()
 
     def get_name(self, obj):

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -1945,7 +1945,7 @@ class TestDeclaredElementsApi(APITestCase):
         microorganism = DeclaredMicroorganismFactory(new=True, declaration=declaration_today)
         ingredient = DeclaredIngredientFactory(new=True, declaration=ancient_declaration)
 
-        order_url = f"{reverse('api:list_new_declared_elements')}?ordering=-declarationCreationDate"
+        order_url = f"{reverse('api:list_new_declared_elements')}?ordering=declarationCreationDate"
         response = self.client.get(order_url, format="json")
         results = response.json()
         self.assertEqual(results["count"], 3)
@@ -1954,7 +1954,7 @@ class TestDeclaredElementsApi(APITestCase):
         self.assertEqual(results[1]["id"], plant.id)
         self.assertEqual(results[2]["id"], ingredient.id)
 
-        order_url = f"{reverse('api:list_new_declared_elements')}?ordering=declarationCreationDate"
+        order_url = f"{reverse('api:list_new_declared_elements')}?ordering=-declarationCreationDate"
         response = self.client.get(order_url, format="json")
         results = response.json()
         self.assertEqual(results["count"], 3)

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -1952,7 +1952,16 @@ class TestDeclaredElementsApi(APITestCase):
         results = results["results"]
         self.assertEqual(results[0]["id"], microorganism.id)
         self.assertEqual(results[1]["id"], plant.id)
-        self.assertEqual(results[3]["id"], ingredient.id)
+        self.assertEqual(results[2]["id"], ingredient.id)
+
+        order_url = f"{reverse('api:list_new_declared_elements')}?ordering=declarationCreationDate"
+        response = self.client.get(order_url, format="json")
+        results = response.json()
+        self.assertEqual(results["count"], 3)
+        results = results["results"]
+        self.assertEqual(results[0]["id"], ingredient.id)
+        self.assertEqual(results[1]["id"], plant.id)
+        self.assertEqual(results[2]["id"], microorganism.id)
 
 
 class TestSingleDeclaredElementApi(APITestCase):

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -74,7 +74,7 @@ class DeclaredElementsView(ListAPIView):
             return sorted(
                 chain(*filtered_querysets),
                 key=lambda instance: instance.declaration.creation_date,
-                reverse=not ordering.startswith("-"),
+                reverse=ordering.startswith("-"),
             )
 
         return list(chain(*filtered_querysets))

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -70,10 +70,10 @@ class DeclaredElementsView(ListAPIView):
         ]
 
         ordering = self.request.query_params.get("ordering")
-        if ordering and ordering.endswith("declarationCreationDate"):
+        if ordering and ordering.endswith("responseLimitDate"):
             return sorted(
                 chain(*filtered_querysets),
-                key=lambda instance: instance.declaration.creation_date,
+                key=lambda instance: instance.declaration.response_limit_date or instance.declaration.creation_date,
                 reverse=ordering.startswith("-"),
             )
 

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -71,8 +71,6 @@ class DeclaredElementsView(ListAPIView):
 
         ordering = self.request.query_params.get("ordering")
         if ordering and ordering.endswith("declarationCreationDate"):
-            # for qs in filtered_querysets:
-            #     qs.annotate(date=Q("declaration__creation_date"))
             return sorted(
                 chain(*filtered_querysets),
                 key=lambda instance: instance.declaration.creation_date,

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -68,6 +68,17 @@ class DeclaredElementsView(ListAPIView):
         filtered_querysets = [
             queryset.filter(request_status_filter & declaration_status_filter) for queryset in querysets
         ]
+
+        ordering = self.request.query_params.get("ordering")
+        if ordering and ordering.endswith("declarationCreationDate"):
+            # for qs in filtered_querysets:
+            #     qs.annotate(date=Q("declaration__creation_date"))
+            return sorted(
+                chain(*filtered_querysets),
+                key=lambda instance: instance.declaration.creation_date,
+                reverse=not ordering.startswith("-"),
+            )
+
         return list(chain(*filtered_querysets))
 
     @staticmethod

--- a/frontend/src/components/MultiselectFilter.vue
+++ b/frontend/src/components/MultiselectFilter.vue
@@ -38,7 +38,10 @@ const props = defineProps({
 const selectedOptions = ref([])
 const opened = ref(false)
 
-onMounted(() => (selectedOptions.value = props.selectedString ? props.selectedString.split(",") : []))
+const updateSelected = () => (selectedOptions.value = props.selectedString ? props.selectedString.split(",") : [])
+onMounted(updateSelected)
+watch(() => props.selectedString, updateSelected)
+
 watch(selectedOptions, () => emit("updateFilter", selectedOptions.value.join(",")))
 
 const findLabel = (value) => {

--- a/frontend/src/components/MultiselectFilter.vue
+++ b/frontend/src/components/MultiselectFilter.vue
@@ -16,7 +16,7 @@
         />
       </span>
       <span v-else-if="noFilterText">
-        <DsfrTag class="ml-2 mt-1" label="Toutes les déclarations" small />
+        <DsfrTag class="ml-2 mt-1" :label="noFilterText" small />
       </span>
     </p>
     <p>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -330,6 +330,7 @@ const routes = [
         page: 1,
         statut: "REQUESTED,INFORMATION",
         statutDeclaration: "", // par défaut on filtre par les statuts ouverts
+        triage: "declarationCreationDate",
         limit: "10",
       },
     },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -329,6 +329,7 @@ const routes = [
       defaultQueryParams: {
         page: 1,
         statut: "REQUESTED,INFORMATION",
+        statutDeclaration: "", // par défaut on filtre par les statuts ouverts
         limit: "10",
       },
     },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -330,7 +330,7 @@ const routes = [
         page: 1,
         statut: "REQUESTED,INFORMATION",
         statutDeclaration: "", // par défaut on filtre par les statuts ouverts
-        triage: "declarationCreationDate",
+        triage: "responseLimitDate",
         limit: "10",
       },
     },

--- a/frontend/src/views/NewElementsPage/NewElementsTable.vue
+++ b/frontend/src/views/NewElementsPage/NewElementsTable.vue
@@ -23,7 +23,7 @@ const headers = [
   "Nom de l'ingrédient",
   "Type d'ingrédient",
   "Authorisation marché FR ou EU",
-  "Date de création de la déclaration",
+  "Date limite de réponse",
   "Statut de la déclaration",
   "Statut de la demande",
   "",
@@ -35,7 +35,7 @@ const rows = computed(() =>
       x.name,
       getTypeInFrench(x.type),
       getAuthorizationModeInFrench(x.authorizationMode),
-      x.declaration.creationDate && isoToPrettyDate(x.declaration.creationDate),
+      x.declaration.responseLimitDate && isoToPrettyDate(x.declaration.responseLimitDate),
       getStatusTagForCell(x.declaration.status),
       getRequestStatusTagForCell(x),
       {

--- a/frontend/src/views/NewElementsPage/NewElementsTable.vue
+++ b/frontend/src/views/NewElementsPage/NewElementsTable.vue
@@ -23,7 +23,7 @@ const headers = [
   "Nom de l'ingrédient",
   "Type d'ingrédient",
   "Authorisation marché FR ou EU",
-  "Date de demande d'ajout",
+  "Date de création de la déclaration",
   "Statut de la déclaration",
   "Statut de la demande",
   "",

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -15,6 +15,13 @@
           :selectedString="statusFilter"
           @updateFilter="(v) => updateQuery({ statut: v })"
         />
+        <MultiselectFilter
+          filterTitle="Statut de déclaration :"
+          :options="declarationStatusOptions"
+          :selectedString="declarationStatusFilter"
+          noFilterText="Toutes les déclarations ouvertes"
+          @updateFilter="(v) => updateQuery({ statutDeclaration: v })"
+        />
       </div>
       <div v-if="isFetching" class="flex justify-center my-10">
         <ProgressSpinner />
@@ -36,13 +43,14 @@
 
 <script setup>
 import { useFetch } from "@vueuse/core"
-import { computed, ref, watch } from "vue"
+import { computed, watch } from "vue"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import NewElementsTable from "./NewElementsTable"
 import NewElementActionInfo from "./NewElementActionInfo"
 import { useRoute, useRouter } from "vue-router"
 import { getPagesForPagination } from "@/utils/components"
+import { statusProps } from "@/utils/mappings"
 import MultiselectFilter from "@/components/MultiselectFilter"
 
 const router = useRouter()
@@ -57,6 +65,7 @@ const pages = computed(() => getPagesForPagination(data.value?.count, limit.valu
 // Valeurs obtenus du queryparams
 const page = computed(() => parseInt(route.query.page))
 const statusFilter = computed(() => route.query.statut)
+const declarationStatusFilter = computed(() => route.query.statutDeclaration)
 const limit = computed(() => parseInt(route.query.limit) || 10)
 
 const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...newQuery } })
@@ -65,7 +74,8 @@ const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
 
 // Obtention de la donnée via API
 const url = computed(
-  () => `/api/v1/new-declared-elements/?limit=${limit.value}&offset=${offset.value}&requestStatus=${statusFilter.value}`
+  () =>
+    `/api/v1/new-declared-elements/?limit=${limit.value}&offset=${offset.value}&requestStatus=${statusFilter.value}&declarationStatus=${declarationStatusFilter.value}`
 )
 const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
@@ -73,7 +83,7 @@ const fetchSearchResults = async () => {
   await handleError(response)
 }
 
-watch([page, statusFilter, limit], fetchSearchResults)
+watch([page, statusFilter, declarationStatusFilter, limit], fetchSearchResults)
 
 const statusOptions = [
   { value: "REQUESTED", label: "Nouvelle" },
@@ -81,4 +91,21 @@ const statusOptions = [
   { value: "REJECTED", label: "Refusé" },
   { value: "REPLACED", label: "Remplacé" },
 ]
+
+const declarationStatuses = [
+  "AWAITING_INSTRUCTION",
+  "ONGOING_INSTRUCTION",
+  "AWAITING_VISA",
+  "ONGOING_VISA",
+  "OBJECTION",
+  "OBSERVATION",
+  "AUTHORIZED",
+  "ABANDONED",
+  "REJECTED",
+  "WITHDRAWN",
+]
+const declarationStatusOptions = declarationStatuses.map((key) => ({
+  value: key,
+  label: statusProps[key].label,
+}))
 </script>

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -26,6 +26,17 @@
             class="-mb-4 py-1"
           />
         </div>
+        <div class="md:border-l md:pl-4">
+          <DsfrInputGroup class="max-w-sm">
+            <DsfrSelect
+              label="Trier par"
+              defaultUnselectedText=""
+              v-model="ordering"
+              @update:modelValue="(v) => updateQuery({ triage: v })"
+              :options="orderingOptions"
+            />
+          </DsfrInputGroup>
+        </div>
       </div>
       <div v-if="isFetching" class="flex justify-center my-10">
         <ProgressSpinner />
@@ -47,7 +58,7 @@
 
 <script setup>
 import { useFetch } from "@vueuse/core"
-import { computed, watch } from "vue"
+import { computed, watch, ref } from "vue"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import NewElementsTable from "./NewElementsTable"
@@ -71,6 +82,7 @@ const page = computed(() => parseInt(route.query.page))
 const statusFilter = computed(() => route.query.statut)
 const declarationStatusFilter = computed(() => route.query.statutDeclaration)
 const limit = computed(() => parseInt(route.query.limit) || 10)
+const ordering = ref(route.query.triage)
 
 const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...newQuery } })
 
@@ -79,7 +91,7 @@ const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
 // Obtention de la donnée via API
 const url = computed(
   () =>
-    `/api/v1/new-declared-elements/?limit=${limit.value}&offset=${offset.value}&requestStatus=${statusFilter.value}&declarationStatus=${declarationStatusFilter.value}`
+    `/api/v1/new-declared-elements/?limit=${limit.value}&offset=${offset.value}&requestStatus=${statusFilter.value}&declarationStatus=${declarationStatusFilter.value}&ordering=${ordering.value}`
 )
 const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
@@ -87,7 +99,7 @@ const fetchSearchResults = async () => {
   await handleError(response)
 }
 
-watch([page, statusFilter, declarationStatusFilter, limit], fetchSearchResults)
+watch([page, statusFilter, declarationStatusFilter, limit, ordering], fetchSearchResults)
 
 const statusOptions = [
   { value: "REQUESTED", label: "Nouvelle" },
@@ -112,4 +124,15 @@ const declarationStatusOptions = declarationStatuses.map((key) => ({
   value: key,
   label: statusProps[key].label,
 }))
+
+const orderingOptions = [
+  {
+    value: "declarationCreationDate",
+    text: "Date de création de la déclaration",
+  },
+  {
+    value: "-declarationCreationDate",
+    text: "Date de création de la déclaration (descendent)",
+  },
+]
 </script>

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -127,12 +127,12 @@ const declarationStatusOptions = declarationStatuses.map((key) => ({
 
 const orderingOptions = [
   {
-    value: "declarationCreationDate",
-    text: "Date de création de la déclaration",
+    value: "responseLimitDate",
+    text: "Date limite de réponse",
   },
   {
-    value: "-declarationCreationDate",
-    text: "Date de création de la déclaration (descendent)",
+    value: "-responseLimitDate",
+    text: "Date limite de réponse (descendent)",
   },
 ]
 </script>

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -8,20 +8,24 @@
       />
       <h1 class="fr-h4">Liste des demandes en attente d’ajout d’ingrédients</h1>
       <NewElementActionInfo />
-      <div class="border px-4 pt-4 pb-0 mb-2 sm:flex gap-8 items-baseline filters">
+      <div class="border px-4 py-4 mb-2 sm:flex gap-8 items-baseline filters">
         <MultiselectFilter
-          filterTitle="Statut de demande :"
+          filterTitle="Statut de la demande :"
           :options="statusOptions"
           :selectedString="statusFilter"
           @updateFilter="(v) => updateQuery({ statut: v })"
+          class="-mb-4 py-1"
         />
-        <MultiselectFilter
-          filterTitle="Statut de déclaration :"
-          :options="declarationStatusOptions"
-          :selectedString="declarationStatusFilter"
-          noFilterText="Toutes les déclarations ouvertes"
-          @updateFilter="(v) => updateQuery({ statutDeclaration: v })"
-        />
+        <div class="md:border-l md:pl-4">
+          <MultiselectFilter
+            filterTitle="Statut de la déclaration :"
+            :options="declarationStatusOptions"
+            :selectedString="declarationStatusFilter"
+            noFilterText="Toutes les déclarations ouvertes"
+            @updateFilter="(v) => updateQuery({ statutDeclaration: v })"
+            class="-mb-4 py-1"
+          />
+        </div>
       </div>
       <div v-if="isFetching" class="flex justify-center my-10">
         <ProgressSpinner />

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -152,7 +152,7 @@ const orderingOptions = [
   },
   {
     value: "-responseLimitDate",
-    text: "Date limite de réponse (descendent)",
+    text: "Date limite de réponse (descendant)",
   },
 ]
 </script>


### PR DESCRIPTION
Ce changement n'est pas idéal car la méthode `sorted` va avoir besoin de retrouver toutes les objets `DeclaredX` et après faire le join avec la déclaration pour retrouver la date limite de réponse. Au moins le filtrage sur le statut de demande et décla sont fait avant.

Il y a environ 270 demandes d'ajout (de tout statut) en prod en ce moment. Je crois que ça devrait pas poser de problème ajd.

Je me suis dit qu'on pourrait essayer et si il y a des problèmes on peut optimizer.

![Screenshot 2025-02-26 at 16-28-08 Nouveaux ingrédients - Compl'Alim](https://github.com/user-attachments/assets/41515a2d-5a32-4e3e-879e-2917b5547a96)

closes #1709 