### PR TITLE
Modif Substance : option de spécifier les doses max à la création ou modification d'une substance 

### DIFF
--- a/api/serializers/substance.py
+++ b/api/serializers/substance.py
@@ -137,6 +137,13 @@ class SubstanceModificationSerializer(CommonIngredientModificationSerializer, Wi
         )
         read_only = COMMON_READ_ONLY_FIELDS
 
+    def validate_max_quantities(self, value):
+        population_ids = [v["population"].id for v in value]
+        unique_pop_ids = list(set(population_ids))
+        if len(population_ids) != len(unique_pop_ids):
+            raise serializers.ValidationError("Veuillez donner qu'une quantité maximale par population")
+        return value
+
     @transaction.atomic
     def create(self, validated_data):
         max_quantities = validated_data.pop("maxquantityperpopulationrelation_set", None)
@@ -167,7 +174,6 @@ class SubstanceModificationSerializer(CommonIngredientModificationSerializer, Wi
                 existing_q = existing_q.first()
                 existing_q.ca_max_quantity = max_quantity["ca_max_quantity"]
                 existing_q.save()
-                # TODO: add change reason?
             else:
                 self.add_max_quantity(substance, max_quantity)
 

--- a/api/serializers/substance.py
+++ b/api/serializers/substance.py
@@ -100,7 +100,8 @@ class SubstanceSynonymModificationSerializer(serializers.ModelSerializer):
 
 
 class SubstanceMaxQuantityModificationSerializer(serializers.ModelSerializer):
-    population = serializers.CharField(source="population.name")
+    population = serializers.PrimaryKeyRelatedField(queryset=Population.objects.all())
+    max_quantity = serializers.FloatField(source="ca_max_quantity")
 
     class Meta:
         model = MaxQuantityPerPopulationRelation
@@ -136,46 +137,114 @@ class SubstanceModificationSerializer(CommonIngredientModificationSerializer, Wi
         )
         read_only = COMMON_READ_ONLY_FIELDS
 
+    # @transaction.atomic
+    # def create(self, validated_data):
+    #     # le champ `max_quantity` n'existe pas dans validated_data
+    #     # car ce n'est pas un champ du Model mais une property
+    #     max_quantity = self.initial_data.get("max_quantity")
+    #     substance = super().create(validated_data)
+    #     if max_quantity:
+    #         general_population = Population.objects.get(name="Population générale")
+    #         MaxQuantityPerPopulationRelation.objects.create(
+    #             substance=substance, population=general_population, ca_max_quantity=max_quantity
+    #         )
+
+    #     return substance
+
+    # @transaction.atomic
+    # def update(self, instance, validated_data):
+    #     substance = super().update(instance, validated_data)
+
+    #     # le champ `max_quantity` n'existe pas dans validated_data
+    #     # car ce n'est pas un champ du Model mais une property
+    #     if "max_quantity" in self.initial_data.keys():
+    #         max_quantity = self.initial_data.get("max_quantity")
+
+    #         general_population = Population.objects.get(name="Population générale")
+    #         max_qty_general_pop = MaxQuantityPerPopulationRelation.objects.filter(
+    #             substance=substance, population=general_population
+    #         )
+
+    #         # delete
+    #         if max_qty_general_pop.exists() and max_quantity is None:
+    #             max_qty_general_pop.first().delete()
+    #         # update
+    #         elif max_qty_general_pop.exists() and max_quantity is not None:
+    #             max_quantity_to_change = max_qty_general_pop.first()
+    #             max_quantity_to_change.ca_max_quantity = max_quantity
+    #             max_quantity_to_change.save()
+    #         # create
+    #         elif not max_qty_general_pop.exists() and max_quantity is not None:
+    #             MaxQuantityPerPopulationRelation.objects.create(
+    #                 substance=substance, population=general_population, ca_max_quantity=max_quantity
+    #             )
+
+    #     return substance
+    # DRF ne gère pas automatiquement la création des nested-fields :
+    # https://www.django-rest-framework.org/api-guide/serializers/#writable-nested-representations
     @transaction.atomic
     def create(self, validated_data):
-        # le champ `max_quantity` n'existe pas dans validated_data
-        # car ce n'est pas un champ du Model mais une property
-        max_quantity = self.initial_data.get("max_quantity")
+        max_quantities = validated_data.pop("maxquantityperpopulationrelation_set", None)
         substance = super().create(validated_data)
-        if max_quantity:
-            general_population = Population.objects.get(name="Population générale")
-            MaxQuantityPerPopulationRelation.objects.create(
-                substance=substance, population=general_population, ca_max_quantity=max_quantity
-            )
+        if max_quantities is None:
+            return substance
+
+        for max_quantity in max_quantities:
+            self.add_max_quantity(substance, max_quantity)
 
         return substance
 
     @transaction.atomic
     def update(self, instance, validated_data):
+        max_quantities = validated_data.pop("maxquantityperpopulationrelation_set", None)
         substance = super().update(instance, validated_data)
+        if max_quantities is None:
+            return substance
 
-        # le champ `max_quantity` n'existe pas dans validated_data
-        # car ce n'est pas un champ du Model mais une property
-        if "max_quantity" in self.initial_data.keys():
-            max_quantity = self.initial_data.get("max_quantity")
+        # TODO: make this more sophisticated
+        substance.maxquantityperpopulationrelation_set.all().delete()
 
-            general_population = Population.objects.get(name="Population générale")
-            max_qty_general_pop = MaxQuantityPerPopulationRelation.objects.filter(
-                substance=substance, population=general_population
-            )
+        for max_quantity in max_quantities:
+            self.add_max_quantity(substance, max_quantity)
 
-            # delete
-            if max_qty_general_pop.exists() and max_quantity is None:
-                max_qty_general_pop.first().delete()
-            # update
-            elif max_qty_general_pop.exists() and max_quantity is not None:
-                max_quantity_to_change = max_qty_general_pop.first()
-                max_quantity_to_change.ca_max_quantity = max_quantity
-                max_quantity_to_change.save()
-            # create
-            elif not max_qty_general_pop.exists() and max_quantity is not None:
-                MaxQuantityPerPopulationRelation.objects.create(
-                    substance=substance, population=general_population, ca_max_quantity=max_quantity
-                )
+        # synonyms = validated_data.pop(self.synonym_set_field_name, [])
+        # change_reason = validated_data.pop("change_reason", "Modification via Compl'Alim")
+        # data_items = copy.deepcopy(validated_data).items()
+        # for key, value in data_items:
+        #     if key.startswith("ca_"):
+        #         siccrf_key = key.replace("ca_", "siccrf_")
+        #         siccrf_value = getattr(instance, siccrf_key, None)
+        #         ca_value = getattr(instance, key, None)
+        #         if not value and (siccrf_value or ca_value):
+        #             validated_data[siccrf_key] = value  # mettre comme None ou "" selon la requête
+        #             logger.info(
+        #                 f"SICCRF champ supprimé : le champ '{siccrf_key}' a été supprimé sur l'ingrédient type '{instance.object_type}', id '{instance.id}'"
+        #             )
+        #         elif value == siccrf_value and not ca_value:
+        #             # si la valeur siccrf n'a pas été surpassée par une valeur CA, et la valeur donnée est la même que l'existante, pas besoin de la sauvegarder
+        #             validated_data.pop(key, None)
 
+        # super().update(instance, validated_data)
+        # update_change_reason(instance, change_reason)
+
+        # try:
+        #     new_synonym_list = [s["name"] for s in synonyms]
+        # except KeyError:
+        #     raise ParseError(detail="Must provide 'name' to create new synonym")
+        # existing_synonyms = getattr(instance, self.synonym_set_field_name)
+
+        # # TODO: is it important to update, rather delete and recreate, 'new' synonyms ?
+        # synonyms_to_delete = existing_synonyms.exclude(name__in=new_synonym_list)
+        # synonyms_to_delete.delete()
+
+        # for synonym in synonyms:
+        #     if not existing_synonyms.filter(name=synonym["name"]).exists():
+        #         self.add_synonym(instance, synonym)
+
+        # return instance
         return substance
+
+    def add_max_quantity(self, substance, max_quantity):
+        MaxQuantityPerPopulationRelation.objects.create(
+            substance=substance, population=max_quantity["population"], ca_max_quantity=max_quantity["ca_max_quantity"]
+        )

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -632,7 +632,7 @@ class TestElementsModifyApi(APITestCase):
         )
 
     # TODO: other errors to test: key errors, bad population id, duplicate population id
