### PR TITLE
Filtre composition dans la recherche avancée

### DIFF
--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -13,6 +13,7 @@ from data.factories import (
     AwaitingInstructionDeclarationFactory,
     AwaitingVisaDeclarationFactory,
     CompanyFactory,
+    ComputedSubstanceFactory,
     ConditionFactory,
     DeclarantRoleFactory,
     DeclarationFactory,
@@ -39,9 +40,9 @@ from data.factories import (
     VisaRoleFactory,
 )
 from data.models import (
+    Addable,
     Attachment,
     Declaration,
-    Addable,
     DeclaredMicroorganism,
     DeclaredPlant,
     DeclaredSubstance,
@@ -1965,6 +1966,89 @@ class TestDeclaredElementsApi(APITestCase):
         response = self.client.get(filter_url, format="json")
         results = response.json()
         self.assertEqual(results["count"], 4)
+
+    @authenticate
+    def test_filter_by_composition(self):
+        """
+        On peut filtrer par composition (utilisé dans la recherche avancée)
+        """
+        InstructionRoleFactory(user=authenticate.user)
+
+        camomille = PlantFactory(name="Camomille")
+        declaration_camomille = AwaitingInstructionDeclarationFactory()
+        DeclaredPlantFactory(plant=camomille, declaration=declaration_camomille)
+
+        eucalyptus = PlantFactory(name="Eucalyptus")
+        declaration_eucalyptus = AwaitingInstructionDeclarationFactory()
+        DeclaredPlantFactory(plant=eucalyptus, declaration=declaration_eucalyptus)
+
+        lactobacilus = MicroorganismFactory(name="Lactobacilus")
+        declaration_lactobacilus = AwaitingInstructionDeclarationFactory()
+        DeclaredMicroorganismFactory(microorganism=lactobacilus, declaration=declaration_lactobacilus)
+
+        streptococcus = MicroorganismFactory(name="Streptococcus")
+        declaration_streptococcus = AwaitingInstructionDeclarationFactory()
+        DeclaredMicroorganismFactory(microorganism=streptococcus, declaration=declaration_streptococcus)
+
+        flavanones = SubstanceFactory(name="Flavanones")
+        declaration_flavanones = AwaitingInstructionDeclarationFactory()
+        ComputedSubstanceFactory(substance=flavanones, declaration=declaration_flavanones)
+
+        levain = IngredientFactory(name="Levain")
+        declaration_levain = AwaitingInstructionDeclarationFactory()
+        DeclaredIngredientFactory(ingredient=levain, declaration=declaration_levain)
+
+        declaration_both_plants = AwaitingInstructionDeclarationFactory()
+        DeclaredPlantFactory(plant=camomille, declaration=declaration_both_plants)
+        DeclaredPlantFactory(plant=eucalyptus, declaration=declaration_both_plants)
+
+        declaration_both_microorganisms = AwaitingInstructionDeclarationFactory()
+        DeclaredMicroorganismFactory(microorganism=lactobacilus, declaration=declaration_both_microorganisms)
+        DeclaredMicroorganismFactory(microorganism=streptococcus, declaration=declaration_both_microorganisms)
+
+        declaration_plant_mo = AwaitingInstructionDeclarationFactory()
+        DeclaredPlantFactory(plant=camomille, declaration=declaration_plant_mo)
+        DeclaredMicroorganismFactory(microorganism=lactobacilus, declaration=declaration_plant_mo)
+
+        filter_url = f"{reverse('api:list_all_declarations')}?plants={camomille.id}"
+        response = self.client.get(filter_url, format="json")
+        body = response.json()
+        self.assertEqual(body["count"], 3)
+        self.assertIn(declaration_camomille.id, map(lambda x: x["id"], body["results"]))
+        self.assertIn(declaration_both_plants.id, map(lambda x: x["id"], body["results"]))
+        self.assertIn(declaration_plant_mo.id, map(lambda x: x["id"], body["results"]))
+
+        filter_url = f"{reverse('api:list_all_declarations')}?plants={camomille.id},{eucalyptus.id}"
+        response = self.client.get(filter_url, format="json")
+        body = response.json()
+        self.assertEqual(body["count"], 1)
+        self.assertIn(declaration_both_plants.id, map(lambda x: x["id"], body["results"]))
+
+        filter_url = f"{reverse('api:list_all_declarations')}?microorganisms={lactobacilus.id}"
+        response = self.client.get(filter_url, format="json")
+        body = response.json()
+        self.assertEqual(body["count"], 3)
+        self.assertIn(declaration_lactobacilus.id, map(lambda x: x["id"], body["results"]))
+        self.assertIn(declaration_both_microorganisms.id, map(lambda x: x["id"], body["results"]))
+        self.assertIn(declaration_plant_mo.id, map(lambda x: x["id"], body["results"]))
+
+        filter_url = f"{reverse('api:list_all_declarations')}?microorganisms={lactobacilus.id}&plants={camomille.id}"
+        response = self.client.get(filter_url, format="json")
+        body = response.json()
+        self.assertEqual(body["count"], 1)
+        self.assertIn(declaration_plant_mo.id, map(lambda x: x["id"], body["results"]))
+
+        filter_url = f"{reverse('api:list_all_declarations')}?substances={flavanones.id}"
+        response = self.client.get(filter_url, format="json")
+        body = response.json()
+        self.assertEqual(body["count"], 1)
+        self.assertIn(declaration_flavanones.id, map(lambda x: x["id"], body["results"]))
+
+        filter_url = f"{reverse('api:list_all_declarations')}?ingredients={levain.id}"
+        response = self.client.get(filter_url, format="json")
+        body = response.json()
+        self.assertEqual(body["count"], 1)
+        self.assertIn(declaration_levain.id, map(lambda x: x["id"], body["results"]))
 
     @authenticate
     def test_order_by_creation_date(self):

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -155,7 +155,7 @@ class DeclarationFilterSet(django_filters.FilterSet):
     def _annotate_queryset(self, queryset):
         return queryset.annotate(name_unaccented_lower=Lower(Unaccent(F("company__social_name"))))
 
-    def status__in(self, queryset, name, value, *args, **kwargs):
+    def status__in(self, queryset, value, *args, **kwargs):
         return queryset.filter(status__in=args[0].split(","))
 
     def plants__and(self, queryset, name, value, *args, **kwargs):

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -66,6 +66,10 @@ class DeclarationFilterSet(django_filters.FilterSet):
     company_name_start = django_filters.CharFilter(method="company_name_start__gte")
     company_name_end = django_filters.CharFilter(method="company_name_end__lte")
     status = django_filters.CharFilter(method="status__in")
+    plants = django_filters.CharFilter(method="plants__and")
+    microorganisms = django_filters.CharFilter(method="microorganisms__and")
+    substances = django_filters.CharFilter(method="substances__and")
+    ingredients = django_filters.CharFilter(method="ingredients__and")
 
     # Une fois https://github.com/carltongibson/django-filter/issues/1673 on peut
     # enlever cette ligne
@@ -151,8 +155,28 @@ class DeclarationFilterSet(django_filters.FilterSet):
     def _annotate_queryset(self, queryset):
         return queryset.annotate(name_unaccented_lower=Lower(Unaccent(F("company__social_name"))))
 
-    def status__in(self, queryset, value, *args, **kwargs):
+    def status__in(self, queryset, name, value, *args, **kwargs):
         return queryset.filter(status__in=args[0].split(","))
+
+    def plants__and(self, queryset, name, value, *args, **kwargs):
+        for id in value.split(","):
+            queryset = queryset.filter(declared_plants__plant__id=id)
+        return queryset
+
+    def microorganisms__and(self, queryset, name, value, *args, **kwargs):
+        for id in value.split(","):
+            queryset = queryset.filter(declared_microorganisms__microorganism__id=id)
+        return queryset
+
+    def substances__and(self, queryset, name, value, *args, **kwargs):
+        for id in value.split(","):
+            queryset = queryset.filter(computed_substances__substance__id=id)
+        return queryset
+
+    def ingredients__and(self, queryset, name, value, *args, **kwargs):
+        for id in value.split(","):
+            queryset = queryset.filter(declared_ingredients__ingredient__id=id)
+        return queryset
 
 
 class UserDeclarationPagination(DeclarationPagination):
@@ -369,7 +393,7 @@ class OngoingDeclarationsListView(GenericDeclarationsListView):
         UnaccentSearchFilter,
     ]
     ordering_fields = ["creation_date", "modification_date", "name", "response_limit_date"]
-    queryset = Declaration.objects.exclude(status=Declaration.DeclarationStatus.DRAFT)
+    queryset = Declaration.objects.exclude(status=Declaration.DeclarationStatus.DRAFT).distinct()
 
 
 class OpenDataDeclarationsListView(GenericDeclarationsListView):

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -444,6 +444,7 @@ const routes = [
         galenicFormulation: "",
         limit: "10",
         recherche: "",
+        composition: "",
       },
     },
   },

