### PR TITLE
Gestion ingrédients : améliorer la navigation après action

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -265,7 +265,7 @@ import FormWrapper from "@/components/FormWrapper"
 import ElementAutocomplete from "@/components/ElementAutocomplete"
 import NumberField from "@/components/NumberField"
 
-const props = defineProps({ element: Object, type: String })
+const props = defineProps({ element: Object, type: String, urlComponent: String })
 
 const isNewIngredient = computed(() => !props.element?.id)
 
@@ -338,8 +338,8 @@ const saveElement = async () => {
       id: "element-creation-success",
       description: `L'ingrédient a été ${isNewIngredient.value ? "créé" : "modifié"}`,
     })
-    if (isNewIngredient.value) router.push({ name: "DashboardPage" })
-    else router.navigateBack({ name: "DashboardPage" })
+    if (isNewIngredient.value) router.push({ name: "NewElementsPage" })
+    else router.push({ name: "ElementPage", params: { urlComponent: props.urlComponent } })
   } else {
     if ($externalResults.value.fieldErrors?.maxQuantities) {
       maxQuantitiesError.value = $externalResults.value.fieldErrors.maxQuantities[0]

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -20,7 +20,7 @@
 
       <DsfrTabs v-model="activeTab" :tab-list-name="tabListName" :tab-titles="tabTitles">
         <DsfrTabContent panel-id="form-content" tab-id="form">
-          <FormFields :element="element" :type="type" />
+          <FormFields :element="element" :type="type" :urlComponent="props.urlComponent" />
         </DsfrTabContent>
 
         <DsfrTabContent panel-id="history-content" tab-id="history">


### PR DESCRIPTION
Reflexion perso :

- Quand on crée des ingrédients, ça a du sens de revenir à la page où on retrouve le bouton-lien pour créer les ingrédients
- Quand on modifie des ingrédients, ça a du sens d'aller vers le fiche public de l'ingrédient, où on peut vérifier les données et où on retrouve le bouton-lien pour modifier l'ingrédient

Avant, le comportement etait :

- Nouvel ingrédient : on arrive sur le tableau de bord dans tous les cas
- Modification ingrédient : on arrive soit au fiche public, soit au tableau de bord, selon l'activité de l'instructrice avant la modif