-    # TODO: test against siccrf data
+    # TODO: test can't create with maxQuantities if no unit
     @authenticate
     def test_update_siccrf_max_quantity(self):
         """

--- a/data/tests/test_declaration.py
+++ b/data/tests/test_declaration.py
@@ -25,7 +25,7 @@ from data.models.ingredient_status import IngredientStatus
 
 class DeclarationTestCase(TestCase):
     def setUp(self):
-        self.pop_generale = PopulationFactory.create(ca_name="Population générale")
+        self.general_pop = PopulationFactory.create(ca_name="Population générale")
 
     def test_json_representation(self):
         declaration = InstructionReadyDeclarationFactory()
@@ -300,7 +300,7 @@ class DeclarationTestCase(TestCase):
             substance = SubstanceFactory(substance_types=type)
             MaxQuantityPerPopulationRelationFactory(
                 substance=substance,
-                population=self.pop_generale,
+                population=self.general_pop,
                 ca_max_quantity=SUBSTANCE_MAX_QUANTITY,
             )
             ComputedSubstanceFactory(
@@ -369,12 +369,12 @@ class DeclarationTestCase(TestCase):
         ]
         for type in substance_types:
             declaration_with_computed_substance_max_exceeded = InstructionReadyDeclarationFactory(
-                computed_substances=[], populations=[self.pop_generale]
+                computed_substances=[], populations=[self.general_pop]
             )
             substance = SubstanceFactory(substance_types=type)
             MaxQuantityPerPopulationRelationFactory(
                 substance=substance,
-                population=self.pop_generale,
+                population=self.general_pop,
                 ca_max_quantity=SUBSTANCE_MAX_QUANTITY,
             )
             ComputedSubstanceFactory(
@@ -457,7 +457,7 @@ class DeclarationTestCase(TestCase):
             substance = SubstanceFactory(substance_types=substance_type)
             MaxQuantityPerPopulationRelationFactory(
                 substance=substance,
-                population=self.pop_generale,
+                population=self.general_pop,
                 ca_max_quantity=2,
             )
             MaxQuantityPerPopulationRelationFactory(

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -257,7 +257,8 @@ watch(
     if (state.value.objectType && apiType.value === "other-ingredient")
       state.value.ingredientType = ingredientTypes.find((t) => t.apiValue === state.value.objectType).value
     if (state.value.unitId) state.value.unit = state.value.unitId
-    // TODO: read in max doses
+    if (state.value.maxQuantities?.length)
+      state.value.maxQuantities.map((q) => (q.population = q.population.id.toString()))
   }
 )
 
@@ -400,7 +401,7 @@ const unitString = computed(() => {
 })
 
 const populationOptions = computed(() => {
-  return populations.value?.map((pop) => ({ text: pop.name, value: pop.id }))
+  return populations.value?.map((pop) => ({ text: pop.name, value: pop.id.toString() }))
 })
 // const populationQuantities = ref([])
 const addNewMaxQuantity = () => {

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -136,10 +136,8 @@
         <DsfrInputGroup :error-message="firstErrorMsg(v$, 'nutritionalReference')">
           <NumberField label="Apport nutritionnel de référence" label-visible v-model="state.nutritionalReference" />
         </DsfrInputGroup>
-        <DsfrInputGroup :error-message="firstErrorMsg(v$, 'maxQuantity')">
-          <NumberField label="Quantité maximale autorisée" label-visible v-model="state.maxQuantity" />
-        </DsfrInputGroup>
         <div class="max-w-32">
+          <!-- TODO: how to make it clear that this needs to be specified first? -->
           <DsfrInputGroup v-if="isNewIngredient" :error-message="firstErrorMsg(v$, 'unit')">
             <DsfrSelect
               label="Unité"
@@ -353,7 +351,6 @@ const rules = computed(() => {
     ingredientType: form?.ingredientType ? errorRequiredField : {},
     family: form?.family ? errorRequiredField : {},
     nutritionalReference: form?.nutritionalReference ? errorNumeric : {},
-    // maxQuantity: form?.maxQuantity ? errorNumeric : {},
     changeReason: isNewIngredient.value ? {} : Object.assign({}, errorRequiredField, errorMaxStringLength(100)),
   }
 })
@@ -413,6 +410,7 @@ const deleteMaxQuantity = (idx) => {
 }
 const maxQuantitiesError = ref()
 const validateMaxQuantities = () => {
+  // TODO: do we use must_specify_max_quantity ?
   const hasMissingData = populationQuantities.value.some(
     (q) => !q.population || (!q.maxQuantity && q.maxQuantity !== 0)
   )

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -153,12 +153,11 @@
         </div>
       </div>
       <div v-if="formForType.maxQuantity">
-        <!-- TODO: reduce the size of the table title -->
         <DsfrTable
           v-if="state.maxQuantities.length"
           title="Quantités maximales par population"
           :headers="maxQuantitiesHeaders"
-          class="!mb-2"
+          class="!mb-2 quantities-table"
         >
           <tr v-for="(q, idx) in state.maxQuantities" :key="`max-quantity-row-${idx}`">
             <td><DsfrSelect v-model="q.population" :options="populationOptions" /></td>
@@ -403,7 +402,6 @@ const unitString = computed(() => {
 const populationOptions = computed(() => {
   return populations.value?.map((pop) => ({ text: pop.name, value: pop.id.toString() }))
 })
-// const populationQuantities = ref([])
 const addNewMaxQuantity = () => {
   state.value.maxQuantities.push({})
 }
@@ -420,3 +418,10 @@ const maxQuantitiesHeaders = computed(() => {
   return ["Population", `Quantité max (en ${unitString.value})`, ""]
 })
 </script>
+
+<style scoped>
+.quantities-table :deep(caption.caption) {
+  /* la taille du fr-h5 */
+  font-size: 1.375rem;
+}
+</style>

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -157,12 +157,12 @@
         <!-- TODO: reduce the size of the table title -->
         <!-- TODO: maybe move unit to quantity header since it is the same for all rows -->
         <DsfrTable
-          v-if="populationQuantities.length"
+          v-if="state.maxQuantities.length"
           title="Quantités maximales par population"
           :headers="['Population', 'Quantité max', 'Unité', '']"
           class="!mb-2"
         >
-          <tr v-for="(q, idx) in populationQuantities" :key="`max-quantity-row-${idx}`">
+          <tr v-for="(q, idx) in state.maxQuantities" :key="`max-quantity-row-${idx}`">
             <td><DsfrSelect v-model="q.population" :options="populationOptions" /></td>
             <td><DsfrInput v-model.number="q.maxQuantity" /></td>
             <td>{{ unitString }}</td>
@@ -247,6 +247,7 @@ const state = ref({
   plantParts: [],
   substances: [],
   synonyms: [createEmptySynonym(), createEmptySynonym(), createEmptySynonym()],
+  maxQuantities: [],
 })
 
 watch(
@@ -259,6 +260,7 @@ watch(
     if (state.value.objectType && apiType.value === "other-ingredient")
       state.value.ingredientType = ingredientTypes.find((t) => t.apiValue === state.value.objectType).value
     if (state.value.unitId) state.value.unit = state.value.unitId
+    // TODO: read in max doses
   }
 )
 
@@ -402,19 +404,17 @@ const unitString = computed(() => {
 const populationOptions = computed(() => {
   return populations.value?.map((pop) => ({ text: pop.name, value: pop.id }))
 })
-const populationQuantities = ref([])
+// const populationQuantities = ref([])
 const addNewMaxQuantity = () => {
-  populationQuantities.value.push({})
+  state.value.maxQuantities.push({})
 }
 const deleteMaxQuantity = (idx) => {
-  populationQuantities.value.splice(idx, 1)
+  state.value.maxQuantities.splice(idx, 1)
 }
 const maxQuantitiesError = ref()
 const validateMaxQuantities = () => {
   // TODO: do we use must_specify_max_quantity ?
-  const hasMissingData = populationQuantities.value.some(
-    (q) => !q.population || (!q.maxQuantity && q.maxQuantity !== 0)
-  )
+  const hasMissingData = state.value.maxQuantities.some((q) => !q.population || (!q.maxQuantity && q.maxQuantity !== 0))
   maxQuantitiesError.value = hasMissingData && "Veuillez compléter tous les champs ou supprimer les lignes vides"
 }
 </script>

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -355,6 +355,7 @@ const rules = computed(() => {
     family: form?.family ? errorRequiredField : {},
     nutritionalReference: form?.nutritionalReference ? errorNumeric : {},
     changeReason: isNewIngredient.value ? {} : Object.assign({}, errorRequiredField, errorMaxStringLength(100)),
+    unit: state.value.maxQuantities?.length || state.value.nutritionalReference ? errorRequiredField : {},
   }
 })
 watch(formForType, () => v$.value.$reset())
@@ -398,7 +399,7 @@ const plantFamiliesDisplay = computed(() => {
 const aromaId = 3
 
 const unitString = computed(() => {
-  return getUnitString(state.value.unit, units)
+  return getUnitString(parseInt(state.value.unit, 10), units)
 })
 
 const populationOptions = computed(() => {

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -155,6 +155,7 @@
       </div>
       <div v-if="formForType.maxQuantity">
         <!-- TODO: reduce the size of the table title -->
+        <!-- TODO: maybe move unit to quantity header since it is the same for all rows -->
         <DsfrTable
           v-if="populationQuantities.length"
           title="Quantités maximales par population"

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -174,8 +174,6 @@
           </tr>
         </DsfrTable>
         <p v-else>Aucune quantité maximale n'est spécifiée.</p>
-        <!-- TODO: I'm sure this can be improved visually and accessibility -->
-        <!-- maybe add red to the table colours, or have a little alert icon next to the offending lines -->
         <p v-if="maxQuantitiesError" class="text-red-marianne-425">{{ maxQuantitiesError }}</p>
         <DsfrButton
           label="Ajouter une dose max pour une population"

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -292,6 +292,10 @@ const saveElement = async () => {
     })
     if (isNewIngredient.value) router.push({ name: "DashboardPage" })
     else router.navigateBack({ name: "DashboardPage" })
+  } else {
+    if ($externalResults.value.fieldErrors?.maxQuantities) {
+      maxQuantitiesError.value = $externalResults.value.fieldErrors.maxQuantities[0]
+    }
   }
 }
 const addNewSynonym = async () => {

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -144,6 +144,7 @@
               :options="store.units?.map((unit) => ({ text: unit.name, value: unit.id }))"
               v-model="state.unit"
               defaultUnselectedText="Unité"
+              required
             />
           </DsfrInputGroup>
           <div v-else class="pt-4">
@@ -348,9 +349,9 @@ const rules = computed(() => {
     genus: form?.genus ? errorRequiredField : {},
     ingredientType: form?.ingredientType ? errorRequiredField : {},
     family: form?.family ? errorRequiredField : {},
+    unit: form?.nutritionalReference && !props.element ? errorRequiredField : {},
     nutritionalReference: form?.nutritionalReference ? errorNumeric : {},
     changeReason: isNewIngredient.value ? {} : Object.assign({}, errorRequiredField, errorMaxStringLength(100)),
-    unit: state.value.maxQuantities?.length || state.value.nutritionalReference ? errorRequiredField : {},
   }
 })
 watch(formForType, () => v$.value.$reset())

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -256,7 +256,7 @@ watch(
       state.value.ingredientType = ingredientTypes.find((t) => t.apiValue === state.value.objectType).value
     if (state.value.unitId) state.value.unit = state.value.unitId
     if (state.value.maxQuantities?.length)
-      state.value.maxQuantities.map((q) => (q.population = q.population.id.toString()))
+      state.value.maxQuantities.forEach((q) => (q.population = q.population.id.toString()))
   }
 )
 

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -413,7 +413,6 @@ const deleteMaxQuantity = (idx) => {
 }
 const maxQuantitiesError = ref()
 const validateMaxQuantities = () => {
-  // TODO: do we use must_specify_max_quantity ?
   const hasMissingData = state.value.maxQuantities.some((q) => !q.population || (!q.maxQuantity && q.maxQuantity !== 0))
   maxQuantitiesError.value = hasMissingData && "Veuillez compléter tous les champs ou supprimer les lignes vides"
 }

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -137,7 +137,6 @@
           <NumberField label="Apport nutritionnel de référence" label-visible v-model="state.nutritionalReference" />
         </DsfrInputGroup>
         <div class="max-w-32">
-          <!-- TODO: how to make it clear that this needs to be specified first? -->
           <DsfrInputGroup v-if="isNewIngredient" :error-message="firstErrorMsg(v$, 'unit')">
             <DsfrSelect
               label="Unité"
@@ -155,17 +154,15 @@
       </div>
       <div v-if="formForType.maxQuantity">
         <!-- TODO: reduce the size of the table title -->
-        <!-- TODO: maybe move unit to quantity header since it is the same for all rows -->
         <DsfrTable
           v-if="state.maxQuantities.length"
           title="Quantités maximales par population"
-          :headers="['Population', 'Quantité max', 'Unité', '']"
+          :headers="maxQuantitiesHeaders"
           class="!mb-2"
         >
           <tr v-for="(q, idx) in state.maxQuantities" :key="`max-quantity-row-${idx}`">
             <td><DsfrSelect v-model="q.population" :options="populationOptions" /></td>
             <td><DsfrInput v-model.number="q.maxQuantity" /></td>
-            <td>{{ unitString }}</td>
             <td>
               <DsfrButton
                 label="Supprimer"
@@ -418,4 +415,7 @@ const validateMaxQuantities = () => {
   const hasMissingData = state.value.maxQuantities.some((q) => !q.population || (!q.maxQuantity && q.maxQuantity !== 0))
   maxQuantitiesError.value = hasMissingData && "Veuillez compléter tous les champs ou supprimer les lignes vides"
 }
+const maxQuantitiesHeaders = computed(() => {
+  return ["Population", `Quantité max (en ${unitString.value})`, ""]
+})
 </script>


### PR DESCRIPTION
Changements :

- unité est maintenant obligatoire (j'ai fait une recherche pour des substances sans unité et il n'y a aucune. Ça a des implications sur plusieurs choses si on n'a pas d'unité)
- ajout du tableau pour définir les doses max

![Screenshot 2025-04-15 at 14-50-48 Nouvel ingrédient - Compl'Alim](https://github.com/user-attachments/assets/a6db4dda-10b1-4f01-94ec-91b22df3f6ab)
![Screenshot 2025-04-15 at 14-51-08 Nouvel ingrédient - Compl'Alim](https://github.com/user-attachments/assets/3d4a6fde-3b0c-4dd6-b953-dbac8376422b)
![Screenshot 2025-04-15 at 14-51-21 Nouvel ingrédient - Compl'Alim](https://github.com/user-attachments/assets/c5e30a65-7bb0-4775-9436-6bfee30cd04e)
