### PR TITLE
:bug: Fix : modification des ingrédients qui ne sont pas plantes

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -298,7 +298,7 @@ const saveElement = async () => {
   }
   payload.synonyms = payload.synonyms.filter((s) => !!s.name)
   if (payload.ingredientType && payload.ingredientType == aromaId) delete payload.novelFood
-  if (payload.authorisedPlantParts?.length || payload.forbiddenPlantParts.length) {
+  if (payload.authorisedPlantParts?.length || payload.forbiddenPlantParts?.length) {
     const authorisedParts = payload.authorisedPlantParts
     const forbiddenParts = payload.forbiddenPlantParts
     payload.plantParts = authorisedParts


### PR DESCRIPTION
Bug introduit avec #1930, qui bloque la sauvegarde de changements sur la page modification/création d'ingrédient.

`payload.forbiddenPlantParts is undefined`