### PR TITLE
Modification ingrédient : ajouter nom de l'utilisateur et champs modifiés dans l'historique

### DIFF
--- a/api/serializers/historical_record.py
+++ b/api/serializers/historical_record.py
@@ -11,11 +11,15 @@ class HistoricalRecordSerializer(serializers.Serializer):
     user = serializers.SerializerMethodField()
     history_date = serializers.DateTimeField()
     history_change_reason = serializers.CharField()
+    changed_fields = serializers.ListField(child=serializers.CharField())
 
     def get_user(self, obj):
-        users = User.objects.filter(id=obj.history_user_id)
-        if obj.history_user_id and users.exists():
+        users = User.objects.filter(id=obj["history_user_id"])
+        if obj["history_user_id"] and users.exists():
             return SimpleUserSerializer(users.first()).data
+
+    def to_representation(self, data):
+        return super().to_representation(data)
 
 
 class HistoricalRecordField(serializers.ListField):
@@ -29,7 +33,25 @@ class HistoricalRecordField(serializers.ListField):
             is_priviledged_user = False
 
         if is_priviledged_user:
-            records = HistoricalRecordSerializer(data, many=True).data
+            data_with_changes = []
+            history_list = list(data.all())
+            length = len(history_list)
+            for idx in range(length):
+                later_version = history_list[idx]
+                earlier_version = history_list[idx + 1] if idx + 1 < length else None
+                changes = later_version.diff_against(earlier_version) if earlier_version else None
+                changed_fields = changes.changed_fields if changes else []
+                obj_model_meta = type(data.first())._meta
+                translated_changed_fields = [obj_model_meta.get_field(f).verbose_name for f in changed_fields]
+                data_with_changes.append(
+                    {
+                        "history_date": later_version.history_date,
+                        "history_change_reason": later_version.history_change_reason,
+                        "history_user_id": later_version.history_user_id,
+                        "changed_fields": translated_changed_fields,
+                    }
+                )
+            records = HistoricalRecordSerializer(data_with_changes, many=True).data
             return super().to_representation(records)
         else:
             return super().to_representation(data.values("history_date", "history_change_reason"))

--- a/api/serializers/historical_record.py
+++ b/api/serializers/historical_record.py
@@ -1,8 +1,27 @@
+from django.contrib.auth import get_user_model
+
 from rest_framework import serializers
+
+from .user import SimpleUserSerializer
+
+User = get_user_model()
+
+
+# TODO: only change usage for view in question
+class HistoricalRecordSerializer(serializers.Serializer):
+    user = serializers.SerializerMethodField()
+    history_date = serializers.DateTimeField()
+    history_change_reason = serializers.CharField()
+
+    def get_user(self, obj):
+        users = User.objects.filter(id=obj.history_user_id)
+        if obj.history_user_id and users.exists():
+            return SimpleUserSerializer(users.first()).data
 
 
 class HistoricalRecordField(serializers.ListField):
     child = serializers.DictField()
 
     def to_representation(self, data):
-        return super().to_representation(data.values("history_date", "history_change_reason"))
+        dvs = HistoricalRecordSerializer(data, many=True).data
+        return super().to_representation(dvs)

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -47,11 +47,15 @@ class TestElementsFetchApi(APITestCase):
     @authenticate
     def test_get_single_plant_history_instructor(self):
         plant = PlantFactory.create()
+        plant.ca_name = "Test change"
+        plant.save()
+        self.assertEqual(plant.ca_name, "Test change")
         InstructionRoleFactory(user=authenticate.user)
         response = self.client.get(f"{reverse('api:single_plant', kwargs={'pk': plant.id})}?history=true")
         body = response.json()
 
         self.assertIn("user", body["history"][0])
+        self.assertEqual(body["history"][0]["changedFields"], ["nom CA"])
 
     @authenticate
     def test_plant_private_comments(self):

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -31,17 +31,27 @@ class TestElementsFetchApi(APITestCase):
         self.assertEqual(plant.name, body["name"])
         self.assertEqual(plant.id, body["id"])
 
-    def test_get_single_plant_history(self):
+    def test_get_single_plant_history_unauthenticated(self):
         plant = PlantFactory.create()
         response = self.client.get(f"{reverse('api:single_plant', kwargs={'pk': plant.id})}?history=true")
         body = response.json()
 
         self.assertIn("history", body)
+        self.assertNotIn("user", body["history"][0])
 
         response = self.client.get(reverse("api:single_plant", kwargs={"pk": plant.id}))
         body = response.json()
 
         self.assertNotIn("history", body)
+
+    @authenticate
+    def test_get_single_plant_history_instructor(self):
+        plant = PlantFactory.create()
+        InstructionRoleFactory(user=authenticate.user)
+        response = self.client.get(f"{reverse('api:single_plant', kwargs={'pk': plant.id})}?history=true")
+        body = response.json()
+
+        self.assertIn("user", body["history"][0])
 
     @authenticate
     def test_plant_private_comments(self):

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -25,7 +25,7 @@
 
         <DsfrTabContent panel-id="history-content" tab-id="history">
           <div class="-my-8">
-            <DsfrTable :rows="historyDataDedup" />
+            <DsfrTable :headers="headers" :rows="historyDataDedup" />
           </div>
         </DsfrTabContent>
       </DsfrTabs>
@@ -97,6 +97,8 @@ const forms = {
   microorganism: "Micro-organisme",
   ingredient: "Autre ingrédient",
 }
+
+const headers = ["Date", "Réalisée par", "Détail"]
 
 const historyData = computed(() =>
   element.value?.history

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -102,7 +102,8 @@ const historyData = computed(() =>
   element.value?.history
     .filter((item) => item.historyChangeReason)
     .map((item) => [
-      new Date(item.historyDate).toLocaleString("default", { month: "long", year: "numeric" }),
+      new Date(item.historyDate).toLocaleString("default", { day: "numeric", month: "long", year: "numeric" }),
+      item.user ? `${item.user.firstName} ${item.user.lastName}` : "",
       item.historyChangeReason,
     ])
 )

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -98,14 +98,15 @@ const forms = {
   ingredient: "Autre ingrédient",
 }
 
-const headers = ["Date", "Réalisée par", "Détail"]
+const headers = ["Date", "Réalisée par", "Champs modifiés", "Détail"]
 
 const historyData = computed(() =>
   element.value?.history
     .filter((item) => item.historyChangeReason)
     .map((item) => [
-      new Date(item.historyDate).toLocaleString("default", { day: "numeric", month: "long", year: "numeric" }),
+      new Date(item.historyDate).toLocaleString("default", { day: "numeric", month: "numeric", year: "numeric" }),
       item.user ? `${item.user.firstName} ${item.user.lastName}` : "",
+      item.changedFields.map((f) => `« ${f} »`).join(", "),
       item.historyChangeReason,
     ])
 )


### PR DESCRIPTION
Cette PR ajoute est à la suite de  #1707 

à noter que les champs qui sont un ManyToMany ne sont pas inclus dans l'historique... alors synonyme, substances, partie de plante etc

![Screenshot 2025-02-27 at 23-15-27 Modification ingrédient - Compl'Alim](https://github.com/user-attachments/assets/dc4e115e-6412-499b-acc7-a9c6c3863b85)

