### PR TITLE
Bug fix hot module reload : lazy import du dsfr chart 

### DIFF
--- a/frontend/src/views/StatsPage.vue
+++ b/frontend/src/views/StatsPage.vue
@@ -161,7 +161,7 @@
   </div>
 </template>
 <script setup>
-import { ref, watch, computed } from "vue"
+import { ref, watch, computed, onMounted } from "vue"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 
@@ -198,4 +198,15 @@ const formatMonthLabel = (apiLabel) => {
   const date = new Date(year, month - 1)
   return new Intl.DateTimeFormat("fr-FR", { month: "long", year: "numeric" }).format(date)
 }
+
+onMounted(async () => {
+  const script = document.createElement("script")
+  script.type = "module"
+  script.src = "/static/js/BarChart.js"
+  document.body.appendChild(script)
+  const style = document.createElement("link")
+  style.rel = "stylesheet"
+  style.src = "/static/css/BarChart.js"
+  document.body.appendChild(style)
+})
 </script>

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -42,5 +42,14 @@ module.exports = defineConfig({
       .https(false)
       // eslint-disable-next-line no-useless-escape
       .headers({ "Access-Control-Allow-Origin": ["*"] })
+
+    config.module
+      .rule("vue")
+      .use("vue-loader")
+      .tap((options) => {
+        options.compilerOptions = options.compilerOptions || {}
+        options.compilerOptions.isCustomElement = (tag) => ["bar-chart"].includes(tag)
+        return options
+      })
   },
 })

--- a/web/templates/vue-app.html
+++ b/web/templates/vue-app.html
@@ -19,9 +19,6 @@
         window.ENVIRONMENT = "{% environment %}";
         window.MATOMO_ID = "{% matomo_id %}";
     </script>
-
-    <script type="module" src="{% static 'js/BarChart.js' %}"></script>
-    <link rel="stylesheet" href="{% static 'css/BarChart.css' %}" />
 </head>
 
 <body>


### PR DESCRIPTION
c'est un fix imparfait - si on visite la page avec les mesures d'impact, ça va casser HMR jusqu'à une refresh. HMR va pas marcher sur la page stats. Peut-être ça suffit comme solution pour l'instant.