### PR TITLE
Ne pas permettre l'ajout des métabolites sécondaires directement

### DIFF
--- a/api/views/autocomplete.py
+++ b/api/views/autocomplete.py
@@ -27,7 +27,7 @@ class AutocompleteView(APIView):
 
         query = {"term": term, "type": request.data.get("type")}
         results = search_elements(
-            query, deduplicate=False, exclude_not_authorized=True, exclude_vitamines_minerals=True
+            query, deduplicate=False, exclude_not_authorized=True, exclude_indirect_substances=True
         )[: self.max_autocomplete_items]
         return JsonResponse(self.serialize_results(results), safe=False)
 

--- a/data/admin/substance.py
+++ b/data/admin/substance.py
@@ -7,7 +7,7 @@ from django.utils.html import format_html
 from simple_history.admin import SimpleHistoryAdmin
 
 from data.models.declaration import Declaration
-from data.models.substance import MaxQuantityPerPopulationRelation, Substance, SubstanceSynonym
+from data.models.substance import MaxQuantityPerPopulationRelation, Substance, SubstanceSynonym, SubstanceType
 
 from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 
@@ -40,6 +40,19 @@ class SubstanceMaxQuantitiesInline(admin.TabularInline):
         models.TextField: {"widget": forms.Textarea(attrs={"cols": 60, "rows": 1})},
     }
     readonly_fields = ("siccrf_max_quantity",)
+
+
+class SubstanceTypeListFilter(admin.SimpleListFilter):
+    title = "type de substance"
+    parameter_name = "type"
+
+    def lookups(self, request, model_admin):
+        return SubstanceType.choices
+
+    def queryset(self, request, queryset):
+        substance_type_id = self.value()
+        if substance_type_id:
+            return queryset.filter(substance_types__contains=[substance_type_id])
 
 
 @admin.register(Substance)
@@ -160,7 +173,7 @@ class SubstanceAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
         "is_risky",
         "novel_food",
     )
-    list_filter = ("is_obsolete", "status", "is_risky", "novel_food")
+    list_filter = ("is_obsolete", "status", "is_risky", "novel_food", SubstanceTypeListFilter)
     show_facets = admin.ShowFacets.NEVER
     search_fields = ["id", "name"]
 

--- a/frontend/src/components/SubstancesTable.vue
+++ b/frontend/src/components/SubstancesTable.vue
@@ -62,19 +62,21 @@
               pour {{ payload.computedSubstances[rowIndex].substance.maxQuantity }} maximum autorisés
             </span>
           </div>
-          <DsfrInputGroup v-else>
-            <NumberField
-              v-model="payload.computedSubstances[rowIndex].quantity"
-              label="Quantité par DJR"
-              :required="payload.computedSubstances[rowIndex].substance.mustSpecifyQuantity"
-            />
-            <div
-              class="!text-neutral-500 mt-1"
-              v-if="payload.computedSubstances[rowIndex].substance.mustSpecifyQuantity"
-            >
-              * champ obligatoire
-            </div>
-          </DsfrInputGroup>
+          <div v-else class="-mt-1 pb-2">
+            <DsfrInputGroup>
+              <NumberField
+                v-model="payload.computedSubstances[rowIndex].quantity"
+                label="Quantité par DJR"
+                :required="payload.computedSubstances[rowIndex].substance.mustSpecifyQuantity"
+              />
+              <div
+                class="!text-neutral-500 mt-1"
+                v-if="payload.computedSubstances[rowIndex].substance.mustSpecifyQuantity"
+              >
+                * champ obligatoire
+              </div>
+            </DsfrInputGroup>
+          </div>
         </div>
         <div class="hidden sm:table-cell fr-text-alt ca-cell font-italic">
           <span>


### PR DESCRIPTION
Suite à la discussion ici : https://mattermost.incubateur.net/ruche/pl/fxyaay1p3p8gzpyceaewtkbbjc

Je viens de lire cette partie du base de code alors quand la discussion est arrivé je voulais essayer faire cette modif. Je veux bien que vous questionne la solution par contre, je ne suis pas certaine d'avoir bien compris.

Avec l'exclusion des métabolites sécondaires, j'ai ajouté un filtre dans l'admin et l'affichage des types de substance pour les fiches, pour améliorer la visibilité de types.