### PR TITLE
Ajout d'une colonne additionnelle dans l'export de la recherche avancée contenant le département de l'entreprise

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -307,6 +307,7 @@ class ExcelExportDeclarationSerializer(serializers.ModelSerializer):
     vat = serializers.CharField(read_only=True, source="company.vat")
     article = serializers.SerializerMethodField(read_only=True)
     status = serializers.SerializerMethodField(read_only=True)
+    department = serializers.CharField(read_only=True, source="company.department")
 
     # Champ spécial utilisé par drf-excel documenté ici : https://github.com/django-commons/drf-excel
     row_color = serializers.SerializerMethodField()
@@ -321,6 +322,7 @@ class ExcelExportDeclarationSerializer(serializers.ModelSerializer):
             "company_name",
             "siret",
             "vat",
+            "department",
             "row_color",  # Champ utilisé en interne par drf-excel
         )
         read_only_fields = fields

--- a/api/tests/test_declaration_excel_export.py
+++ b/api/tests/test_declaration_excel_export.py
@@ -42,6 +42,7 @@ class TestDeclarationExcelExport(APITestCase):
             "Nom de l'entreprise",
             "No. SIRET",
             "No. TVA",
+            "No. de département",
         )
         for h in expected_headers:
             self.assertIn(h, headers)

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -316,8 +316,9 @@ class OngoingDeclarationsExcelView(XLSXFileMixin, CommonOngoingDeclarationView):
             "Nom de l'entreprise",
             "No. SIRET",
             "No. TVA",
+            "No. de département",
         ],
-        "column_width": [30, 20, 30, 25, 30, 15, 15],
+        "column_width": [30, 20, 30, 25, 30, 15, 15, 15],
         "height": 30,
         "style": {
             "fill": {

--- a/data/models/company.py
+++ b/data/models/company.py
@@ -44,6 +44,15 @@ class Address(models.Model):
     def department(self):
         if self.country != CountryChoices.FRANCE:
             return None
+
+        if self.postal_code[:2] == "97" or self.postal_code[:2] == "98":
+            return self.postal_code[:3]
+
+        # Cas pour la corse : Corse du Sud : 2A, Corse du Nord : 2B
+        if self.postal_code[:2] == "20":
+            corsica_identifier = self.postal_code[2:3]
+            return "2A" if corsica_identifier == "0" or corsica_identifier == "1" else "2B"
+
         return self.postal_code[:2]
 
 

--- a/data/models/company.py
+++ b/data/models/company.py
@@ -40,6 +40,12 @@ class Address(models.Model):
         ]
         return "\n".join(filter(None, lines))
 
+    @property
+    def department(self):
+        if self.country != CountryChoices.FRANCE:
+            return None
+        return self.postal_code[:2]
+
 
 class CompanyContact(models.Model):
     class Meta:

--- a/data/tests/test_open_data.py
+++ b/data/tests/test_open_data.py
@@ -60,13 +60,14 @@ class IngredientTestCase(TestCase):
         Le fichier csv créé à la sortie du process d'extraction du JDD Open Data contient des colonnes de données complexes qui sont en json bien formé
         """
         # Création de declarations dont déclarations provenant de TeleIcare
+        milligrams = SubstanceUnitFactory(name="mg")
         declaration_1 = AuthorizedDeclarationFactory()
         DeclaredPlantFactory(
             declaration=declaration_1,
             plant=PlantFactory(name="Ortie"),
             used_part=PlantPartFactory(ca_name="Parties aériennes"),
             quantity=5.0,
-            unit=SubstanceUnitFactory(name="mg"),
+            unit=milligrams,
         )
         declaration_2 = AuthorizedDeclarationFactory(declared_substances=[])
         substance = SubstanceFactory(ca_name="Vitamine C")
@@ -74,7 +75,7 @@ class IngredientTestCase(TestCase):
             declaration=declaration_2,
             substance=substance,
             quantity=10.0,
-            unit=SubstanceUnitFactory(name="mg"),
+            unit=milligrams,
         )
         declaration_teleicare = AuthorizedDeclarationFactory(siccrf_id=567365, teleicare_id="2025-06-07")
         DeclaredMicroorganismFactory(

--- a/data/tests/test_open_data.py
+++ b/data/tests/test_open_data.py
@@ -60,14 +60,13 @@ class IngredientTestCase(TestCase):
         Le fichier csv créé à la sortie du process d'extraction du JDD Open Data contient des colonnes de données complexes qui sont en json bien formé
         """
         # Création de declarations dont déclarations provenant de TeleIcare
-        milligrams = SubstanceUnitFactory(name="mg")
         declaration_1 = AuthorizedDeclarationFactory()
         DeclaredPlantFactory(
             declaration=declaration_1,
             plant=PlantFactory(name="Ortie"),
             used_part=PlantPartFactory(ca_name="Parties aériennes"),
             quantity=5.0,
-            unit=milligrams,
+            unit=SubstanceUnitFactory(name="mg"),
         )
         declaration_2 = AuthorizedDeclarationFactory(declared_substances=[])
         substance = SubstanceFactory(ca_name="Vitamine C")
@@ -75,7 +74,7 @@ class IngredientTestCase(TestCase):
             declaration=declaration_2,
             substance=substance,
             quantity=10.0,
-            unit=milligrams,
+            unit=SubstanceUnitFactory(name="mg"),
         )
         declaration_teleicare = AuthorizedDeclarationFactory(siccrf_id=567365, teleicare_id="2025-06-07")
         DeclaredMicroorganismFactory(


### PR DESCRIPTION
Ajout d'une colonne contenant le numéro du département (si l'entreprise se trouve en France). Utile pour que le BEPIAS donne des consignes aux DD pertinents.

## :camera: Démo

![image](https://github.com/user-attachments/assets/abcaee9f-7602-4ce7-be88-e2895a057fa8)

## Technique

La solution est assez simple car le deux premiers chiffres du code postal en France donne le numéro du département. Il suffit donc de créer une propriété dans le modèle `Address` qu'on peut utiliser dans le serializer pour les exports Excel.

Closes #1957
