### PR TITLE
Fix de la migration 124

### DIFF
--- a/data/migrations/0124_add_action_to_historical_declarations_snapshots.py
+++ b/data/migrations/0124_add_action_to_historical_declarations_snapshots.py
@@ -16,12 +16,13 @@ class Migration(migrations.Migration):
         """Set action to the first snapshot of declarations from TeleIcare"""
         Snapshot = apps.get_model("data", "Snapshot")
         for declaration in Declaration.objects.exclude(siccrf_id=None).iterator():
-            try:
-                snapshot = declaration.snapshots.filter(action=None) # filtre les snapshots créé via l'api pour éviter les snapshots de 'Retrait du marché' qui ont déjà une action
-                snapshot.action = compute_action(snapshot.status, 1) # en forçant le nb de version à 1 les actions RESPOND_ éventuelles seront remplacées par des actions SUBMIT
+
+            # filtre les snapshots créés via l'api pour éviter les snapshots de 'Retrait du marché' qui ont déjà une action,
+            # en forçant le nb de version à 1 les actions RESPOND_ éventuelles seront remplacées par des actions SUBMIT
+            snapshots_qs = declaration.snapshots.filter(action=None)
+            for snapshot in snapshots_qs:
+                snapshot.action = compute_action(snapshot.status, 1) 
                 snapshot.save()
-            except Snapshot.DoesNotExist:
-                pass
 
     def reverse_set_action(apps, schema_editor):
         pass


### PR DESCRIPTION
Closes #1781 

## 1. enlève  le try/catch

L'exception `Snapshot.DoesNotExist` était levée dans une version précédente de la migration où on utilisait `.earliest("creation_date")`. Depuis [ce commit](https://github.com/betagouv/complements-alimentaires/commit/b7a4c33ebd91534dc2bbf4e408b0e052fd657494)  on utilise `.filter` qui ne lève pas d'exception.

## 2. itère le résultat de `.filter` (queryset)

La ligne suivante traitait le résultat de `.filter` comme un objet snapshot, alors que c'était un queryset. 

```python
snapshot.action = compute_action(snapshot.status, 1)
```

Cette PR itère le résultat du `.filter` pour assigner la propriété `action`