### PR TITLE
Fiche public ingrédient : donner aux instructrices un lien vers une liste de déclarations qui utilisent cet ingrédient

### DIFF
--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -98,7 +98,7 @@
             :to="{ name: 'AdvancedSearchPage', query: { composition: `${element.id}||${element.name}||${type}` } }"
             class="h-fit"
           >
-            Les déclarations
+            Voir les déclarations concernées
           </router-link>
           <router-link
             :to="{ name: 'ModifyElement', params: { urlComponent: props.urlComponent } }"

--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -91,16 +91,23 @@
         <DsfrTable :headers="historyHeaders" :rows="historyDataDedup"></DsfrTable>
       </DsfrAccordion>
 
-      <!-- bouton temporaire à enlever quand on a une page dédiée à la recherche d'ingrédients interne -->
       <div v-if="isInstructor" class="text-right mt-4">
         <p class="mb-2"><em>Vous avez le role d'instruction :</em></p>
-        <router-link
-          :to="{ name: 'ModifyElement', params: { urlComponent: props.urlComponent } }"
-          class="fr-btn fr-btn--tertiary fr-btn--sm"
-        >
-          <v-icon name="ri-pencil-line" :scale="0.85" class="mr-1"></v-icon>
-          Modifier
-        </router-link>
+        <div class="flex justify-end items-center">
+          <router-link
+            :to="{ name: 'AdvancedSearchPage', query: { composition: `${element.id}||${element.name}||${type}` } }"
+            class="h-fit"
+          >
+            Les déclarations
+          </router-link>
+          <router-link
+            :to="{ name: 'ModifyElement', params: { urlComponent: props.urlComponent } }"
+            class="fr-btn fr-btn--tertiary fr-btn--sm ml-4"
+          >
+            <v-icon name="ri-pencil-line" :scale="0.85" class="mr-1"></v-icon>
+            Modifier
+          </router-link>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
En réfléchissant sur #1835 je me suis dit que ce serait utile de pouvoir rapidement retrouver les déclarations liées à un ingrédient pour après vérifier que l'article a bien été MAJ. Alors je me suis dit que ça pourrait être utile aussi pour les instructrices.

![Screenshot 2025-05-06 at 18-18-18 Eucalyptus globulus Labill  - Compl'Alim](https://github.com/user-attachments/assets/e662b0e7-bc55-4bed-ad89-fe37a84e75b6)

