### PR TITLE
:lady_beetle:  Fixes sur le JDD Open-Data declarations

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -360,6 +360,7 @@ def add_enum_or_personnalized_value(item, custom_value):
 
 class OpenDataDeclarationSerializer(serializers.ModelSerializer):
     id = serializers.SerializerMethodField()
+    numero_declaration_teleicare = serializers.SerializerMethodField()
     decision = serializers.SerializerMethodField()
     responsable_mise_sur_marche = serializers.SerializerMethodField()
     siret_responsable_mise_sur_marche = serializers.SerializerMethodField()
@@ -389,6 +390,7 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
 
         fields = (
             "id",
+            "numero_declaration_teleicare",
             "decision",
             "responsable_mise_sur_marche",
             "siret_responsable_mise_sur_marche",
@@ -419,7 +421,10 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
         """
         Cette fonction retourne le TeleIcare id s'il existe sinon le Compl'Alim id
         """
-        return obj.teleicare_id or obj.id
+        return obj.siccrf_id or obj.id
+
+    def get_numero_declaration_teleicare(self, obj):
+        return obj.teleicare_id
 
     def get_decision(self, obj):
         return obj.get_status_display()

--- a/data/etl/transformer_loader.py
+++ b/data/etl/transformer_loader.py
@@ -21,8 +21,8 @@ class OPEN_DATA(TRANSFORMER_LOADER):
 
         # transforme les objects en json strings pour éviter de créer un csv avec des json string
         # qui ne respectent pas https://www.rfc-editor.org/rfc/rfc7159#section-7
-        json_columns = df_csv.columns[df_csv.applymap(type).eq(list).any()]
-        df_csv[json_columns] = df_csv[json_columns].map(json.dumps).astype("string")
+        json_columns = df_csv.columns[df_csv.map(type).eq(list).any()]
+        df_csv[json_columns] = df_csv[json_columns].map(lambda x: json.dumps(x, ensure_ascii=False)).astype("string")
 
         with default_storage.open(filename + ".csv", "w") as csv_file:
             df_csv.to_csv(

--- a/data/etl/transformer_loader.py
+++ b/data/etl/transformer_loader.py
@@ -21,8 +21,8 @@ class OPEN_DATA(TRANSFORMER_LOADER):
 
         # transforme les objects en json strings pour éviter de créer un csv avec des json string
         # qui ne respectent pas https://www.rfc-editor.org/rfc/rfc7159#section-7
-        json_columns = self.df.columns[self.df.applymap(type).eq(list).any()]
-        self.df[json_columns] = self.df[json_columns].map(json.dumps).astype("string")
+        json_columns = df_csv.columns[df_csv.applymap(type).eq(list).any()]
+        df_csv[json_columns] = df_csv[json_columns].map(json.dumps).astype("string")
 
         with default_storage.open(filename + ".csv", "w") as csv_file:
             df_csv.to_csv(

--- a/data/schemas/CHANGELOG_declarations.md
+++ b/data/schemas/CHANGELOG_declarations.md
@@ -52,3 +52,9 @@ Tous les changements notables apportés aux jeux de données exposés sur data.g
 ## Amélioration qualité données
 - le champ id contient l'identifiant TeleIcare ou Compl'Alim
 - les champs complexes ['objectif_effet', 'facteurs_risques', 'populations_cibles', 'additifs', 'nutriments', 'autres_ingredients_actifs', 'ingredients_inactifs'] sont écrit comme des JSON string conformes
+
+## 2025-04-30
+
+## Amélioration qualité données
+- le champ id contient l'identifiant TeleIcare ou Compl'Alim
+- le champ numero_declaration_teleicare contient le numéro de déclaration si la déclaration a été faite dans la plateforme historique TeleIcare

--- a/data/schemas/schema_declarations.json
+++ b/data/schemas/schema_declarations.json
@@ -15,6 +15,13 @@
       "example": "3211",
       "name": "id",
       "title": "Identifiant",
+      "type": "integer"
+    },
+    {
+      "description": "Numéro de déclaration (identifiant unique qui n'existait que dans la plateforme historique TeleIcare)",
+      "example": "2024-12-890",
+      "name": "numero_declaration_teleicare",
+      "title": "Numero de déclaration de TeleIcare",
       "type": "string"
     },
     {

--- a/data/tests/test_open_data.py
+++ b/data/tests/test_open_data.py
@@ -1,0 +1,74 @@
+import json
+import os
+from unittest import mock
+
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.test import TestCase
+
+import pandas as pd
+
+from data.etl.transformer_loader import ETL_OPEN_DATA_DECLARATIONS
+from data.factories import (
+    AuthorizedDeclarationFactory,
+    AwaitingInstructionDeclarationFactory,
+    DeclaredMicroorganismFactory,
+    DeclaredPlantFactory,
+    DeclaredSubstanceFactory,
+    MicroorganismFactory,
+    PlantFactory,
+    PlantPartFactory,
+    SubstanceFactory,
+    SubstanceUnitFactory,
+)
+from data.models import Declaration
+
+
+class IngredientTestCase(TestCase):
+    @mock.patch("data.etl.datagouv.update_resources")
+    def test_created_csv_is_json_compliant(self, mocked_update_resources):
+        """
+        Le fichier csv créé à la sortie du process d'extraction du JDD Open Data contient des colonnes de données complexes qui sont en json bien formé
+        """
+        # Création de declarations dont déclarations provenant de TeleIcare
+        declaration_1 = AuthorizedDeclarationFactory()
+        DeclaredPlantFactory(
+            declaration=declaration_1,
+            plant=PlantFactory(name="Ortie"),
+            used_part=PlantPartFactory(ca_name="Parties aériennes"),
+            quantity=5.0,
+            unit=SubstanceUnitFactory(name="mg"),
+        )
+        declaration_2 = AuthorizedDeclarationFactory()
+        declaration_2.declared_substances.set([])
+        substance = SubstanceFactory(ca_name="Vitamine C")
+        DeclaredSubstanceFactory(
+            declaration=declaration_2,
+            substance=substance,
+            quantity=10.0,
+            unit=SubstanceUnitFactory(name="mg"),
+        )
+        declaration_teleicare = AuthorizedDeclarationFactory(siccrf_id=567365, teleicare_id="2025-06-07")
+        DeclaredMicroorganismFactory(
+            declaration=declaration_teleicare,
+            microorganism=MicroorganismFactory(ca_genus="Lactobasine", ca_species="en bois"),
+            quantity=5.0,
+        )
+        AwaitingInstructionDeclarationFactory()
+        self.assertEqual(Declaration.objects.all().count(), 4)
+
+        # default_storage est FileSystemStorage dans l'environnement de test
+        etl_test = ETL_OPEN_DATA_DECLARATIONS()
+        etl_test.dataset_name = "test_declarations"
+        etl_test.extract_dataset()
+        etl_test.transform_dataset()
+        etl_test.load_dataset()
+
+        open_data_jdd = pd.read_csv(os.path.join(settings.MEDIA_ROOT, etl_test.dataset_name + ".csv"), delimiter=";")
+        self.assertEqual(len(open_data_jdd), 3)
+        substance_loaded = json.loads(open_data_jdd["substances"][1])
+        self.assertEqual(substance_loaded[3]["nom"], "Vitamine C")
+        self.assertEqual(substance_loaded[3]["unite"], "mg")
+
+        # supprime le fichier qui vient d'être créé
+        default_storage.delete(etl_test.dataset_name + ".csv")

--- a/data/tests/test_open_data.py
+++ b/data/tests/test_open_data.py
@@ -36,7 +36,6 @@ class IngredientTestCase(TestCase):
         self.etl_test.dataset_name = "test_declarations"
 
     def test_declaration_jdd_contains_only_authorized_declarations(self):
-        # Création de declarations dont déclarations provenant de TeleIcare
         AuthorizedDeclarationFactory()
         AwaitingInstructionDeclarationFactory()
         InstructionReadyDeclarationFactory()
@@ -69,8 +68,7 @@ class IngredientTestCase(TestCase):
             quantity=5.0,
             unit=SubstanceUnitFactory(name="mg"),
         )
-        declaration_2 = AuthorizedDeclarationFactory()
-        declaration_2.declared_substances.set([])
+        declaration_2 = AuthorizedDeclarationFactory(declared_substances=[])
         substance = SubstanceFactory(ca_name="Vitamine C")
         DeclaredSubstanceFactory(
             declaration=declaration_2,
@@ -94,8 +92,9 @@ class IngredientTestCase(TestCase):
         )
         self.assertEqual(len(open_data_jdd), 3)
         substance_loaded = json.loads(open_data_jdd["substances"][1])
-        self.assertEqual(substance_loaded[3]["nom"], "Vitamine C")
-        self.assertEqual(substance_loaded[3]["unite"], "mg")
+        self.assertEqual(substance_loaded[0]["nom"], "Vitamine C")
+        self.assertEqual(substance_loaded[0]["quantité_par_djr"], 10)
+        self.assertEqual(substance_loaded[0]["unite"], "mg")
 
         # supprime le fichier qui vient d'être créé
         default_storage.delete(self.etl_test.dataset_name + ".csv")


### PR DESCRIPTION
Lié à #1946 

# :id: Le jeu de données déclarations MASA contient le même id que celui du Ministère de l'économie pour les déclarations historiques

- Dans le [jdd opendata de la CCRF](https://www.data.gouv.fr/fr/datasets/liste-des-complements-alimentaires-declares/), l'id unique des déclarations est le siccrf_id (et pas le teleicare_id) => permet la réconciliation des données pour les réutilisateurs de la donnée
- les string pour les composition d'ingrédients complexes n'était pas des string json valides

Seules les 2 items qui auraient du être corrigés par https://github.com/betagouv/complements-alimentaires/pull/1878 sont repris ici car les résolutions apportées n'étaient pas satisfaisantes.
Et ajout de tests du coup !