### PR TITLE
Génération des snapshots TAKE_FOR_INSTRUCTION et TAKE_FOR_VISA

### DIFF
--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -594,6 +594,8 @@ class DeclarationTakeForInstructionView(DeclarationFlowView):
 
     permission_classes = [IsInstructor]
     transition = "take_for_instruction"
+    create_snapshot = True
+    snapshot_action = Snapshot.SnapshotActions.TAKE_FOR_INSTRUCTION
 
     def on_transition_success(self, request, declaration):
         declaration.instructor = InstructionRole.objects.get(user=request.user)
@@ -607,6 +609,8 @@ class DeclarationTakeForVisaView(DeclarationFlowView):
 
     permission_classes = [IsVisor]
     transition = "take_for_visa"
+    create_snapshot = True
+    snapshot_action = Snapshot.SnapshotActions.TAKE_FOR_VISA
 
     def on_transition_success(self, request, declaration):
         declaration.visor = VisaRole.objects.get(user=request.user)

--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -20,9 +20,10 @@ from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin
 class SnapshotInline(admin.TabularInline):
     model = Snapshot
     can_delete = False
-    fields = ("user", "creation_date", "status", "comment")
+    fields = ("user", "creation_date", "action", "status", "comment")
     readonly_fields = fields
     extra = 0
+    ordering = ("creation_date",)
 
     def has_add_permission(self, request, object):
         return False


### PR DESCRIPTION
Closes #1842 

:lady_beetle:  Le bug : Précédemment les actions `TAKE_FOR_VISA` et `TAKE_FOR_INSTRUCTION` ne créaient pas d'objets Snapshot. 

Pour les déclarations existantes, un script créera les snapshots manquants à partir des éléments de l'historique. 

Le script sera : 

```python
import json

from djangorestframework_camel_case.render import CamelCaseJSONRenderer

from api.serializers import DeclarationSerializer
from data.factories import SnapshotFactory
from data.models import Declaration, InstructionRole, Snapshot, VisaRole

# On va patcher toutes les déclarations qui ne sont pas en état DRAFT
declarations = Declaration.objects.exclude(status=Declaration.DeclarationStatus.DRAFT).iterator(chunk_size=1000)

ONGOING_INSTRUCTION = Declaration.DeclarationStatus.ONGOING_INSTRUCTION
AWAITING_INSTRUCTION = Declaration.DeclarationStatus.AWAITING_INSTRUCTION
AWAITING_VISA = Declaration.DeclarationStatus.AWAITING_VISA
ONGOING_VISA = Declaration.DeclarationStatus.ONGOING_VISA


def get_history_instructor(record):
    # Si le rôle d'instruction a été supprimé depuis, on n'a plus accès à cet info
    try:
        return InstructionRole.objects.get(pk=record.instructor_id).user
    except Exception as _:
        return None


def get_history_visor(record):
    # Si le rôle de visa a été supprimé depuis, on n'a plus accès à cet info
    try:
        return VisaRole.objects.get(pk=record.visor_id).user
    except Exception as _:
        return None


def get_history_json(record):
    try:
        serialized_data = DeclarationSerializer(record).data
        camelized_bytes = CamelCaseJSONRenderer().render(serialized_data)
        return json.loads(camelized_bytes.decode("utf-8"))
    except Exception as _:
        return {}


for declaration in declarations:
    history = declaration.history.order_by("history_date")  # type: ignore

    # Les objets historiques correspondant au changement de AWAITING_INSTRUCTION vers ONGOING_INSTRUCTION
    transition_instruction_records = []

    # Les objets historiques correspondant au changement de AWAITING_VISA vers ONGOING_VISA
    transition_visa_records = []

    previous_status = None
    for record in history:
        if previous_status == AWAITING_INSTRUCTION and record.status == ONGOING_INSTRUCTION:
            transition_instruction_records.append(record)
        if previous_status == AWAITING_VISA and record.status == ONGOING_VISA:
            transition_visa_records.append(record)
        previous_status = record.status

    # Ici on crée les Snapshots avec action "TAKE_FOR_INSTRUCTION"
    for record in transition_instruction_records:
        snapshot = SnapshotFactory(
            declaration=declaration,
            user=get_history_instructor(record),
            status=record.status,
            json_declaration=get_history_json(record),
            expiration_days=None,
            comment="",
            action=Snapshot.SnapshotActions.TAKE_FOR_INSTRUCTION,
            post_validation_status="",
            blocking_reasons=None,
        )
        snapshot.creation_date = record.history_date
        snapshot.save()

    # Ici on crée les Snapshots avec action "TAKE_FOR_VISA"
    for record in transition_visa_records:
        snapshot = SnapshotFactory(
            declaration=declaration,
            user=get_history_visor(record),
            status=record.status,
            json_declaration=get_history_json(record),
            expiration_days=None,
            comment="",
            action=Snapshot.SnapshotActions.TAKE_FOR_VISA,
            post_validation_status="",
            blocking_reasons=None,
        )
        # Je laisse volontairement la date de modification tel qu'elle est pour
        # pouvoir repérer les snapshots créés de cette façon
        snapshot.creation_date = record.history_date
        snapshot.save()
```

Le script a été exécuté correctement entre **avril 8, 2025, 9:23 PM (UTC)** et **avril 8, 2025, 9:30 PM (UTC)**.

