### PR TITLE
Ajout de la mesure d'impact Gain de temps à l'instruction 2

### DIFF
--- a/frontend/src/views/StatsPage.vue
+++ b/frontend/src/views/StatsPage.vue
@@ -29,13 +29,14 @@
         <DsfrAccordion id="accordion-1" title="Gain de temps à l'instruction">
           <h4>Statistiques de temps passé entre la soumission d'une déclaration et sa validation</h4>
           <p>
-            En réduisant le temps de validation, les déclarants sont plus satisfaits car ils peuvent mettre leur produit
-            sur le marché plus rapidement, et le BEPIAS peut concentrer ses efforts sur les cas les plus complexes.
+            L’instruction automatique de certaines déclarations permet au BEPIAS de concentrer ses efforts sur les cas
+            les plus complexes. Le temps de validation est ainsi réduit et les déclarants sont plus satisfaits car ils
+            peuvent mettre leurs produits sur le marché plus rapidement.
           </p>
           <p>
             Avec Compl'Alim, nous avons mis en place une aide à l'instruction pour le BEPIAS en octobre 2024. Nous
-            améliorons en continu les outils et les méthodes d'évaluation pour réduire le temps d'instruction, selon la
-            législation française et les retours d'utilisateurs.
+            améliorons en continu les outils et les méthodes d'évaluation pour réduire le temps d'instruction, en tenant
+            compte des évolutions réglementaires et des retours d'utilisateurs.
           </p>
           <iframe
             src="https://compl-alim-metabase.cleverapps.io/public/question/572252e2-0d2a-4465-8ec4-c9f594508f15"

--- a/frontend/src/views/StatsPage.vue
+++ b/frontend/src/views/StatsPage.vue
@@ -27,6 +27,7 @@
           ></iframe>
         </DsfrAccordion>
         <DsfrAccordion id="accordion-1" title="Gain de temps à l'instruction">
+          <h4>Nombre de déclaration à instruction facilitée par mois</h4>
           <p>
             Notre outil permet l'automatisation de l'instruction de certaines déclarations ARTICLE 15 sans risque. Ces
             déclarations n'étaient pas facilement identifiables auparavant et devaient nécessairement passer par le même
@@ -42,6 +43,8 @@
             height="600"
             allowtransparency
           ></iframe>
+          <br />
+          <h4>Statistiques de temps passé entre la soumission d'une déclaration et sa validation</h4>
           <p>
             Le temps passé entre la soumission d'une déclaration et son autorisation reflète la complexité de
             l'instruction. Celui-ci devrait diminuer au fur et à mesure de nos efforts pour rendre la règlementation

--- a/frontend/src/views/StatsPage.vue
+++ b/frontend/src/views/StatsPage.vue
@@ -27,7 +27,25 @@
           ></iframe>
         </DsfrAccordion>
         <DsfrAccordion id="accordion-1" title="Gain de temps à l'instruction">
-          <h4>Nombre de déclaration à instruction facilitée par mois</h4>
+          <h4>Statistiques de temps passé entre la soumission d'une déclaration et sa validation</h4>
+          <p>
+            En réduisant le temps de validation, les déclarants sont plus satisfaits car ils peuvent mettre leur produit
+            sur le marché plus rapidement, et le BEPIAS peut concentrer ses efforts sur les cas les plus complexes.
+          </p>
+          <p>
+            Avec Compl'Alim, nous avons mis en place une aide à l'instruction pour le BEPIAS en octobre 2024. Nous
+            améliorons en continu les outils et les méthodes d'évaluation pour réduire le temps d'instruction, selon la
+            législation française et les retours d'utilisateurs.
+          </p>
+          <iframe
+            src="https://compl-alim-metabase.cleverapps.io/public/question/572252e2-0d2a-4465-8ec4-c9f594508f15"
+            frameborder="0"
+            width="800"
+            height="600"
+            allowtransparency
+          ></iframe>
+          <br />
+          <h4>Impact de l'instruction facilitée</h4>
           <p>
             Notre outil permet l'automatisation de l'instruction de certaines déclarations ARTICLE 15 sans risque. Ces
             déclarations n'étaient pas facilement identifiables auparavant et devaient nécessairement passer par le même
