### PR TITLE
Enlever le distinction entre les parties de plantes utiles et non

### DIFF
--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -152,9 +152,7 @@ const icon = computed(() => getTypeIcon(type.value))
 // Information affichée
 const family = computed(() => element.value?.family?.name)
 const genre = computed(() => element.value?.genre)
-const plantParts = computed(() =>
-  element.value?.plantParts?.filter((x) => x.isUseful === true && !!x.name).map((x) => x.name)
-)
+const plantParts = computed(() => element.value?.plantParts?.map((x) => x.name))
 const substances = computed(() => element.value?.substances)
 const synonyms = computed(() => element.value?.synonyms?.map((x) => x.name).filter((x) => !!x))
 const casNumber = computed(() => element.value?.casNumber)


### PR DESCRIPTION
Closes #1832 

Dans le fiche d'une plante, il y avait un filtre sur les parties de plantes affichées pour que afficher les parties dites "utiles" dans la base.

![Screenshot 2025-03-27 at 16-51-56 Corymbia citriodora (Hook ) K D Hill   L A S  Johnson - Compl'Alim](https://github.com/user-attachments/assets/f98a4209-2858-4686-bd81-79477fde8885)


Je vois que `isUseful`/`is_useful` n'est nulle part utilisé hors de ça. Plus spécifiquement, je vois que ce n'impacte pas la liste d'options présentée au déclarant quand il fait sa composition. AMA la liste là et la liste sur le fiche de l'ingrédient devrait être les mêmes. L'enlèvement du filtre est le changement le moins impactant que j'ai identifié.

D'après notre discussion sur mattermost, je me demande si ce champ (et aussi `must_be_monitored` ?) devrait être supprimé un jour ? Ou est-ce qu'on pense à l'utiliser à l'avenir ?