### PR TITLE
Ajout d'un site ID par défault

### DIFF
--- a/config/matomo_api.py
+++ b/config/matomo_api.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 class MatomoAPI:
     def __init__(self):
         self.base_url = "https://stats.beta.gouv.fr"
-        self.site_id = settings.MATOMO_ID
+        self.site_id = settings.MATOMO_ID or "95"  # Les environnements prod et démo utiliseront l'ID 95
 
     def _make_request(self, params):
         query_params = {


### PR DESCRIPTION
Utile pour les plateformes staging et démo - qui n'ont pas un MATOMO_ID et qui doivent afficher les stats de la prod.