### PR TITLE
Petites améliorations du JDD open-data déclaration

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -366,10 +366,9 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
 
     def get_id(self, obj):
         """
-        This function is useless as the field has the correct name already and no transformation.
-        It is left for lisibilty
+        This function returns TeleIcare id if it exists otherwise Compl'Alim id
         """
-        return obj.id
+        return obj.teleicare_id if obj.teleicare_id else obj.id
 
     def get_decision(self, obj):
         return obj.get_status_display()

--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -366,9 +366,9 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
 
     def get_id(self, obj):
         """
-        This function returns TeleIcare id if it exists otherwise Compl'Alim id
+        Cette fonction retourne le TeleIcare id s'il existe sinon le Compl'Alim id
         """
-        return obj.teleicare_id if obj.teleicare_id else obj.id
+        return obj.teleicare_id or obj.id
 
     def get_decision(self, obj):
         return obj.get_status_display()
@@ -387,15 +387,14 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
 
     def get_gamme(self, obj):
         """
-        This function is useless as the field has the correct name already and no transformation.
-        It is left for lisibilty
+        Cette fonction est là pour la lisibilité, pas utile d'un point de vue fonctionnel
         """
         return obj.gamme
 
     def get_article_procedure(self, obj):
         """
-        Unify all types of Articles 15 categories.
-        If not part of Article 15, then return display name
+        Unifie tous les types d'Articles 15.
+        Si ce n'est pas un Article 15, alors le display name est retourné
         """
         if obj.article in [
             Declaration.Article.ARTICLE_15,

--- a/data/etl/transformer_loader.py
+++ b/data/etl/transformer_loader.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import logging
 
 from django.core.files.storage import default_storage
@@ -17,6 +18,12 @@ class OPEN_DATA(TRANSFORMER_LOADER):
 
     def _load_data_csv(self, filename):
         df_csv = self.df.copy()
+
+        # transforme les objects en json strings pour éviter de créer un csv avec des json string
+        # qui ne respectent pas https://www.rfc-editor.org/rfc/rfc7159#section-7
+        json_columns = self.df.columns[self.df.applymap(type).eq(list).any()]
+        self.df[json_columns] = self.df[json_columns].map(json.dumps).astype("string")
+
         with default_storage.open(filename + ".csv", "w") as csv_file:
             df_csv.to_csv(
                 csv_file,

--- a/data/schemas/CHANGELOG_declarations.md
+++ b/data/schemas/CHANGELOG_declarations.md
@@ -46,3 +46,9 @@ Tous les changements notables apportés aux jeux de données exposés sur data.g
   -plantes
   -micro_organismes
   -substances
+
+## 2025-04-07
+
+## Amélioration qualité données
+- le champ id contient l'identifiant TeleIcare ou Compl'Alim
+- les champs complexes ['objectif_effet', 'facteurs_risques', 'populations_cibles', 'additifs', 'nutriments', 'autres_ingredients_actifs', 'ingredients_inactifs'] sont écrit comme des JSON string conformes

--- a/data/schemas/schema_declarations.json
+++ b/data/schemas/schema_declarations.json
@@ -15,7 +15,7 @@
       "example": "3211",
       "name": "id",
       "title": "Identifiant",
-      "type": "integer"
+      "type": "string"
     },
     {
       "constraints": {

--- a/data/schemas/schema_declarations.json
+++ b/data/schemas/schema_declarations.json
@@ -11,7 +11,7 @@
       "constraints": {
         "required": true
       },
-      "description": "Identifiant unique permettant de référencer une déclaration d'un complément alimentaire",
+      "description": "Identifiant unique permettant de référencer une déclaration d'un complément alimentaire. Le format d'identifiant est différent si la déclaration a été déclarée dans la plateforme obsolète Teleicare",
       "example": "3211",
       "name": "id",
       "title": "Identifiant",


### PR DESCRIPTION
closes #1877 : L'id du jeu de données est soit l'id compl'alim soit l'id teleicare
Closes #1879 : le csv sauve les columns complexes en tant que json string

Suite à un retour d'un réutilisateur de la donnée.