### PR TITLE
Remplacement de demande : si le champ active du remplacement est modifiable, utilise la valeur de la demande

### DIFF
--- a/frontend/src/views/DeclaredElementPage/index.vue
+++ b/frontend/src/views/DeclaredElementPage/index.vue
@@ -38,6 +38,7 @@ import { useRootStore } from "@/stores/root"
 import { useRouter } from "vue-router"
 import { getApiType } from "@/utils/mappings"
 import { headers } from "@/utils/data-fetching"
+import { getActivityReadonlyByType } from "@/utils/mappings"
 import useToaster from "@/composables/use-toaster"
 import ElementInfo from "./ElementInfo"
 import ElementAlert from "./ElementAlert"
@@ -118,7 +119,11 @@ watch(replacement, (newReplacement) => {
   synonyms.value = JSON.parse(JSON.stringify(newReplacement.synonyms || []))
   additionalFields.value.element = JSON.parse(JSON.stringify(newReplacement))
   // le suivant devrait copier la logique pertinate de addElement, définit dans CompositionTab
-  additionalFields.value.active = !!newReplacement.activity
+  if (getActivityReadonlyByType(newReplacement.objectType)) {
+    // si l'activité n'est pas modifiable pour le nouveau type, s'assurer qu'on suit la même logique que CompositionTab, addElement
+    // sinon, utilise l'activité définit par le pro avec la demande
+    additionalFields.value.active = !!newReplacement.activity
+  }
   if (newReplacement.objectType === "microorganism" && newReplacement.objectType !== element.value.objectType) {
     additionalFields.value.activated = true
   }


### PR DESCRIPTION
Exemple d'une demande de plante inactive vers une autre plante (alors garde active comme false) et vers une microorganisme (alors rend actif l'ingrédient)

![Screenshot 2025-03-06 at 20-05-54 ma plante inactive - Compl'Alim](https://github.com/user-attachments/assets/78588ea3-c4aa-4bff-a2e4-278d1ebc63ae)
![Screenshot 2025-03-06 at 20-06-04 ma plante inactive - Compl'Alim](https://github.com/user-attachments/assets/f8919593-7b05-4bc7-a432-4bf952230964)
