### PR TITLE
Recherche avancée : permet d'effacer la recherche par mot clé

### DIFF
--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -6,7 +6,12 @@
     <div class="mb-2 md:flex gap-8 search-area">
       <div class="md:w-1/3 lg:w-2/5 pt-1">
         <DsfrFieldset legend="Recherche" class="!mb-0">
-          <DsfrSearchBar v-model="searchTerm" placeholder="Nom du produit, ID ou entreprise" @search="search" />
+          <DsfrSearchBar
+            v-model="searchTerm"
+            placeholder="Nom du produit, ID ou entreprise"
+            @search="search"
+            @update:modelValue="(val) => val === '' && search()"
+          />
         </DsfrFieldset>
       </div>
       <div class="md:w-2/3 lg:w-3/5 md:flex gap-3">


### PR DESCRIPTION
Lors qu'on vide le champ de la recherche, une recherche "vide" s'effectue sans avoir besoin de re-cliquer sur le bouton :mag_right: 

## :movie_camera: Démo


https://github.com/user-attachments/assets/856a4ecd-698a-4556-a72b-75cfd77e9517



Closes #1981