### PR TITLE
Historique ingrédient : Afficher la déclaration d'origine

### DIFF
--- a/api/serializers/common_ingredient.py
+++ b/api/serializers/common_ingredient.py
@@ -8,6 +8,8 @@ from simple_history.utils import update_change_reason
 
 from data.models import Substance
 
+from .utils import HistoricalModelSerializer, PrivateFieldsSerializer
+
 logger = logging.getLogger(__name__)
 
 COMMON_NAME_FIELDS = ("name",)
@@ -99,3 +101,7 @@ class CommonIngredientModificationSerializer(serializers.ModelSerializer):
                 self.synonym_model.objects.create(standard_name=instance, name=name)
         except KeyError:
             raise ParseError(detail="Must provide 'name' to create new synonym")
+
+
+class CommonIngredientReadSerializer(HistoricalModelSerializer, PrivateFieldsSerializer):
+    private_fields = ("private_comments", "origin_declaration")

--- a/api/serializers/common_ingredient.py
+++ b/api/serializers/common_ingredient.py
@@ -6,8 +6,10 @@ from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from simple_history.utils import update_change_reason
 
-from data.models import Substance
+from api.utils.choice_field import GoodReprChoiceField
+from data.models import Substance, IngredientStatus
 
+from .historical_record import HistoricalRecordField
 from .utils import HistoricalModelSerializer, PrivateFieldsSerializer
 
 logger = logging.getLogger(__name__)
@@ -26,6 +28,21 @@ COMMON_FIELDS = (
 )
 
 COMMON_READ_ONLY_FIELDS = ("id",)
+
+COMMON_FETCH_FIELDS = (
+    "id",
+    "name",
+    "synonyms",
+    "public_comments",
+    "private_comments",  # Caché si l'utilisateur.ice ne fait pas partie de l'administration
+    "activity",
+    "status",
+    "novel_food",
+    "is_risky",
+    "history",
+    "object_type",
+    "origin_declaration",
+)
 
 
 class WithSubstances(serializers.ModelSerializer):
@@ -104,4 +121,7 @@ class CommonIngredientModificationSerializer(serializers.ModelSerializer):
 
 
 class CommonIngredientReadSerializer(HistoricalModelSerializer, PrivateFieldsSerializer):
+    status = GoodReprChoiceField(choices=IngredientStatus.choices, read_only=True)
+    history = HistoricalRecordField(read_only=True)
+
     private_fields = ("private_comments", "origin_declaration")

--- a/api/serializers/ingredient.py
+++ b/api/serializers/ingredient.py
@@ -1,14 +1,13 @@
 from rest_framework import serializers
 
-from api.utils.choice_field import GoodReprChoiceField
-from data.models import Ingredient, IngredientStatus, IngredientSynonym
+from data.models import Ingredient, IngredientSynonym
 
