### PR TITLE
Mise à jour boto / botocore / django-storages avec une nouvelle configuration

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import environ
 import sentry_sdk
+from botocore.client import Config as BotoConfig
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -212,6 +213,10 @@ if default_file_storage == "storages.backends.s3.S3Storage":
     AWS_STORAGE_BUCKET_NAME = env("CELLAR_BUCKET_NAME")
     AWS_LOCATION = "media"
     AWS_QUERYSTRING_AUTH = False
+    AWS_S3_CLIENT_CONFIG = BotoConfig(
+        request_checksum_calculation="when_required",
+        response_checksum_validation="when_required",
+    )
 
 MEDIA_ROOT = env("MEDIA_ROOT", default=os.path.join(BASE_DIR, "media"))
 MEDIA_URL = "/media/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ autopep8==2.3.2
 beautifulsoup4==4.13.3
 billiard==4.2.1
 bleach==6.2.0
-boto3==1.35.95
-botocore==1.35.95
+boto3==1.37.18
+botocore==1.37.18
 bs4==0.0.2
 celery==5.4.0
 certifi==2025.1.31
@@ -100,7 +100,7 @@ reportlab==4.3.1
 requests==2.32.3
 requests-mock==1.12.1
 ruff==0.11.0
-s3transfer==0.10.4
+s3transfer==0.11.4
 sentry-sdk==2.20.0
 sib-api-v3-sdk==7.6.0
 six==1.17.0


### PR DESCRIPTION
Suite au breaking change et non-suivi de Semver de la [part de boto](https://github.com/boto/boto3/issues/4392), cette PR vise à remettre les dernières versions des dépendances S3.

# À surveiller

L'[issue boto](https://github.com/boto/boto3/issues/4392) est encore ouvert, et notamment il semble avoir des soucis encore avec la suppression ([commentaire ici](https://github.com/boto/boto3/issues/4392#issuecomment-2651900564)). Nous n'avons pas de suppression via l'API donc on n'est pour l'instant pas concernés.

---

@pletelli [certains commentaires](https://github.com/jschneier/django-storages/issues/1482#issuecomment-2710052738) faisaient aussi mention d'un souci avec des ressources privées. Est-ce qu'on a des buckets privés accédés via boto ?

