### PR TITLE
Ajout d'un champ "raison du changement" dans l'admin pour les models pertinents (ingrédients et modèles de référence, déclaration, company)

### DIFF
--- a/data/admin/abstract_admin.py
+++ b/data/admin/abstract_admin.py
@@ -4,6 +4,9 @@ from simple_history.admin import SimpleHistoryAdmin
 class ElementAdminWithChangeReason(SimpleHistoryAdmin):
     def save_model(self, request, obj, form, change):
         if change:
-            # TODO: la change reason devrait pouvoir être renseignée dans le form
-            obj._change_reason = "Modification de l'ingrédient"
+            obj._change_reason = (
+                form.cleaned_data["change_reason"]
+                if "change_reason" in form.cleaned_data.keys()
+                else "Modification de l'ingrédient"
+            )
         super().save_model(request, obj, form, change)

--- a/data/admin/abstract_admin.py
+++ b/data/admin/abstract_admin.py
@@ -1,14 +1,10 @@
-from simple_history.utils import update_change_reason
-
-
 class ChangeReasonAdminMixin:
     def save_model(self, request, obj, form, change):
         if change:
-            update_change_reason(
-                obj,
+            obj._change_reason = (
                 form.cleaned_data["change_reason"]
                 if "change_reason" in form.cleaned_data.keys()
-                else "Modification via l'admin",
+                else "Modification via l'admin"
             )
 
         super().save_model(request, obj, form, change)

--- a/data/admin/abstract_admin.py
+++ b/data/admin/abstract_admin.py
@@ -1,12 +1,14 @@
-from simple_history.admin import SimpleHistoryAdmin
+from simple_history.utils import update_change_reason
 
 
-class ElementAdminWithChangeReason(SimpleHistoryAdmin):
+class ChangeReasonAdminMixin:
     def save_model(self, request, obj, form, change):
         if change:
-            obj._change_reason = (
+            update_change_reason(
+                obj,
                 form.cleaned_data["change_reason"]
                 if "change_reason" in form.cleaned_data.keys()
-                else "Modification de l'ingrédient"
+                else "Modification de l'ingrédient",
             )
+
         super().save_model(request, obj, form, change)

--- a/data/admin/abstract_admin.py
+++ b/data/admin/abstract_admin.py
@@ -8,7 +8,7 @@ class ChangeReasonAdminMixin:
                 obj,
                 form.cleaned_data["change_reason"]
                 if "change_reason" in form.cleaned_data.keys()
-                else "Modification de l'ingrédient",
+                else "Modification via l'admin",
             )
 
         super().save_model(request, obj, form, change)

--- a/data/admin/abstract_admin.py
+++ b/data/admin/abstract_admin.py
@@ -1,3 +1,16 @@
+from django import forms
+
+
+class ChangeReasonFormMixin(forms.ModelForm):
+    # thanks to https://github.com/jazzband/django-simple-history/issues/853#issuecomment-1105754544
+    change_reason = forms.CharField(
+        label="Raison de modification (rendue publique dans le cas des Ingrédients, Plantes, Substances, Microorganismes)",
+        help_text="100 caractères max",
+        max_length=100,
+        widget=forms.TextInput(attrs={"size": "100"}),
+    )
+
+
 class ChangeReasonAdminMixin:
     def save_model(self, request, obj, form, change):
         if change:

--- a/data/admin/company.py
+++ b/data/admin/company.py
@@ -20,10 +20,6 @@ class DeclarantInline(admin.TabularInline):
 
 
 class CompanyForm(forms.ModelForm):
-    class Meta:
-        model = Company
-        fields = "__all__"
-
     # thanks to https://github.com/jazzband/django-simple-history/issues/853#issuecomment-1105754544
     change_reason = forms.CharField(
         label="Raison de modification",
@@ -131,11 +127,6 @@ class CompanyAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
         return "Cette entreprise peut seulement déclarer pour elle-même."
 
     display_represented_companies.short_description = "Entreprises representées"
-
-    def save_model(self, request, obj, form, change):
-        if change:
-            obj._change_reason = form.cleaned_data["change_reason"]
-        super().save_model(request, obj, form, change)
 
 
 @admin.register(SupervisorRole)

--- a/data/admin/company.py
+++ b/data/admin/company.py
@@ -1,4 +1,3 @@
-from django import forms
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join, mark_safe
@@ -6,7 +5,7 @@ from django.utils.html import format_html, format_html_join, mark_safe
 from simple_history.admin import SimpleHistoryAdmin
 
 from ..models.company import Company, DeclarantRole, SupervisorRole
-from .abstract_admin import ChangeReasonAdminMixin
+from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
 
 class SupervisionInline(admin.TabularInline):
@@ -19,14 +18,8 @@ class DeclarantInline(admin.TabularInline):
     extra = 0
 
 
-class CompanyForm(forms.ModelForm):
-    # thanks to https://github.com/jazzband/django-simple-history/issues/853#issuecomment-1105754544
-    change_reason = forms.CharField(
-        label="Raison de modification",
-        help_text="100 caractères max",
-        max_length=100,
-        widget=forms.TextInput(attrs={"size": "70"}),
-    )
+class CompanyForm(ChangeReasonFormMixin):
+    pass
 
 
 @admin.register(Company)

--- a/data/admin/company.py
+++ b/data/admin/company.py
@@ -3,7 +3,10 @@ from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join, mark_safe
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from ..models.company import Company, DeclarantRole, SupervisorRole
+from .abstract_admin import ChangeReasonAdminMixin
 
 
 class SupervisionInline(admin.TabularInline):
@@ -31,7 +34,7 @@ class CompanyForm(forms.ModelForm):
 
 
 @admin.register(Company)
-class CompanyAdmin(admin.ModelAdmin):
+class CompanyAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = CompanyForm
     filter_horizontal = ("mandated_companies",)
     readonly_fields = ("display_represented_companies",)

--- a/data/admin/company.py
+++ b/data/admin/company.py
@@ -46,6 +46,10 @@ class CompanyAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
 
     fieldsets = (
         (
+            None,
+            {"fields": ["change_reason"]},
+        ),
+        (
             "",
             {
                 "fields": (

--- a/data/admin/condition.py
+++ b/data/admin/condition.py
@@ -5,17 +5,14 @@ from simple_history.admin import SimpleHistoryAdmin
 
 from data.models import Condition
 
-from .abstract_admin import ChangeReasonAdminMixin
+from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
 
-class ConditionForm(forms.ModelForm):
+class ConditionForm(ChangeReasonFormMixin):
     class Meta:
         widgets = {
             "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
-            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
-
-    change_reason = forms.CharField(label="Raison de modification", max_length=100)
 
 
 @admin.register(Condition)

--- a/data/admin/condition.py
+++ b/data/admin/condition.py
@@ -22,6 +22,7 @@ class ConditionForm(forms.ModelForm):
 class ConditionAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = ConditionForm
     fields = [
+        "change_reason",
         "name",
         "ca_name",
         "category",
@@ -32,7 +33,6 @@ class ConditionAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
         "max_age",
         "creation_date",
         "modification_date",
-        "change_reason",
     ]
     readonly_fields = [
         "name",

--- a/data/admin/condition.py
+++ b/data/admin/condition.py
@@ -1,18 +1,25 @@
 from django import forms
 from django.contrib import admin
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from data.models import Condition
+
+from .abstract_admin import ChangeReasonAdminMixin
 
 
 class ConditionForm(forms.ModelForm):
     class Meta:
         widgets = {
             "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
+            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
+
+    change_reason = forms.CharField(label="Raison de modification", max_length=100)
 
 
 @admin.register(Condition)
-class ConditionAdmin(admin.ModelAdmin):
+class ConditionAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = ConditionForm
     fields = [
         "name",
@@ -25,6 +32,7 @@ class ConditionAdmin(admin.ModelAdmin):
         "max_age",
         "creation_date",
         "modification_date",
+        "change_reason",
     ]
     readonly_fields = [
         "name",

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -260,6 +260,7 @@ class DeclarationForm(forms.ModelForm):
             "other_conditions": forms.Textarea(attrs={"cols": 35, "rows": 1}),
             "daily_recommended_dose": forms.Textarea(attrs={"cols": 35, "rows": 1}),
             "minimum_duration": forms.Textarea(attrs={"cols": 35, "rows": 1}),
+            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
 
     # thanks to https://github.com/jazzband/django-simple-history/issues/853#issuecomment-1105754544
@@ -267,7 +268,6 @@ class DeclarationForm(forms.ModelForm):
         label="Raison de modification",
         help_text="100 caractères max",
         max_length=100,
-        widget=forms.TextInput(attrs={"size": "70"}),
     )
 
 

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -2,7 +2,6 @@ from django import forms
 from django.contrib import admin
 
 from simple_history.admin import SimpleHistoryAdmin
-from simple_history.utils import update_change_reason
 
 from data.models import (
     Attachment,
@@ -380,6 +379,6 @@ class DeclarationAdmin(SimpleHistoryAdmin):
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
         if change:
-            update_change_reason(obj, form.cleaned_data["change_reason"])
+            obj._change_reason = form.cleaned_data["change_reason"]
             obj.assign_calculated_article()
         super().save_model(request, obj, form, change)

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -298,6 +298,10 @@ class DeclarationAdmin(SimpleHistoryAdmin):
 
     fieldsets = (
         (
+            None,
+            {"fields": ["change_reason"]},
+        ),
+        (
             "",
             {
                 "fields": (
@@ -369,10 +373,6 @@ class DeclarationAdmin(SimpleHistoryAdmin):
                     "country",
                 ),
             },
-        ),
-        (
-            None,
-            {"fields": ["change_reason"]},
         ),
     )
 

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -14,6 +14,8 @@ from data.models import (
     Snapshot,
 )
 
+from .abstract_admin import ChangeReasonFormMixin
+
 
 class SnapshotInline(admin.TabularInline):
     model = Snapshot
@@ -234,7 +236,7 @@ class ComputedSubstanceInline(admin.TabularInline):
         return True
 
 
-class DeclarationForm(forms.ModelForm):
+class DeclarationForm(ChangeReasonFormMixin):
     class Meta:
         widgets = {
             "address": forms.Textarea(attrs={"cols": 35, "rows": 1}),
@@ -259,15 +261,7 @@ class DeclarationForm(forms.ModelForm):
             "other_conditions": forms.Textarea(attrs={"cols": 35, "rows": 1}),
             "daily_recommended_dose": forms.Textarea(attrs={"cols": 35, "rows": 1}),
             "minimum_duration": forms.Textarea(attrs={"cols": 35, "rows": 1}),
-            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
-
-    # thanks to https://github.com/jazzband/django-simple-history/issues/853#issuecomment-1105754544
-    change_reason = forms.CharField(
-        label="Raison de modification",
-        help_text="100 caractères max",
-        max_length=100,
-    )
 
 
 @admin.register(Declaration)

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -261,6 +261,14 @@ class DeclarationForm(forms.ModelForm):
             "minimum_duration": forms.Textarea(attrs={"cols": 35, "rows": 1}),
         }
 
+    # thanks to https://github.com/jazzband/django-simple-history/issues/853#issuecomment-1105754544
+    change_reason = forms.CharField(
+        label="Raison de modification",
+        help_text="100 caractères max",
+        max_length=100,
+        widget=forms.TextInput(attrs={"size": "70"}),
+    )
+
 
 @admin.register(Declaration)
 class DeclarationAdmin(SimpleHistoryAdmin):
@@ -367,5 +375,6 @@ class DeclarationAdmin(SimpleHistoryAdmin):
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
         if change:
+            obj._change_reason = form.cleaned_data["change_reason"]
             obj.assign_calculated_article()
         super().save_model(request, obj, form, change)

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib import admin
 
 from simple_history.admin import SimpleHistoryAdmin
+from simple_history.utils import update_change_reason
 
 from data.models import (
     Attachment,
@@ -370,11 +371,15 @@ class DeclarationAdmin(SimpleHistoryAdmin):
                 ),
             },
         ),
+        (
+            None,
+            {"fields": ["change_reason"]},
+        ),
     )
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
         if change:
-            obj._change_reason = form.cleaned_data["change_reason"]
+            update_change_reason(obj, form.cleaned_data["change_reason"])
             obj.assign_calculated_article()
         super().save_model(request, obj, form, change)

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -14,7 +14,7 @@ from data.models import (
     Snapshot,
 )
 
-from .abstract_admin import ChangeReasonFormMixin
+from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
 
 class SnapshotInline(admin.TabularInline):
@@ -265,7 +265,7 @@ class DeclarationForm(ChangeReasonFormMixin):
 
 
 @admin.register(Declaration)
-class DeclarationAdmin(SimpleHistoryAdmin):
+class DeclarationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = DeclarationForm
     list_display = ("id", "name", "status", "company", "author")
     list_filter = ("status", "company", "author")
@@ -372,7 +372,6 @@ class DeclarationAdmin(SimpleHistoryAdmin):
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
-        if change:
-            obj._change_reason = form.cleaned_data["change_reason"]
+        if change and "overridden_article" not in form.changed_data:
             obj.assign_calculated_article()
-        super().save_model(request, obj, form, change)
+            obj.save()

--- a/data/admin/effect.py
+++ b/data/admin/effect.py
@@ -5,22 +5,14 @@ from simple_history.admin import SimpleHistoryAdmin
 
 from data.models import Effect
 
-from .abstract_admin import ChangeReasonAdminMixin
+from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
 
-class EffectForm(forms.ModelForm):
+class EffectForm(ChangeReasonFormMixin):
     class Meta:
         widgets = {
             "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
-            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
-
-    # saved in ChangeReasonAdminMixin.save()
-    change_reason = forms.CharField(
-        label="Raison de modification",
-        help_text="100 caractères max",
-        max_length=100,
-    )
 
 
 @admin.register(Effect)

--- a/data/admin/effect.py
+++ b/data/admin/effect.py
@@ -1,18 +1,30 @@
 from django import forms
 from django.contrib import admin
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from data.models import Effect
+
+from .abstract_admin import ChangeReasonAdminMixin
 
 
 class EffectForm(forms.ModelForm):
     class Meta:
         widgets = {
             "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
+            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
+
+    # saved in ChangeReasonAdminMixin.save()
+    change_reason = forms.CharField(
+        label="Raison de modification",
+        help_text="100 caractères max",
+        max_length=100,
+    )
 
 
 @admin.register(Effect)
-class EffectAdmin(admin.ModelAdmin):
+class EffectAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = EffectForm
     fields = [
         "name",
@@ -22,6 +34,7 @@ class EffectAdmin(admin.ModelAdmin):
         "ca_is_obsolete",
         "creation_date",
         "modification_date",
+        "change_reason",
     ]
     readonly_fields = [
         "name",

--- a/data/admin/effect.py
+++ b/data/admin/effect.py
@@ -27,6 +27,7 @@ class EffectForm(forms.ModelForm):
 class EffectAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = EffectForm
     fields = [
+        "change_reason",
         "name",
         "ca_name",
         "siccrf_name_en",
@@ -34,7 +35,6 @@ class EffectAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
         "ca_is_obsolete",
         "creation_date",
         "modification_date",
-        "change_reason",
     ]
     readonly_fields = [
         "name",

--- a/data/admin/galenic_formulation.py
+++ b/data/admin/galenic_formulation.py
@@ -1,18 +1,30 @@
 from django import forms
 from django.contrib import admin
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from data.models import GalenicFormulation
+
+from .abstract_admin import ChangeReasonAdminMixin
 
 
 class GalenicFormulationForm(forms.ModelForm):
     class Meta:
         widgets = {
             "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
+            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
+
+    # saved in ChangeReasonAdminMixin.save()
+    change_reason = forms.CharField(
+        label="Raison de modification",
+        help_text="100 caractères max",
+        max_length=100,
+    )
 
 
 @admin.register(GalenicFormulation)
-class GalenicFormulationAdmin(admin.ModelAdmin):
+class GalenicFormulationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = GalenicFormulationForm
     fields = [
         "name",
@@ -24,6 +36,7 @@ class GalenicFormulationAdmin(admin.ModelAdmin):
         "ca_is_obsolete",
         "creation_date",
         "modification_date",
+        "change_reason",
     ]
     readonly_fields = [
         "name",

--- a/data/admin/galenic_formulation.py
+++ b/data/admin/galenic_formulation.py
@@ -27,6 +27,7 @@ class GalenicFormulationForm(forms.ModelForm):
 class GalenicFormulationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = GalenicFormulationForm
     fields = [
+        "change_reason",
         "name",
         "ca_name",
         "siccrf_name_en",
@@ -36,7 +37,6 @@ class GalenicFormulationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
         "ca_is_obsolete",
         "creation_date",
         "modification_date",
-        "change_reason",
     ]
     readonly_fields = [
         "name",

--- a/data/admin/galenic_formulation.py
+++ b/data/admin/galenic_formulation.py
@@ -12,7 +12,7 @@ class GalenicFormulationForm(forms.ModelForm):
     class Meta:
         widgets = {
             "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
-            "change_reason": forms.TextInput(attrs={"size": "70"}),
+            "change_reason": forms.TextInput(attrs={"size": "100"}),
         }
 
     # saved in ChangeReasonAdminMixin.save()

--- a/data/admin/ingredient.py
+++ b/data/admin/ingredient.py
@@ -30,6 +30,14 @@ class IngredientForm(forms.ModelForm):
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
         }
 
+    # saved in ElementAdminWithChangeReason.save()
+    change_reason = forms.CharField(
+        label="Raison de modification",
+        help_text="100 caractères max",
+        max_length=100,
+        widget=forms.TextInput(attrs={"size": "70"}),
+    )
+
 
 @admin.register(Ingredient)
 class IngredientAdmin(ElementAdminWithChangeReason):

--- a/data/admin/ingredient.py
+++ b/data/admin/ingredient.py
@@ -2,9 +2,11 @@ from django import forms
 from django.contrib import admin
 from django.db import models
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from data.models import Ingredient, IngredientSynonym
 
-from .abstract_admin import ElementAdminWithChangeReason
+from .abstract_admin import ChangeReasonAdminMixin
 
 
 class IngredientSynonymInline(admin.TabularInline):
@@ -28,19 +30,19 @@ class IngredientForm(forms.ModelForm):
             "siccrf_name_en": forms.Textarea(attrs={"cols": 60, "rows": 1}),
             "public_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
+            "change_reason": forms.Textarea(attrs={"size": "70"}),
         }
 
-    # saved in ElementAdminWithChangeReason.save()
+    # saved in ChangeReasonAdminMixin.save()
     change_reason = forms.CharField(
         label="Raison de modification",
         help_text="100 caractères max",
         max_length=100,
-        widget=forms.TextInput(attrs={"size": "70"}),
     )
 
 
 @admin.register(Ingredient)
-class IngredientAdmin(ElementAdminWithChangeReason):
+class IngredientAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = IngredientForm
     inlines = (
         SubstanceInlineAdmin,

--- a/data/admin/ingredient.py
+++ b/data/admin/ingredient.py
@@ -6,7 +6,7 @@ from simple_history.admin import SimpleHistoryAdmin
 
 from data.models import Ingredient, IngredientSynonym
 
-from .abstract_admin import ChangeReasonAdminMixin
+from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
 
 class IngredientSynonymInline(admin.TabularInline):
@@ -23,22 +23,14 @@ class SubstanceInlineAdmin(admin.TabularInline):
     extra = 0
 
 
-class IngredientForm(forms.ModelForm):
+class IngredientForm(ChangeReasonFormMixin):
     class Meta:
         widgets = {
             "name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
             "siccrf_name_en": forms.Textarea(attrs={"cols": 60, "rows": 1}),
             "public_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
-            "change_reason": forms.Textarea(attrs={"size": "70"}),
         }
-
-    # saved in ChangeReasonAdminMixin.save()
-    change_reason = forms.CharField(
-        label="Raison de modification",
-        help_text="100 caractères max",
-        max_length=100,
-    )
 
 
 @admin.register(Ingredient)

--- a/data/admin/microorganism.py
+++ b/data/admin/microorganism.py
@@ -17,7 +17,7 @@ class MicroorganismForm(forms.ModelForm):
             "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
 
-    # saved in ElementAdminWithChangeReason.save()
+    # saved in ChangeReasonAdminMixin.save()
     change_reason = forms.CharField(
         label="Raison de modification",
         help_text="100 caractères max",
@@ -29,6 +29,10 @@ class MicroorganismForm(forms.ModelForm):
 class MicroorganismAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = MicroorganismForm
     fieldsets = [
+        (
+            None,
+            {"fields": ["change_reason"]},
+        ),
         (
             None,  # Pas d'entête
             {
@@ -64,10 +68,6 @@ class MicroorganismAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
                     "ca_private_comments",
                 ],
             },
-        ),
-        (
-            None,
-            {"fields": ["change_reason"]},
         ),
     ]
 

--- a/data/admin/microorganism.py
+++ b/data/admin/microorganism.py
@@ -1,9 +1,11 @@
 from django import forms
 from django.contrib import admin
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from data.models import Microorganism
 
-from .abstract_admin import ElementAdminWithChangeReason
+from .abstract_admin import ChangeReasonAdminMixin
 
 
 class MicroorganismForm(forms.ModelForm):
@@ -12,6 +14,7 @@ class MicroorganismForm(forms.ModelForm):
             "name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
             "public_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
+            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
 
     # saved in ElementAdminWithChangeReason.save()
@@ -19,12 +22,11 @@ class MicroorganismForm(forms.ModelForm):
         label="Raison de modification",
         help_text="100 caractères max",
         max_length=100,
-        widget=forms.TextInput(attrs={"size": "70"}),
     )
 
 
 @admin.register(Microorganism)
-class MicroorganismAdmin(ElementAdminWithChangeReason):
+class MicroorganismAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = MicroorganismForm
     fieldsets = [
         (
@@ -62,6 +64,10 @@ class MicroorganismAdmin(ElementAdminWithChangeReason):
                     "ca_private_comments",
                 ],
             },
+        ),
+        (
+            None,
+            {"fields": ["change_reason"]},
         ),
     ]
 

--- a/data/admin/microorganism.py
+++ b/data/admin/microorganism.py
@@ -5,24 +5,16 @@ from simple_history.admin import SimpleHistoryAdmin
 
 from data.models import Microorganism
 
-from .abstract_admin import ChangeReasonAdminMixin
+from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
 
-class MicroorganismForm(forms.ModelForm):
+class MicroorganismForm(ChangeReasonFormMixin):
     class Meta:
         widgets = {
             "name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
             "public_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
-            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
-
-    # saved in ChangeReasonAdminMixin.save()
-    change_reason = forms.CharField(
-        label="Raison de modification",
-        help_text="100 caractères max",
-        max_length=100,
-    )
 
 
 @admin.register(Microorganism)

--- a/data/admin/microorganism.py
+++ b/data/admin/microorganism.py
@@ -14,6 +14,14 @@ class MicroorganismForm(forms.ModelForm):
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
         }
 
+    # saved in ElementAdminWithChangeReason.save()
+    change_reason = forms.CharField(
+        label="Raison de modification",
+        help_text="100 caractères max",
+        max_length=100,
+        widget=forms.TextInput(attrs={"size": "70"}),
+    )
+
 
 @admin.register(Microorganism)
 class MicroorganismAdmin(ElementAdminWithChangeReason):

--- a/data/admin/plant.py
+++ b/data/admin/plant.py
@@ -6,7 +6,7 @@ from simple_history.admin import SimpleHistoryAdmin
 
 from data.models import Plant, PlantSynonym
 
-from .abstract_admin import ChangeReasonAdminMixin
+from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
 
 class PlantSynonymInline(admin.TabularInline):
@@ -28,22 +28,14 @@ class SubstanceInlineAdmin(admin.TabularInline):
     extra = 1
 
 
-class PlantForm(forms.ModelForm):
+class PlantForm(ChangeReasonFormMixin):
     class Meta:
         widgets = {
             "name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
             "siccrf_name_en": forms.Textarea(attrs={"cols": 60, "rows": 1}),
             "public_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
-            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
-
-    # saved in ChangeReasonAdminMixin.save()
-    change_reason = forms.CharField(
-        label="Raison de modification",
-        help_text="100 caractères max",
-        max_length=100,
-    )
 
 
 @admin.register(Plant)

--- a/data/admin/plant.py
+++ b/data/admin/plant.py
@@ -51,6 +51,10 @@ class PlantAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = PlantForm
     fieldsets = [
         (
+            None,
+            {"fields": ["change_reason"]},
+        ),
+        (
             None,  # Pas d'entête
             {
                 "fields": [
@@ -82,10 +86,6 @@ class PlantAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
             {
                 "fields": ["siccrf_family", "ca_family"],
             },
-        ),
-        (
-            None,
-            {"fields": ["change_reason"]},
         ),
     ]
 

--- a/data/admin/plant.py
+++ b/data/admin/plant.py
@@ -35,6 +35,14 @@ class PlantForm(forms.ModelForm):
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
         }
 
+    # saved in ElementAdminWithChangeReason.save()
+    change_reason = forms.CharField(
+        label="Raison de modification",
+        help_text="100 caractères max",
+        max_length=100,
+        widget=forms.TextInput(attrs={"size": "70"}),
+    )
+
 
 @admin.register(Plant)
 class PlantAdmin(ElementAdminWithChangeReason):

--- a/data/admin/plant.py
+++ b/data/admin/plant.py
@@ -2,9 +2,11 @@ from django import forms
 from django.contrib import admin
 from django.db import models
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from data.models import Plant, PlantSynonym
 
-from .abstract_admin import ElementAdminWithChangeReason
+from .abstract_admin import ChangeReasonAdminMixin
 
 
 class PlantSynonymInline(admin.TabularInline):
@@ -33,19 +35,19 @@ class PlantForm(forms.ModelForm):
             "siccrf_name_en": forms.Textarea(attrs={"cols": 60, "rows": 1}),
             "public_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
+            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
 
-    # saved in ElementAdminWithChangeReason.save()
+    # saved in ChangeReasonAdminMixin.save()
     change_reason = forms.CharField(
         label="Raison de modification",
         help_text="100 caractères max",
         max_length=100,
-        widget=forms.TextInput(attrs={"size": "70"}),
     )
 
 
 @admin.register(Plant)
-class PlantAdmin(ElementAdminWithChangeReason):
+class PlantAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = PlantForm
     fieldsets = [
         (
@@ -80,6 +82,10 @@ class PlantAdmin(ElementAdminWithChangeReason):
             {
                 "fields": ["siccrf_family", "ca_family"],
             },
+        ),
+        (
+            None,
+            {"fields": ["change_reason"]},
         ),
     ]
 

--- a/data/admin/population.py
+++ b/data/admin/population.py
@@ -5,22 +5,14 @@ from simple_history.admin import SimpleHistoryAdmin
 
 from data.models import Population
 
-from .abstract_admin import ChangeReasonAdminMixin
+from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
 
-class PopulationForm(forms.ModelForm):
+class PopulationForm(ChangeReasonFormMixin):
     class Meta:
         widgets = {
             "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
-            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
-
-    # saved in ChangeReasonAdminMixin.save()
-    change_reason = forms.CharField(
-        label="Raison de modification",
-        help_text="100 caractères max",
-        max_length=100,
-    )
 
 
 @admin.register(Population)

--- a/data/admin/population.py
+++ b/data/admin/population.py
@@ -1,18 +1,30 @@
 from django import forms
 from django.contrib import admin
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from data.models import Population
+
+from .abstract_admin import ChangeReasonAdminMixin
 
 
 class PopulationForm(forms.ModelForm):
     class Meta:
         widgets = {
             "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
+            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
+
+    # saved in ChangeReasonAdminMixin.save()
+    change_reason = forms.CharField(
+        label="Raison de modification",
+        help_text="100 caractères max",
+        max_length=100,
+    )
 
 
 @admin.register(Population)
-class PopulationAdmin(admin.ModelAdmin):
+class PopulationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = PopulationForm
     fields = [
         "name",
@@ -25,6 +37,7 @@ class PopulationAdmin(admin.ModelAdmin):
         "max_age",
         "creation_date",
         "modification_date",
+        "change_reason",
     ]
     readonly_fields = [
         "name",

--- a/data/admin/population.py
+++ b/data/admin/population.py
@@ -27,6 +27,7 @@ class PopulationForm(forms.ModelForm):
 class PopulationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = PopulationForm
     fields = [
+        "change_reason",
         "name",
         "ca_name",
         "category",
@@ -37,7 +38,6 @@ class PopulationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
         "max_age",
         "creation_date",
         "modification_date",
-        "change_reason",
     ]
     readonly_fields = [
         "name",

--- a/data/admin/preparation.py
+++ b/data/admin/preparation.py
@@ -5,22 +5,14 @@ from simple_history.admin import SimpleHistoryAdmin
 
 from data.models import Preparation
 
-from .abstract_admin import ChangeReasonAdminMixin
+from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
 
-class PreparationForm(forms.ModelForm):
+class PreparationForm(ChangeReasonFormMixin):
     class Meta:
         widgets = {
             "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
-            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
-
-    # saved in ChangeReasonAdminMixin.save()
-    change_reason = forms.CharField(
-        label="Raison de modification",
-        help_text="100 caractères max",
-        max_length=100,
-    )
 
 
 @admin.register(Preparation)

--- a/data/admin/preparation.py
+++ b/data/admin/preparation.py
@@ -1,18 +1,30 @@
 from django import forms
 from django.contrib import admin
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from data.models import Preparation
+
+from .abstract_admin import ChangeReasonAdminMixin
 
 
 class PreparationForm(forms.ModelForm):
     class Meta:
         widgets = {
             "ca_name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
+            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
+
+    # saved in ChangeReasonAdminMixin.save()
+    change_reason = forms.CharField(
+        label="Raison de modification",
+        help_text="100 caractères max",
+        max_length=100,
+    )
 
 
 @admin.register(Preparation)
-class PreparationAdmin(admin.ModelAdmin):
+class PreparationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = PreparationForm
     fields = [
         "name",
@@ -22,6 +34,7 @@ class PreparationAdmin(admin.ModelAdmin):
         "contains_alcohol",
         "creation_date",
         "modification_date",
+        "change_reason",
     ]
     readonly_fields = [
         "name",

--- a/data/admin/preparation.py
+++ b/data/admin/preparation.py
@@ -27,6 +27,7 @@ class PreparationForm(forms.ModelForm):
 class PreparationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = PreparationForm
     fields = [
+        "change_reason",
         "name",
         "ca_name",
         "is_obsolete",
@@ -34,7 +35,6 @@ class PreparationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
         "contains_alcohol",
         "creation_date",
         "modification_date",
-        "change_reason",
     ]
     readonly_fields = [
         "name",

--- a/data/admin/substance.py
+++ b/data/admin/substance.py
@@ -19,6 +19,14 @@ class SubstanceForm(forms.ModelForm):
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
         }
 
+    # saved in ElementAdminWithChangeReason.save()
+    change_reason = forms.CharField(
+        label="Raison de modification",
+        help_text="100 caractères max",
+        max_length=100,
+        widget=forms.TextInput(attrs={"size": "70"}),
+    )
+
 
 class SubstanceSynonymInline(admin.TabularInline):
     model = SubstanceSynonym

--- a/data/admin/substance.py
+++ b/data/admin/substance.py
@@ -4,9 +4,11 @@ from django.db import models
 from django.urls import reverse
 from django.utils.html import format_html
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from data.models import Substance, SubstanceSynonym
 
-from .abstract_admin import ElementAdminWithChangeReason
+from .abstract_admin import ChangeReasonAdminMixin
 
 
 class SubstanceForm(forms.ModelForm):
@@ -17,14 +19,14 @@ class SubstanceForm(forms.ModelForm):
             "source": forms.Textarea(attrs={"cols": 60, "rows": 4}),
             "public_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
+            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
 
-    # saved in ElementAdminWithChangeReason.save()
+    # saved in ChangeReasonAdminMixin.save()
     change_reason = forms.CharField(
         label="Raison de modification",
         help_text="100 caractères max",
         max_length=100,
-        widget=forms.TextInput(attrs={"size": "70"}),
     )
 
 
@@ -38,7 +40,7 @@ class SubstanceSynonymInline(admin.TabularInline):
 
 
 @admin.register(Substance)
-class SubstanceAdmin(ElementAdminWithChangeReason):
+class SubstanceAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     @classmethod
     def links_to_objects(cls, object_name, objects):
         rel_list = "<ul>"
@@ -121,6 +123,10 @@ class SubstanceAdmin(ElementAdminWithChangeReason):
             {
                 "fields": ["get_plants", "get_microorganisms", "get_ingredients"],
             },
+        ),
+        (
+            None,
+            {"fields": ["change_reason"]},
         ),
     ]
     inlines = (SubstanceSynonymInline,)

--- a/data/admin/substance.py
+++ b/data/admin/substance.py
@@ -8,10 +8,10 @@ from simple_history.admin import SimpleHistoryAdmin
 
 from data.models import Substance, SubstanceSynonym
 
-from .abstract_admin import ChangeReasonAdminMixin
+from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
 
-class SubstanceForm(forms.ModelForm):
+class SubstanceForm(ChangeReasonFormMixin):
     class Meta:
         widgets = {
             "name": forms.Textarea(attrs={"cols": 60, "rows": 1}),
@@ -19,15 +19,7 @@ class SubstanceForm(forms.ModelForm):
             "source": forms.Textarea(attrs={"cols": 60, "rows": 4}),
             "public_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
             "private_comments": forms.Textarea(attrs={"cols": 60, "rows": 4}),
-            "change_reason": forms.TextInput(attrs={"size": "70"}),
         }
-
-    # saved in ChangeReasonAdminMixin.save()
-    change_reason = forms.CharField(
-        label="Raison de modification",
-        help_text="100 caractères max",
-        max_length=100,
-    )
 
 
 class SubstanceSynonymInline(admin.TabularInline):

--- a/data/admin/substance.py
+++ b/data/admin/substance.py
@@ -65,6 +65,10 @@ class SubstanceAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = SubstanceForm
     fieldsets = [
         (
+            None,
+            {"fields": ["change_reason"]},
+        ),
+        (
             None,  # Pas d'entête
             {
                 "fields": [
@@ -123,10 +127,6 @@ class SubstanceAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
             {
                 "fields": ["get_plants", "get_microorganisms", "get_ingredients"],
             },
-        ),
-        (
-            None,
-            {"fields": ["change_reason"]},
         ),
     ]
     inlines = (SubstanceSynonymInline,)


### PR DESCRIPTION
Cette PR :
- ajoute un champ "Raison de la modification" (toujours au début du formulaire, sinon ce champ se retrouve après tous les champs simples mais avant les Inline, donc au milieu, sauf si on modifie le template des pages d'admin, ce que je n'ai pas fait pour ne pas perdre trop de temps)
- enregistre ce champ dans le simple history de chaque modèle
- modifie une classe abstraite en mixin

Pour permettre à @HeleneDubourdieu  de préciser les raison des modifications qu'elle fait parfois dans l'admin

![image](https://github.com/user-attachments/assets/a9311306-46d4-4d75-8b8a-9cc2315f2fb4)