@@ -38,20 +56,6 @@
           </p>
           <iframe
             src="https://compl-alim-metabase.cleverapps.io/public/question/c99b0f9a-77e2-470f-b2a6-98a8ac3a4a46"
-            frameborder="0"
-            width="800"
-            height="600"
-            allowtransparency
-          ></iframe>
-          <br />
-          <h4>Statistiques de temps passé entre la soumission d'une déclaration et sa validation</h4>
-          <p>
-            Le temps passé entre la soumission d'une déclaration et son autorisation reflète la complexité de
-            l'instruction. Celui-ci devrait diminuer au fur et à mesure de nos efforts pour rendre la règlementation
-            plus lisible et notre outil plus convivial.
-          </p>
-          <iframe
-            src="https://compl-alim-metabase.cleverapps.io/public/question/572252e2-0d2a-4465-8ec4-c9f594508f15"
             frameborder="0"
             width="800"
             height="600"

--- a/frontend/src/views/StatsPage.vue
+++ b/frontend/src/views/StatsPage.vue
@@ -43,12 +43,12 @@
             allowtransparency
           ></iframe>
           <p>
-            Le temps passé entre la première ouverture d'une déclaration lors de l'instruction et son autorisation ou
-            demande de visa reflète la complexité de l'instruction. Celui-ci devrait diminuer au fur et à mesure de nos
-            efforts pour rendre la règlementation plus lisible et notre outil plus convivial.
+            Le temps passé entre la soumission d'une déclaration et son autorisation reflète la complexité de
+            l'instruction. Celui-ci devrait diminuer au fur et à mesure de nos efforts pour rendre la règlementation
+            plus lisible et notre outil plus convivial.
           </p>
           <iframe
-            src="https://compl-alim-metabase.cleverapps.io/public/question/c99b0f9a-77e2-470f-b2a6-98a8ac3a4a46"
+            src="https://compl-alim-metabase.cleverapps.io/public/question/572252e2-0d2a-4465-8ec4-c9f594508f15"
             frameborder="0"
             width="800"
             height="600"

--- a/frontend/src/views/StatsPage.vue
+++ b/frontend/src/views/StatsPage.vue
@@ -42,6 +42,18 @@
             height="600"
             allowtransparency
           ></iframe>
+          <p>
+            Le temps passé entre la première ouverture d'une déclaration lors de l'instruction et son autorisation ou
+            demande de visa reflète la complexité de l'instruction. Celui-ci devrait diminuer au fur et à mesure de nos
+            efforts pour rendre la règlementation plus lisible et notre outil plus convivial.
+          </p>
+          <iframe
+            src="https://compl-alim-metabase.cleverapps.io/public/question/c99b0f9a-77e2-470f-b2a6-98a8ac3a4a46"
+            frameborder="0"
+            width="800"
+            height="600"
+            allowtransparency
+          ></iframe>
         </DsfrAccordion>
         <DsfrAccordion id="accordion-1" title="Qualité des déclarations déposées">
           <p>


### PR DESCRIPTION
Carte notion [ici](https://www.notion.so/incubateur-masa/D-lai-entre-ouverture-de-la-d-claration-et-action-validation-ou-visa-1bade24614be80d295e4c409389457fb)
SQL à vérifier [ici](https://compl-alim-metabase.cleverapps.io/question/336-delai-entre-ouverture-de-la-declaration-et-validation-visa)

![image](https://github.com/user-attachments/assets/06121c69-8537-41b5-8509-b3f8d48af45b)


Contrairement à la carte notion c'est le temps passé entre la soumission et la validation (au lieu de la première action d'ouverture de la déclaration par une instructrice) qui est calculé.
Car cette donnée de première ouverture par une instructrice n'est actuellement pas conservée. cf https://github.com/betagouv/complements-alimentaires/issues/1842