-from .historical_record import HistoricalRecordField
 from .substance import SubstanceShortSerializer
 from .common_ingredient import (
     COMMON_FIELDS,
     COMMON_NAME_FIELDS,
     COMMON_READ_ONLY_FIELDS,
+    COMMON_FETCH_FIELDS,
     CommonIngredientModificationSerializer,
     CommonIngredientReadSerializer,
     WithSubstances,
@@ -29,27 +28,13 @@ class IngredientSynonymSerializer(serializers.ModelSerializer):
 class IngredientSerializer(CommonIngredientReadSerializer):
     synonyms = IngredientSynonymSerializer(many=True, read_only=True, source="ingredientsynonym_set")
     substances = SubstanceShortSerializer(many=True, read_only=True)
-    status = GoodReprChoiceField(choices=IngredientStatus.choices, read_only=True)
-    history = HistoricalRecordField(read_only=True)
 
     class Meta:
         model = Ingredient
-        fields = (
-            "id",
-            "name",
+        fields = COMMON_FETCH_FIELDS + (
             "name_en",
             "description",
-            "synonyms",
             "substances",
-            "public_comments",
-            "private_comments",  # Caché si l'utilisateur.ice ne fait pas partie de l'administration
-            "activity",
-            "status",
-            "novel_food",
-            "is_risky",
-            "history",
-            "object_type",
-            "origin_declaration",
         )
         read_only_fields = fields
 

--- a/api/serializers/ingredient.py
+++ b/api/serializers/ingredient.py
@@ -5,12 +5,12 @@ from data.models import Ingredient, IngredientStatus, IngredientSynonym
 
 from .historical_record import HistoricalRecordField
 from .substance import SubstanceShortSerializer
-from .utils import HistoricalModelSerializer, PrivateFieldsSerializer
 from .common_ingredient import (
     COMMON_FIELDS,
     COMMON_NAME_FIELDS,
     COMMON_READ_ONLY_FIELDS,
     CommonIngredientModificationSerializer,
+    CommonIngredientReadSerializer,
     WithSubstances,
     WithName,
 )
@@ -26,7 +26,7 @@ class IngredientSynonymSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class IngredientSerializer(HistoricalModelSerializer, PrivateFieldsSerializer):
+class IngredientSerializer(CommonIngredientReadSerializer):
     synonyms = IngredientSynonymSerializer(many=True, read_only=True, source="ingredientsynonym_set")
     substances = SubstanceShortSerializer(many=True, read_only=True)
     status = GoodReprChoiceField(choices=IngredientStatus.choices, read_only=True)
@@ -49,6 +49,7 @@ class IngredientSerializer(HistoricalModelSerializer, PrivateFieldsSerializer):
             "is_risky",
             "history",
             "object_type",
+            "origin_declaration",
         )
         read_only_fields = fields
 

--- a/api/serializers/microorganism.py
+++ b/api/serializers/microorganism.py
@@ -1,13 +1,12 @@
 from rest_framework import serializers
 
-from api.utils.choice_field import GoodReprChoiceField
-from data.models import IngredientStatus, Microorganism, MicroorganismSynonym
+from data.models import Microorganism, MicroorganismSynonym
 
-from .historical_record import HistoricalRecordField
 from .substance import SubstanceShortSerializer
 from .common_ingredient import (
     COMMON_FIELDS,
     COMMON_READ_ONLY_FIELDS,
+    COMMON_FETCH_FIELDS,
     CommonIngredientModificationSerializer,
     CommonIngredientReadSerializer,
     WithSubstances,
@@ -27,26 +26,13 @@ class MicroorganismSynonymSerializer(serializers.ModelSerializer):
 class MicroorganismSerializer(CommonIngredientReadSerializer):
     synonyms = MicroorganismSynonymSerializer(many=True, read_only=True, source="microorganismsynonym_set")
     substances = SubstanceShortSerializer(many=True, read_only=True)
-    status = GoodReprChoiceField(choices=IngredientStatus.choices, read_only=True)
-    history = HistoricalRecordField(read_only=True)
 
     class Meta:
         model = Microorganism
-        fields = (
-            "id",
-            "name",
+        fields = COMMON_FETCH_FIELDS + (
             "genus",
             "species",
-            "synonyms",
             "substances",
-            "public_comments",
-            "private_comments",  # Caché si l'utilisateur.ice ne fait pas partie de l'administration
-            "activity",
-            "status",
-            "novel_food",
-            "is_risky",
-            "history",
-            "origin_declaration",
         )
         read_only_fields = fields
 

--- a/api/serializers/microorganism.py
+++ b/api/serializers/microorganism.py
@@ -5,11 +5,11 @@ from data.models import IngredientStatus, Microorganism, MicroorganismSynonym
 
 from .historical_record import HistoricalRecordField
 from .substance import SubstanceShortSerializer
-from .utils import HistoricalModelSerializer, PrivateFieldsSerializer
 from .common_ingredient import (
     COMMON_FIELDS,
     COMMON_READ_ONLY_FIELDS,
     CommonIngredientModificationSerializer,
+    CommonIngredientReadSerializer,
     WithSubstances,
 )
 
@@ -24,7 +24,7 @@ class MicroorganismSynonymSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class MicroorganismSerializer(HistoricalModelSerializer, PrivateFieldsSerializer):
+class MicroorganismSerializer(CommonIngredientReadSerializer):
     synonyms = MicroorganismSynonymSerializer(many=True, read_only=True, source="microorganismsynonym_set")
     substances = SubstanceShortSerializer(many=True, read_only=True)
     status = GoodReprChoiceField(choices=IngredientStatus.choices, read_only=True)
@@ -46,6 +46,7 @@ class MicroorganismSerializer(HistoricalModelSerializer, PrivateFieldsSerializer
             "novel_food",
             "is_risky",
             "history",
+            "origin_declaration",
         )
         read_only_fields = fields
 

--- a/api/serializers/plant.py
+++ b/api/serializers/plant.py
@@ -5,12 +5,12 @@ from data.models import IngredientStatus, Part, Plant, PlantFamily, PlantPart, P
 
 from .historical_record import HistoricalRecordField
 from .substance import SubstanceShortSerializer
-from .utils import HistoricalModelSerializer, PrivateFieldsSerializer
 from .common_ingredient import (
     COMMON_FIELDS,
     COMMON_NAME_FIELDS,
     COMMON_READ_ONLY_FIELDS,
     CommonIngredientModificationSerializer,
+    CommonIngredientReadSerializer,
     WithSubstances,
     WithName,
 )
@@ -59,7 +59,7 @@ class PlantSynonymSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class PlantSerializer(HistoricalModelSerializer, PrivateFieldsSerializer):
+class PlantSerializer(CommonIngredientReadSerializer):
     family = PlantFamilySerializer(read_only=True)
     plant_parts = PartRelationSerializer(source="part_set", many=True, read_only=True)
     synonyms = PlantSynonymSerializer(many=True, read_only=True, source="plantsynonym_set")
@@ -77,12 +77,13 @@ class PlantSerializer(HistoricalModelSerializer, PrivateFieldsSerializer):
             "synonyms",
             "substances",
             "public_comments",
-            "private_comments",  # Caché si l'utilisateur.ice ne fait pas partie de l'administration
+            "private_comments",
             "activity",
             "status",
             "novel_food",
             "is_risky",
             "history",
+            "origin_declaration",
         )
         read_only_fields = fields
 

--- a/api/serializers/plant.py
+++ b/api/serializers/plant.py
@@ -1,14 +1,13 @@
 from rest_framework import serializers
 
-from api.utils.choice_field import GoodReprChoiceField
-from data.models import IngredientStatus, Part, Plant, PlantFamily, PlantPart, PlantSynonym
+from data.models import Part, Plant, PlantFamily, PlantPart, PlantSynonym
 
-from .historical_record import HistoricalRecordField
 from .substance import SubstanceShortSerializer
 from .common_ingredient import (
     COMMON_FIELDS,
     COMMON_NAME_FIELDS,
     COMMON_READ_ONLY_FIELDS,
+    COMMON_FETCH_FIELDS,
     CommonIngredientModificationSerializer,
     CommonIngredientReadSerializer,
     WithSubstances,
@@ -64,26 +63,13 @@ class PlantSerializer(CommonIngredientReadSerializer):
     plant_parts = PartRelationSerializer(source="part_set", many=True, read_only=True)
     synonyms = PlantSynonymSerializer(many=True, read_only=True, source="plantsynonym_set")
     substances = SubstanceShortSerializer(many=True, read_only=True)
-    status = GoodReprChoiceField(choices=IngredientStatus.choices, read_only=True)
-    history = HistoricalRecordField(read_only=True)
 
     class Meta:
         model = Plant
-        fields = (
-            "id",
-            "name",
+        fields = COMMON_FETCH_FIELDS + (
             "family",
             "plant_parts",
-            "synonyms",
             "substances",
-            "public_comments",
-            "private_comments",
-            "activity",
-            "status",
-            "novel_food",
-            "is_risky",
-            "history",
-            "origin_declaration",
         )
         read_only_fields = fields
 

--- a/api/serializers/substance.py
+++ b/api/serializers/substance.py
@@ -11,10 +11,11 @@ from .common_ingredient import (
     COMMON_NAME_FIELDS,
     COMMON_READ_ONLY_FIELDS,
     CommonIngredientModificationSerializer,
+    CommonIngredientReadSerializer,
     WithName,
 )
 from .historical_record import HistoricalRecordField
-from .utils import HistoricalModelSerializer, PrivateFieldsSerializer
+from .utils import PrivateFieldsSerializer
 
 
 class SubstanceSynonymSerializer(serializers.ModelSerializer):
@@ -27,7 +28,7 @@ class SubstanceSynonymSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class SubstanceSerializer(HistoricalModelSerializer, PrivateFieldsSerializer):
+class SubstanceSerializer(CommonIngredientReadSerializer):
     synonyms = SubstanceSynonymSerializer(many=True, read_only=True, source="substancesynonym_set")
     unit = serializers.CharField(read_only=True, source="unit.name")
     unit_id = serializers.IntegerField(read_only=True, source="unit.id")
@@ -57,6 +58,7 @@ class SubstanceSerializer(HistoricalModelSerializer, PrivateFieldsSerializer):
             "is_risky",
             "history",
             "object_type",
+            "origin_declaration",
         )
         read_only_fields = fields
 

--- a/api/serializers/substance.py
+++ b/api/serializers/substance.py
@@ -2,19 +2,18 @@ from django.db import transaction
 
 from rest_framework import serializers
 
-from api.utils.choice_field import GoodReprChoiceField
-from data.models import IngredientStatus, Population
+from data.models import Population
 from data.models.substance import MaxQuantityPerPopulationRelation, Substance, SubstanceSynonym
 
 from .common_ingredient import (
     COMMON_FIELDS,
     COMMON_NAME_FIELDS,
     COMMON_READ_ONLY_FIELDS,
+    COMMON_FETCH_FIELDS,
     CommonIngredientModificationSerializer,
     CommonIngredientReadSerializer,
     WithName,
 )
-from .historical_record import HistoricalRecordField
 from .utils import PrivateFieldsSerializer
 
 
@@ -32,14 +31,10 @@ class SubstanceSerializer(CommonIngredientReadSerializer):
     synonyms = SubstanceSynonymSerializer(many=True, read_only=True, source="substancesynonym_set")
     unit = serializers.CharField(read_only=True, source="unit.name")
     unit_id = serializers.IntegerField(read_only=True, source="unit.id")
-    status = GoodReprChoiceField(choices=IngredientStatus.choices, read_only=True)
-    history = HistoricalRecordField(read_only=True)
 
     class Meta:
         model = Substance
-        fields = (
-            "id",
-            "name",
+        fields = COMMON_FETCH_FIELDS + (
             "name_en",
             "cas_number",
             "einec_number",
@@ -49,16 +44,6 @@ class SubstanceSerializer(CommonIngredientReadSerializer):
             "nutritional_reference",
             "unit",
             "unit_id",
-            "synonyms",
-            "public_comments",
-            "private_comments",  # Caché si l'utilisateur.ice ne fait pas partie de l'administration
-            "activity",
-            "status",
-            "novel_food",
-            "is_risky",
-            "history",
-            "object_type",
-            "origin_declaration",
         )
         read_only_fields = fields
 

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -29,7 +29,7 @@
           </div>
           <p v-if="element && element.originDeclaration">
             <router-link :to="{ name: 'InstructionPage', params: { declarationId: element.originDeclaration } }">
-              La déclaration qui a demandé cet ingrédient
+              Déclaration ayant demandé l'ajout de cet ingrédient
             </router-link>
           </p>
           <p v-else>Cet ingrédient ne vient pas d'une demande d'ajout.</p>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -24,9 +24,15 @@
         </DsfrTabContent>
 
         <DsfrTabContent panel-id="history-content" tab-id="history">
-          <div class="-my-8">
+          <div class="-my-8 mb-4">
             <DsfrTable :headers="headers" :rows="historyDataDedup" />
           </div>
+          <p v-if="element && element.originDeclaration">
+            <router-link :to="{ name: 'InstructionPage', params: { declarationId: element.originDeclaration } }">
+              La déclaration qui a demandé cet ingrédient
+            </router-link>
+          </p>
+          <p v-else>Cet ingrédient ne vient pas d'une demande d'ajout.</p>
         </DsfrTabContent>
       </DsfrTabs>
     </div>


### PR DESCRIPTION
Closes #1790 

Pour rappel, quand on remplace une demande avec un ingrédient, on sauvegarde la déclaration comme la déclaration d'origine (demandeur d'ajout) si l'ingrédient ne vient pas de teleicare (n'a pas `siccrf_id`) et si une déclaration d'origine n'existe pas encore pour cet ingrédient.

![Screenshot 2025-04-01 at 18-44-13 Modification ingrédient - Compl'Alim](https://github.com/user-attachments/assets/7c4b82cf-6db6-4951-9a04-8408c4ed3aab)
![Screenshot 2025-04-01 at 18-44-25 Modification ingrédient - Compl'Alim](https://github.com/user-attachments/assets/79fbc402-e036-470d-a30c-a0a21845608b)
