### PR TITLE
Recherche avancée : augmentation à 5000 lignes pour l'export et affichage du nombre de résultats

### DIFF
--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -297,7 +297,7 @@ class OngoingDeclarationsExcelView(XLSXFileMixin, CommonOngoingDeclarationView):
     serializer_class = ExcelExportDeclarationSerializer
     filename = "declarations-resultats.xlsx"
 
-    max_rows = 2000
+    max_rows = 5000
 
     def filter_queryset(self, queryset):
         """

--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -140,6 +140,11 @@
       <ProgressSpinner />
     </div>
     <div v-else-if="hasDeclarations">
+      <div class="text-right">
+        <p class="!text-sm -mb-2 -mt-4 font-medium">
+          {{ data.count }} {{ data.count === 1 ? "résultat" : "résultats" }}
+        </p>
+      </div>
       <SearchResultsTable :data="data" />
 
       <DsfrPagination
@@ -256,7 +261,7 @@ const getApiUrlIdsForType = (types) => {
   return ids.length ? ids : null
 }
 
-const maxDownloadSize = 2000
+const maxDownloadSize = 5000
 const canDownloadFile = computed(() => (data.value?.count || 0) <= maxDownloadSize)
 
 // Requêtes

--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -141,7 +141,7 @@
     </div>
     <div v-else-if="hasDeclarations">
       <div class="text-right">
-        <p class="!text-sm -mb-2 -mt-4 font-medium">
+        <p class="!text-sm -mb-2 -mt-4 font-medium" aria-live="polite">
           {{ data.count }} {{ data.count === 1 ? "résultat" : "résultats" }}
         </p>
       </div>


### PR DESCRIPTION
Permet de télécharger jusqu'à 5000 lignes en format Excel et affiche le nombre total de résultats

## :movie_camera:  Démo

https://github.com/user-attachments/assets/4cdc3629-c218-43e8-b3b7-aa5dc1325975



Closes #1979 

