### PR TITLE
Ingrédient : enlever le champ raison de modification sur la création

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -166,7 +166,7 @@
           <DsfrInput label="Commentaire privé" v-model="state.privateComments" :isTextarea="true" label-visible />
         </div>
       </div>
-      <DsfrInputGroup :error-message="firstErrorMsg(v$, 'changeReason')">
+      <DsfrInputGroup v-if="!isNewIngredient" :error-message="firstErrorMsg(v$, 'changeReason')">
         <DsfrInput
           v-model="state.changeReason"
           label="Raison de changement (public)"
@@ -318,7 +318,7 @@ const rules = computed(() => {
     family: form?.family ? errorRequiredField : {},
     nutritionalReference: form?.nutritionalReference ? errorNumeric : {},
     maxQuantity: form?.maxQuantity ? errorNumeric : {},
-    changeReason: Object.assign({}, errorRequiredField, errorMaxStringLength(100)),
+    changeReason: isNewIngredient.value ? {} : Object.assign({}, errorRequiredField, errorMaxStringLength(100)),
   }
 })
 watch(formForType, () => v$.value.$reset())


### PR DESCRIPTION
Closes #1849 

L'historique devient:

![Screenshot 2025-03-31 at 12-51-14 test no reason - Compl'Alim](https://github.com/user-attachments/assets/2f15b84d-cb1e-4d66-b45e-b4325e6d2558)
