### PR TITLE
Gestion substances : ajouter champ "spécification quantité obligatoire"

### DIFF
--- a/api/serializers/common_ingredient.py
+++ b/api/serializers/common_ingredient.py
@@ -83,7 +83,7 @@ class CommonIngredientModificationSerializer(serializers.ModelSerializer):
                 siccrf_key = key.replace("ca_", "siccrf_")
                 siccrf_value = getattr(instance, siccrf_key, None)
                 ca_value = getattr(instance, key, None)
-                if not value and (siccrf_value or ca_value):
+                if not value and value is not False and (siccrf_value or ca_value):
                     validated_data[siccrf_key] = value  # mettre comme None ou "" selon la requête
                     logger.info(
                         f"SICCRF champ supprimé : le champ '{siccrf_key}' a été supprimé sur l'ingrédient type '{instance.object_type}', id '{instance.id}'"

--- a/api/serializers/substance.py
+++ b/api/serializers/substance.py
@@ -115,6 +115,9 @@ class SubstanceModificationSerializer(CommonIngredientModificationSerializer, Wi
     max_quantities = SubstanceMaxQuantityModificationSerializer(
         many=True, source="maxquantityperpopulationrelation_set", required=False
     )
+    must_specify_quantity = serializers.BooleanField(
+        source="ca_must_specify_quantity", required=False, allow_null=True
+    )
 
     nutritional_reference = serializers.FloatField(source="ca_nutritional_reference", required=False, allow_null=True)
 
@@ -133,6 +136,7 @@ class SubstanceModificationSerializer(CommonIngredientModificationSerializer, Wi
                 "max_quantities",
                 "nutritional_reference",
                 "unit",
+                "must_specify_quantity",
             )
         )
         read_only = COMMON_READ_ONLY_FIELDS

--- a/api/tests/test_elements.py
+++ b/api/tests/test_elements.py
@@ -484,6 +484,8 @@ class TestElementsModifyApi(APITestCase):
             unit=SubstanceUnitFactory.create(),
             siccrf_status=IngredientStatus.NO_STATUS,
             ca_status=IngredientStatus.AUTHORIZED,
+            siccrf_must_specify_quantity=True,
+            ca_must_specify_quantity=None,
         )
         MaxQuantityPerPopulationRelationFactory(
             substance=substance,
@@ -495,6 +497,9 @@ class TestElementsModifyApi(APITestCase):
         self.assertEqual(
             substance.max_quantity, 3.4, "La quantité max pour la population générale est la bonne avant modification"
         )
+        self.assertTrue(
+            substance.siccrf_must_specify_quantity, "Le champ siccrf est vrai, comme donné dans le factory"
+        )
         response = self.client.patch(
             reverse("api:single_substance", kwargs={"pk": substance.id}),
             {
@@ -502,6 +507,7 @@ class TestElementsModifyApi(APITestCase):
                 "unit": new_unit.id,
                 "maxQuantities": [{"population": self.general_pop.id, "maxQuantity": 35}],
                 "status": IngredientStatus.NO_STATUS,
+                "mustSpecifyQuantity": False,
                 "changeReason": "Test change",
             },
             format="json",
@@ -517,7 +523,14 @@ class TestElementsModifyApi(APITestCase):
         self.assertEqual(
             substance.status, IngredientStatus.NO_STATUS, "C'est possible de remettre la valeur originelle"
         )
-        self.assertEqual(substance.history.first().history_change_reason, "Test change")
+        self.assertFalse(substance.must_specify_quantity, "Le champ calculé prend la nouvelle valeur de ca_")
+        self.assertFalse(substance.ca_must_specify_quantity, "Le champ ca_ est donné une valeur")
+        self.assertTrue(substance.siccrf_must_specify_quantity, "Le champ siccrf n'est pas changé")
+        self.assertEqual(
+            substance.history.first().history_change_reason,
+            "Test change",
+            "Le message en texte libre est sauvegardée comme raison de changement",
+        )
 
     @authenticate
     def test_can_modify_substance_max_quantities(self):

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -132,7 +132,7 @@
           ></DsfrTag>
         </div>
       </div>
-      <div class="grid grid-cols-3 gap-x-8" v-if="formForType.nutritionalReference">
+      <div class="grid sm:grid-cols-3 gap-x-8" v-if="formForType.nutritionalReference">
         <DsfrInputGroup :error-message="firstErrorMsg(v$, 'nutritionalReference')">
           <NumberField label="Apport nutritionnel de référence" label-visible v-model="state.nutritionalReference" />
         </DsfrInputGroup>
@@ -149,11 +149,21 @@
           </DsfrInputGroup>
           <div v-else class="pt-4">
             <p class="mb-2">Unité</p>
-            <p>{{ unitString }}</p>
+            <p class="mb-0">{{ unitString }}</p>
           </div>
         </div>
+        <DsfrInputGroup>
+          <DsfrToggleSwitch
+            v-model="state.mustSpecifyQuantity"
+            label="Spécification de quantité obligatoire ?"
+            activeText="Oui"
+            inactiveText="Non"
+            label-left
+            class="self-center mt-4 col-span-2 sm:col-span-2"
+          />
+        </DsfrInputGroup>
       </div>
-      <div v-if="formForType.maxQuantity">
+      <div v-if="formForType.maxQuantity" class="mt-8 sm:mt-0">
         <DsfrTable
           v-if="state.maxQuantities.length"
           title="Quantités maximales par population"


### PR DESCRIPTION
ETQ instructrice je veux gérer si les pros devraient donner une quantité dans la composition pour les substances qu'ils utilisent.

Sur la page création/modification substance il y a un nouveau champ :

## grand écran

![Screenshot 2025-04-25 at 13-42-12 Modification ingrédient - Compl'Alim](https://github.com/user-attachments/assets/ed80e671-9245-4626-a71c-6c509a33367b)


## petit écran

![Screenshot 2025-04-25 at 13-40-45 Modification ingrédient - Compl'Alim](https://github.com/user-attachments/assets/2ccb7ae3-e9b4-4bef-8eae-ce3734c623ee)