--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -212,22 +212,47 @@ const removeIngredient = (idx) => {
   ingredientsToFilter.value.splice(idx, 1)
   updateComposition()
 }
+const getApiUrlIdsForType = (types) => {
+  const ids =
+    ingredientsToFilter.value
+      ?.filter((x) => types.indexOf(x[2]) > -1)
+      .map((x) => x[0])
+      .join(",") || []
+  return ids.length ? ids : null
+}
 
 // Requêtes
 
 const url = computed(() => {
   const baseUrl = "/api/v1/declarations"
-  const limitQuery = limit.value ? `limit=${limit.value}` : ""
-  const offsetQuery = offset.value ? `offset=${offset.value}` : ""
-  const statusQuery = filteredStatus.value ? `status=${filteredStatus.value}` : ""
-  const orderingQuery = ordering.value ? `ordering=${ordering.value}` : ""
-  const articleQuery = article.value ? `article=${article.value}` : ""
-  const populationQuery = population.value ? `population=${population.value}` : ""
-  const conditionQuery = condition.value ? `condition=${condition.value}` : ""
-  const galenicFormulationQuery = galenicFormulation.value ? `galenic_formulation=${galenicFormulation.value}` : ""
-  const searchQuery = searchTerm.value ? `search=${searchTerm.value}` : ""
+  const limitQuery = limit.value ? `?limit=${limit.value}` : "?"
+  const offsetQuery = offset.value ? `&offset=${offset.value}` : ""
+  const statusQuery = filteredStatus.value ? `&status=${filteredStatus.value}` : ""
+  const orderingQuery = ordering.value ? `&ordering=${ordering.value}` : ""
+  const articleQuery = article.value ? `&article=${article.value}` : ""
+  const populationQuery = population.value ? `&population=${population.value}` : ""
+  const conditionQuery = condition.value ? `&condition=${condition.value}` : ""
+  const galenicFormulationQuery = galenicFormulation.value ? `&galenic_formulation=${galenicFormulation.value}` : ""
+  const searchQuery = searchTerm.value ? `&search=${searchTerm.value}` : ""
 
-  const fullPath = `${baseUrl}/?${limitQuery}&${offsetQuery}&${statusQuery}&${orderingQuery}&${articleQuery}&${populationQuery}&${conditionQuery}&${galenicFormulationQuery}&${searchQuery}`
+  const plantIds = getApiUrlIdsForType(["plant"])
+  const microorganismIds = getApiUrlIdsForType(["microorganism"])
+  const substanceIds = getApiUrlIdsForType(["substance"])
+  const ingredientsIds = getApiUrlIdsForType([
+    "ingredient",
+    "form_of_supply",
+    "aroma",
+    "additive",
+    "active_ingredient",
+    "non_active_ingredient",
+  ])
+
+  const plantsQuery = plantIds ? `&plants=${plantIds}` : ""
+  const microorganismsQuery = microorganismIds ? `&microorganisms=${microorganismIds}` : ""
+  const substancesQuery = substanceIds ? `&substances=${substanceIds}` : ""
+  const ingredientsQuery = ingredientsIds ? `&ingredients=${ingredientsIds}` : ""
+
+  const fullPath = `${baseUrl}/${limitQuery}${offsetQuery}${statusQuery}${orderingQuery}${articleQuery}${populationQuery}${conditionQuery}${galenicFormulationQuery}${searchQuery}${plantsQuery}${microorganismsQuery}${substancesQuery}${ingredientsQuery}`
 
   // Enlève les `&` consecutifs
   return fullPath.replace(/&+/g, "&").replace(/&$/, "")

--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -145,7 +145,7 @@ import { getPagesForPagination } from "@/utils/components"
 import SearchResultsTable from "./SearchResultsTable"
 import { useRootStore } from "@/stores/root"
 import ElementAutocomplete from "@/components/ElementAutocomplete.vue"
-import { getTypeIcon, getTypeInFrench } from "@/utils/mappings"
+import { getTypeIcon, getTypeInFrench, typesMapping } from "@/utils/mappings"
 
 const store = useRootStore()
 store.fetchDeclarationFieldsData()
@@ -201,9 +201,14 @@ const pages = computed(() => getPagesForPagination(data.value?.count, limit.valu
 // les noms d'ingrédients. Par exemple, une plante avec un ID: 12 et nom: Fraise serait codifiée
 // dans le URL : `composition=12||Fraise||plant`. Le triple pipe "|||" sépare chaque élément.
 const ingredientSearchTerm = ref()
-const ingredientsToFilter = computed(() =>
-  route.query.composition ? route.query.composition.split("|||").map((x) => x?.split("||")) : []
-)
+const ingredientsToFilter = computed(() => {
+  if (route.query.composition)
+    return route.query.composition
+      .split("|||")
+      .map((x) => x?.split("||"))
+      .filter((x) => x?.[2] && x[2] in typesMapping)
+  return []
+})
 const addIngredient = (x) => {
   ingredientsToFilter.value.push([x.id, x.name, x.objectType])
   updateComposition()

--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -102,7 +102,7 @@
                   :aria-label="`Retirer ${name}`"
                   tagName="button"
                 >
-                  <v-icon scale="0.85" class="mr-2" :name="getTypeIcon(type)" :aria-label="getTypeInFrench(type)" />
+                  <v-icon scale="0.85" class="mr-1" :name="getTypeIcon(type)" :aria-label="getTypeInFrench(type)" />
                   {{ name }}
                 </DsfrTag>
               </div>


### PR DESCRIPTION
Lié à #1640 

## Contexte

Le filtre _composition_ est attendu dans la recherche avancée. Cette PR est une première implémentation.

## Scope

### UI

![image](https://github.com/user-attachments/assets/1e85ee03-482b-426d-8dff-ef3a8caa10b7)

Le filtre contient l'autocomplete et des _DsfrTag_ pour montrer les ingrédients présents dans le filtre

À noter qu'il s'agit d'un filtre "and". La raison es que pour faire un filtre "or" on peut simplement ouvrir un autre onglet, alors que chercher la combinaison dans la composition serait impossible d'une autre façon.

La valeur du filtre est codifiée dans l'URL utilisant `||` et `|||` comme séparateurs pour ne pas entrer en conflit avec le nommage des ingrédients.

### Pour après

Le fait qu'on utilise des `DsfrTag` pour représenter les ingrédients cherchés peut être étendu pour montrer un modal et peaufiner la recherche (par ex en incluant des doses).

### Démo

https://github.com/user-attachments/assets/dec6df8d-3a2d-4af4-a177-d540824f98de

