### PR TITLE
Fiche ingrédient public : remplacer la raison de changement avec une liste de champs modifiés

### DIFF
--- a/api/serializers/historical_record.py
+++ b/api/serializers/historical_record.py
@@ -12,6 +12,7 @@ class HistoricalRecordSerializer(serializers.Serializer):
     history_date = serializers.DateTimeField()
     history_change_reason = serializers.CharField()
     changed_fields = serializers.ListField(child=serializers.CharField())
+    history_type = serializers.CharField()
 
     def get_user(self, obj):
         users = User.objects.filter(id=obj["history_user_id"])
@@ -32,26 +33,24 @@ class HistoricalRecordField(serializers.ListField):
         except Exception as _:
             is_priviledged_user = False
 
-        if is_priviledged_user:
-            data_with_changes = []
-            history_list = list(data.all())
-            length = len(history_list)
-            for idx in range(length):
-                later_version = history_list[idx]
-                earlier_version = history_list[idx + 1] if idx + 1 < length else None
-                changes = later_version.diff_against(earlier_version) if earlier_version else None
-                changed_fields = changes.changed_fields if changes else []
-                obj_model_meta = type(data.first())._meta
-                translated_changed_fields = [obj_model_meta.get_field(f).verbose_name for f in changed_fields]
-                data_with_changes.append(
-                    {
-                        "history_date": later_version.history_date,
-                        "history_change_reason": later_version.history_change_reason,
-                        "history_user_id": later_version.history_user_id,
-                        "changed_fields": translated_changed_fields,
-                    }
-                )
-            records = HistoricalRecordSerializer(data_with_changes, many=True).data
-            return super().to_representation(records)
-        else:
-            return super().to_representation(data.values("history_date", "history_change_reason"))
+        data_with_changes = []
+        history_list = list(data.all())
+        length = len(history_list)
+        for idx in range(length):
+            later_version = history_list[idx]
+            earlier_version = history_list[idx + 1] if idx + 1 < length else None
+            changes = later_version.diff_against(earlier_version) if earlier_version else None
+            changed_fields = changes.changed_fields if changes else []
+            obj_model_meta = type(data.first())._meta
+            translated_changed_fields = [obj_model_meta.get_field(f).verbose_name for f in changed_fields]
+            history_data = {
+                "history_date": later_version.history_date,
+                "changed_fields": translated_changed_fields,
+                "history_type": later_version.history_type,
+            }
+            if is_priviledged_user:
+                history_data["history_change_reason"] = later_version.history_change_reason
+                history_data["history_user_id"] = later_version.history_user_id
+            data_with_changes.append(history_data)
+        records = HistoricalRecordSerializer(data_with_changes, many=True).data
+        return super().to_representation(records)

--- a/api/serializers/historical_record.py
+++ b/api/serializers/historical_record.py
@@ -23,7 +23,7 @@ class HistoricalRecordSerializer(serializers.Serializer):
         return super().to_representation(data)
 
 
-class PriviledgedHistoricalRecordSerializer(HistoricalRecordSerializer):
+class PrivilegedHistoricalRecordSerializer(HistoricalRecordSerializer):
     user = serializers.SerializerMethodField()
     history_change_reason = serializers.CharField(allow_blank=True, allow_null=True)
 
@@ -34,9 +34,9 @@ class HistoricalRecordField(serializers.ListField):
     def to_representation(self, data):
         user = self.context and self.context["request"] and self.context["request"].user
         try:
-            is_priviledged_user = user.instructionrole or user.visarole
+            is_privileged_user = user.instructionrole or user.visarole
         except Exception as _:
-            is_priviledged_user = False
+            is_privileged_user = False
 
         data_with_changes = []
         history_list = list(data.all())
@@ -53,10 +53,10 @@ class HistoricalRecordField(serializers.ListField):
                 "changed_fields": translated_changed_fields,
                 "history_type": later_version.history_type,
             }
-            if is_priviledged_user:
+            if is_privileged_user:
                 history_data["history_change_reason"] = later_version.history_change_reason
                 history_data["history_user_id"] = later_version.history_user_id
             data_with_changes.append(history_data)
