### PR TITLE
:lady_beetle: Mauvais article assigné aux déclarations ayant des nutriments avec des doses max différentes par population

### DIFF
--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -312,6 +312,7 @@ class TestDeclarationApi(APITestCase):
         )
 
         declaration = Declaration.objects.get(pk=response.json()["id"])
+
         self.assertEqual(declaration.article, Declaration.Article.ARTICLE_16)
 
     @authenticate

--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -39,9 +39,9 @@ from data.factories import (
     VisaRoleFactory,
 )
 from data.models import (
+    Addable,
     Attachment,
     Declaration,
-    Addable,
     DeclaredMicroorganism,
     DeclaredPlant,
     DeclaredSubstance,
@@ -272,7 +272,7 @@ class TestDeclarationApi(APITestCase):
         """
         declarant_role = DeclarantRoleFactory(user=authenticate.user)
         company = declarant_role.company
-
+        PopulationFactory(ca_name="Population générale")
         plant = PlantFactory()
         plant_part = PlantPartFactory()
         plant.plant_parts.add(plant_part)
@@ -310,6 +310,7 @@ class TestDeclarationApi(APITestCase):
             payload,
             format="json",
         )
+
         declaration = Declaration.objects.get(pk=response.json()["id"])
         self.assertEqual(declaration.article, Declaration.Article.ARTICLE_16)
 
@@ -879,6 +880,7 @@ class TestDeclarationApi(APITestCase):
         Il est possible d'ajouter un query_param pour forcer le calcul de l'article
         dans la sauvegarde
         """
+        PopulationFactory(ca_name="Population générale")
         declarant_role = DeclarantRoleFactory(user=authenticate.user)
         company = declarant_role.company
         user_declaration = DeclarationFactory(author=authenticate.user, name="Old name", company=company)
@@ -1654,6 +1656,7 @@ class TestDeclarationApi(APITestCase):
         """
         Les viseuses ou instructrices peuvent changer l'article d'une déclaration
         """
+        PopulationFactory(ca_name="Population générale")
         InstructionRoleFactory(user=authenticate.user)
         art_15 = AwaitingInstructionDeclarationFactory(
             declared_plants=[],
@@ -2688,6 +2691,8 @@ class TestSingleDeclaredElementApi(APITestCase):
         """
         Vérifier que l'article est recalculé avec un remplacement d'une demande
         """
+        PopulationFactory(ca_name="Population générale")
+
         InstructionRoleFactory(user=authenticate.user)
 
         declaration = DeclarationFactory()

--- a/data/tests/test_declaration.py
+++ b/data/tests/test_declaration.py
@@ -446,7 +446,7 @@ class DeclarationTestCase(TestCase):
         )
         MaxQuantityPerPopulationRelationFactory(
             substance=substance_1,
-            population=PopulationFactory(ca_name="Population générale"),
+            population=self.pop_generale,
             ca_max_quantity=15,
         )
         MaxQuantityPerPopulationRelationFactory(
@@ -456,7 +456,7 @@ class DeclarationTestCase(TestCase):
         )
         MaxQuantityPerPopulationRelationFactory(
             substance=substance_2,
-            population=PopulationFactory(ca_name="Population générale"),
+            population=self.pop_generale,
             ca_max_quantity=2,
         )
         ComputedSubstanceFactory(

--- a/data/tests/test_declaration.py
+++ b/data/tests/test_declaration.py
@@ -23,6 +23,9 @@ from data.models.ingredient_status import IngredientStatus
 
 
 class DeclarationTestCase(TestCase):
+    def setUp(self):
+        self.pop_generale = PopulationFactory.create(ca_name="Population générale")
+
     def test_json_representation(self):
         declaration = InstructionReadyDeclarationFactory()
         json_representation = declaration.json_representation
@@ -296,7 +299,7 @@ class DeclarationTestCase(TestCase):
             substance = SubstanceFactory(substance_types=type)
             MaxQuantityPerPopulationRelationFactory(
                 substance=substance,
-                population=PopulationFactory(ca_name="Population générale"),
+                population=self.pop_generale,
                 ca_max_quantity=SUBSTANCE_MAX_QUANTITY,
             )
             ComputedSubstanceFactory(
@@ -366,7 +369,7 @@ class DeclarationTestCase(TestCase):
             substance = SubstanceFactory(substance_types=type)
             MaxQuantityPerPopulationRelationFactory(
                 substance=substance,
-                population=PopulationFactory(ca_name="Population générale"),
+                population=self.pop_generale,
                 ca_max_quantity=SUBSTANCE_MAX_QUANTITY,
             )
             ComputedSubstanceFactory(


### PR DESCRIPTION
Ce bug existe depuis lundi dernier (date à laquelle les doses maximales par population ont été renseignées en base).
=> toutes les déclarations ayant des vitamines ou minéraux dans la composition pasent en article 18 si le minimum des quantité à ne pas dépasser pour une population donnée est dépassée par la quantité renseignée

La query SQL qui était générée par l'ORM était la suivante : 
```
SELECT "data_computedsubstance"."id", "data_computedsubstance"."declaration_id", "data_computedsubstance"."substance_id", "data_computedsubstance"."quantity", "data_computedsubstance"."unit_id", 
FROM "data_computedsubstance"
INNER JOIN "data_substance" ON ("data_computedsubstance"."substance_id" = "data_substance"."id")
INNER JOIN "data_maxquantityperpopulationrelation" ON ("data_substance"."id" = "data_maxquantityperpopulationrelation"."substance_id")
INNER JOIN "data_population" ON ("data_maxquantityperpopulationrelation"."population_id" = "data_population"."id")
INNER JOIN "data_maxquantityperpopulationrelation" T8 ON ("data_substance"."id" = T8."substance_id")
WHERE ("data_computedsubstance"."declaration_id" = 87958
AND NOT ("data_computedsubstance"."quantity" IS NULL)
AND "data_population"."name" = 'Population générale'
AND "data_computedsubstance"."unit_id" = ("data_substance"."unit_id")
AND T8."max_quantity" < ("data_computedsubstance"."quantity"))
```
![image](https://github.com/user-attachments/assets/6a9a5940-dcd2-445f-91c4-499cc1bd8ac9)

elle retourne donc une ligne par population qui dépasse la quantité renseignée, avec la quantité de celle dépassée (sans tenir compte de la population générale).
Difficile via l'ORM de construire la bonne query.
Je fais donc une boucle sur toutes les substances avec une query spécifique par substance.