### PR TITLE
Ajout des stats des remontées erreurs base de données ingrédients

### DIFF
--- a/data/admin/error_report.py
+++ b/data/admin/error_report.py
@@ -5,10 +5,10 @@ from data.models import ErrorReport
 
 @admin.register(ErrorReport)
 class ErrorReportAdmin(admin.ModelAdmin):
-    fields = ("email", "message", "author", "status", "element_string")
-    readonly_fields = ("email", "message", "author", "element_string")
+    fields = ("email", "message", "author", "status", "element_string", "creation_date")
+    readonly_fields = ("email", "message", "author", "element_string", "creation_date")
 
-    list_display = ("truncated_message", "element_string", "status")
+    list_display = ("truncated_message", "element_string", "status", "creation_date")
 
     def truncated_message(self, obj):
         return f"{obj.message[:75]}..." if obj.message and len(obj.message) > 30 else obj.message

--- a/frontend/src/views/StatsPage.vue
+++ b/frontend/src/views/StatsPage.vue
@@ -96,6 +96,20 @@
             allowtransparency
           ></iframe>
         </DsfrAccordion>
+        <DsfrAccordion id="accordion-4" title="Nombre de signalements d’erreur dans la base ingrédients">
+          <p>Notre objectif est de faciliter la déclaration de compléments alimentaires pour les professionnels.</p>
+          <p>
+            Nous visons une base de données ingrédients fiable et précise. Les remontées d'imprécisions ou erreurs
+            indiquent le contraire. Nous visons donc un nombre de remontées faible.
+          </p>
+          <iframe
+            src="https://compl-alim-metabase.cleverapps.io/public/question/1814a578-3978-45ce-a471-a29035f9615f"
+            frameborder="0"
+            width="800"
+            height="600"
+            allowtransparency
+          ></iframe>
+        </DsfrAccordion>
         <DsfrAccordion id="accordion-5" title="Nombre de consultations à la base ingrédients">
           <p>
             Nous mettons à disposition une base de données ingrédients avec leur réglementation d'usage mis à jour


### PR DESCRIPTION
Closes #1843 

Lié à #1847 

## UI

![image](https://github.com/user-attachments/assets/1142fcfe-f388-4a27-af8c-aec3f9c31c33)

Question Metabase : https://compl-alim-metabase.cleverapps.io/question/343-nombre-de-signalements-derreur-de-la-base-ingredients