-        serializer = PriviledgedHistoricalRecordSerializer if is_priviledged_user else HistoricalRecordSerializer
+        serializer = PrivilegedHistoricalRecordSerializer if is_privileged_user else HistoricalRecordSerializer
         records = serializer(data_with_changes, many=True).data
         return super().to_representation(records)

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -40,7 +40,11 @@ class TestElementsFetchApi(APITestCase):
         body = response.json()
 
         self.assertIn("history", body)
+        self.assertIn("changedFields", body["history"][0])
+        self.assertIn("historyType", body["history"][0])
+        self.assertIn("historyDate", body["history"][0])
         self.assertNotIn("user", body["history"][0])
+        self.assertNotIn("historyChangeReason", body["history"][0])
 
         response = self.client.get(reverse("api:single_plant", kwargs={"pk": plant.id}))
         body = response.json()
@@ -59,6 +63,10 @@ class TestElementsFetchApi(APITestCase):
 
         self.assertIn("user", body["history"][0])
         self.assertEqual(body["history"][0]["changedFields"], ["nom CA"])
+        self.assertIn("historyType", body["history"][0])
+        self.assertIn("historyDate", body["history"][0])
+        self.assertIn("user", body["history"][0])
+        self.assertIn("historyChangeReason", body["history"][0])
 
     @authenticate
     def test_plant_private_comments(self):

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -169,7 +169,7 @@
       <DsfrInputGroup v-if="!isNewIngredient" :error-message="firstErrorMsg(v$, 'changeReason')">
         <DsfrInput
           v-model="state.changeReason"
-          label="Raison de changement (public)"
+          label="Raison de changement"
           hint="100 caractères max"
           required
           labelVisible

--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -88,7 +88,7 @@
       <ElementTextSection title="Commentaires" :text="publicComments" />
       <!-- Date de dernière mise à jour de la donnée -->
       <DsfrAccordion title="Historique de l'ingrédient" id="accordion-history">
-        <DsfrTable :rows="historyDataDedup"></DsfrTable>
+        <DsfrTable :headers="historyHeaders" :rows="historyDataDedup"></DsfrTable>
       </DsfrAccordion>
 
       <!-- bouton temporaire à enlever quand on a une page dédiée à la recherche d'ingrédients interne -->
@@ -179,17 +179,19 @@ const publicComments = computed(() => element.value?.publicComments)
 
 const historyData = computed(() =>
   element.value?.history
-    .filter((item) => item.historyChangeReason)
+    .filter((item) => item.changedFields?.length || item.historyType === "+")
     .map((item) => [
-      new Date(item.historyDate).toLocaleString("default", { month: "long", year: "numeric" }),
-      item.historyChangeReason,
+      new Date(item.historyDate).toLocaleString("default", { day: "numeric", month: "short", year: "numeric" }),
+      item.historyType === "+" ? "Création de l'ingrédient" : item.changedFields.map((f) => `« ${f} »`).join(", "),
     ])
 )
+
 // Deduplication en passant par une string
 const historyDataDedup = computed(() => Array.from(new Set(historyData.value.map(JSON.stringify)), JSON.parse))
 
+const historyHeaders = ["Date de changement", "Champs modifiés"]
+
 // TODO: remove background
-// TODO: affichage du change reason dans l'admin
 const url = computed(() => `/api/v1/${getApiType(type.value)}s/${elementId.value}?history=true`)
 const { data: element, response, execute } = useFetch(url, { immediate: false }).get().json()
 


### PR DESCRIPTION
But de la partie historique sur le fiche public : d'aider des producteurs à comprendre pourquoi leur déclaration pourrait rentrer dans un article différent avec les mêmes ingrédients (par ex le dose max a changé)

On a décidé alors de remplacer l'affichage de raison de changement avec l'affichage des champs changés.

Je décide de garder la déduplication, mais maintenant ça veut dire que: si le(s) même(s) champ(s) a changé plusieurs fois dans une seule journée, on va afficher que une ligne.

J'ai ajouté une ligne pour la création de l'ingrédient. J'ai ajouté donc le champ de django-simple-history de `history_type` dans le serializer. Je crois que ça va nous aider à la suite quand on affiche des suppressions de synonymes, doses max, parties de plantes... etc.

On ne voit plus toutes les lignes "Import données teleicare..." etc. Ce nous ne semble pas intéresssant pour les producteurs. 

![Screenshot 2025-04-04 at 15-35-08 vitamine B12 - Compl'Alim](https://github.com/user-attachments/assets/12778eb0-ab0f-4baf-8e63-23a8f2bb7769)
