### PR TITLE
Modification ingrédient : raison de changement interne n'est plus obligatoire

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -216,9 +216,8 @@
       <DsfrInputGroup v-if="!isNewIngredient" :error-message="firstErrorMsg(v$, 'changeReason')">
         <DsfrInput
           v-model="state.changeReason"
-          label="Raison de changement"
+          label="Raison de changement (usage interne)"
           hint="100 caractères max"
-          required
           labelVisible
         />
       </DsfrInputGroup>
@@ -298,7 +297,7 @@ const saveElement = async () => {
   }
   payload.synonyms = payload.synonyms.filter((s) => !!s.name)
   if (payload.ingredientType && payload.ingredientType == aromaId) delete payload.novelFood
-  if (payload.authorisedPlantParts?.length || payload.forbiddenPlantParts.length) {
+  if (payload.authorisedPlantParts?.length || payload.forbiddenPlantParts?.length) {
     const authorisedParts = payload.authorisedPlantParts
     const forbiddenParts = payload.forbiddenPlantParts
     payload.plantParts = authorisedParts
@@ -384,7 +383,7 @@ const rules = computed(() => {
     family: form?.family ? errorRequiredField : {},
     unit: form?.nutritionalReference && !props.element ? errorRequiredField : {},
     nutritionalReference: form?.nutritionalReference ? errorNumeric : {},
-    changeReason: isNewIngredient.value ? {} : Object.assign({}, errorRequiredField, errorMaxStringLength(100)),
+    changeReason: isNewIngredient.value ? {} : errorMaxStringLength(100),
   }
 })
 watch(formForType, () => v$.value.$reset())


### PR DESCRIPTION
Aussi modifier le nom du champ. Une partie du travail de #1920 

![Screenshot 2025-04-28 at 16-37-11 Modification ingrédient - Compl'Alim](https://github.com/user-attachments/assets/188537a7-1acc-473f-83fb-a6308c81c37a)
