### PR TITLE
Historique ingrédient interne : ajouter la précision "Création de l'ingrédient"

### DIFF
--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -106,11 +106,11 @@ const headers = ["Date", "Réalisée par", "Champs modifiés", "Détail"]
 
 const historyData = computed(() =>
   element.value?.history
-    .filter((item) => item.historyChangeReason)
+    .filter((item) => item.changedFields?.length || item.historyType === "+")
     .map((item) => [
       new Date(item.historyDate).toLocaleString("default", { day: "numeric", month: "numeric", year: "numeric" }),
       item.user ? `${item.user.firstName} ${item.user.lastName}` : "",
-      item.changedFields.map((f) => `« ${f} »`).join(", "),
+      item.historyType === "+" ? "Création de l'ingrédient" : item.changedFields.map((f) => `« ${f} »`).join(", "),
       item.historyChangeReason,
     ])
 )


### PR DESCRIPTION
Aussi, exclure les lignes d'historique qui ne contiennent pas de champs changés, en reprenant la logique déjà en place côté vue publique.

Avant

![Screenshot 2025-04-08 at 11-40-51 Modification ingrédient - Compl'Alim](https://github.com/user-attachments/assets/550d7245-a4c9-4b80-a162-9e504eadbf47)


Après 

![Screenshot 2025-04-08 at 11-40-33 Modification ingrédient - Compl'Alim](https://github.com/user-attachments/assets/4842be6c-66c6-4fca-ba86-b7f98cc26444)
