### PR TITLE
Rendre l'unité non-modifiable pour les substances existantes

### DIFF
--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -158,7 +158,7 @@ export default { name: "DeclarationSummary" }
 </script>
 
 <script setup>
-import { getObjectSubTypeList, getUnitString } from "@/utils/elements"
+import { getObjectSubTypeList, getUnitQuantityString } from "@/utils/elements"
 import { computed } from "vue"
 import AddressLine from "@/components/AddressLine"
 import SummaryInfoSegment from "./SummaryInfoSegment"
@@ -184,7 +184,7 @@ defineProps({
   showElementAuthorization: Boolean,
   useCompactAttachmentView: Boolean,
 })
-const unitInfo = computed(() => getUnitString(payload.value, units))
+const unitInfo = computed(() => getUnitQuantityString(payload.value, units))
 
 const galenicFormulationsNames = computed(() => {
   if (!payload.value.galenicFormulation) return null

--- a/frontend/src/utils/elements.js
+++ b/frontend/src/utils/elements.js
@@ -14,8 +14,12 @@ export const getObjectSubTypeList = (objectList, subType = null) => {
 
 export const getElementUrlComponent = (e, type) => `${e.id}--${slugifyType(type || e.objectType)}--${e.name}`
 
-export const getUnitString = (declaration, units) => {
+export const getUnitQuantityString = (declaration, units) => {
   if (!declaration?.unitQuantity) return null
-  const unitMeasurement = units.value?.find?.((x) => x.id === declaration.unitMeasurement)?.name || "-"
+  const unitMeasurement = getUnitString(declaration.unitMeasurement, units)
   return `${declaration.unitQuantity} ${unitMeasurement}`
+}
+
+export const getUnitString = (unitId, units) => {
+  return units.value?.find?.((x) => x.id === unitId)?.name || "-"
 }

--- a/frontend/src/views/AdvancedSearchPage/SearchResultsTable.vue
+++ b/frontend/src/views/AdvancedSearchPage/SearchResultsTable.vue
@@ -17,7 +17,7 @@ import { getStatusTagForCell } from "@/utils/components"
 import CompanyTableCell from "@/components/CompanyTableCell"
 import DeclarationName from "@/components/DeclarationName"
 import { articleOptionsWith15Subtypes } from "@/utils/mappings"
-import { getUnitString } from "@/utils/elements"
+import { getUnitQuantityString } from "@/utils/elements"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 
@@ -41,7 +41,7 @@ const rows = computed(() => {
         class: "font-medium",
         to: { name: "AdvancedSearchResult", params: { declarationId: d.id } },
       },
-      getUnitString(d, units),
+      getUnitQuantityString(d, units),
       {
         component: CompanyTableCell,
         company: d.company?.socialName,

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -149,8 +149,8 @@
               defaultUnselectedText="Unité"
             />
           </DsfrInputGroup>
-          <div v-else>
-            <p>Unité</p>
+          <div v-else class="pt-4">
+            <p class="mb-2">Unité</p>
             <p>{{ unitString }}</p>
           </div>
         </div>

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -140,7 +140,7 @@
           <NumberField label="Quantité maximale autorisée" label-visible v-model="state.maxQuantity" />
         </DsfrInputGroup>
         <div class="max-w-32">
-          <DsfrInputGroup :error-message="firstErrorMsg(v$, 'unit')">
+          <DsfrInputGroup v-if="isNewIngredient" :error-message="firstErrorMsg(v$, 'unit')">
             <DsfrSelect
               label="Unité"
               label-visible
@@ -149,6 +149,10 @@
               defaultUnselectedText="Unité"
             />
           </DsfrInputGroup>
+          <div v-else>
+            <p>Unité</p>
+            <p>{{ unitString }}</p>
+          </div>
         </div>
       </div>
       <p class="my-4"><i>Population cible et à risque en construction</i></p>
@@ -188,6 +192,7 @@ import { useFetch } from "@vueuse/core"
 import { headers } from "@/utils/data-fetching"
 import { handleError } from "@/utils/error-handling"
 import { firstErrorMsg, errorRequiredField, errorNumeric, errorMaxStringLength } from "@/utils/forms"
+import { getUnitString } from "@/utils/elements"
 import { useVuelidate } from "@vuelidate/core"
 import useToaster from "@/composables/use-toaster"
 import FormWrapper from "@/components/FormWrapper"
@@ -322,7 +327,7 @@ const $externalResults = ref({})
 const v$ = useVuelidate(rules, state, { $externalResults })
 
 const store = useRootStore()
-const { plantParts, plantFamilies } = storeToRefs(store)
+const { plantParts, plantFamilies, units } = storeToRefs(store)
 store.fetchDeclarationFieldsData()
 store.fetchPlantFamilies()
 
@@ -355,4 +360,8 @@ const plantFamiliesDisplay = computed(() => {
 })
 
 const aromaId = 3
+
+const unitString = computed(() => {
+  return getUnitString(state.value.unit, units)
+})
 </script>


### PR DESCRIPTION
En travaillant sur l'interface de max dose par population, je me suis rendu compte qu'on ne gère pas la possibilité d'une modification d'unité d'une substance. CAD la substance est utilisée dans des déclarations, et on fait le check sur le dosage renseigné pour faire le calcul d'article : si on modifie l'unité, qu'est-ce qu'on fait avec les déclarations déjà existantes ? La solution me paraît complèxe pour un cas que j'imagine est rare, alors je préfère de bloquer la modification de l'unité pour le moment.

Est-ce que vous pensez que ça vaut le coup de faire le même changement côté API et admin ?

![Screenshot 2025-03-27 at 17-14-56 Modification ingrédient - Compl'Alim](https://github.com/user-attachments/assets/c0b670a7-2f48-4790-bb10-7481a917e6f9)

![Screenshot 2025-03-27 at 17-06-13 Nouvel ingrédient - Compl'Alim](https://github.com/user-attachments/assets/18993a49-444d-4eaa-be60-b5f1c65eb74e)
