### PR TITLE
Recherche avancée : Fix du bug avec les boutons back et fwd des navigateurs

### DIFF
--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -252,7 +252,7 @@ const decisionDateBefore = computed(() => route.query.decisionApres)
 // Mises à jour de la requête lors des changements des filtres et recherche
 
 const updateQuery = (newQuery) => {
-  router.push({ query: { ...route.query, ...{ page: 1 }, ...newQuery } }).then(fetchSearchResults)
+  router.push({ query: { ...route.query, ...{ page: 1 }, ...newQuery } })
 }
 
 const updateStatusFilter = (status) => updateQuery({ status })
@@ -367,10 +367,10 @@ const { response, data, isFetching, execute } = useFetch(apiUrl, { headers: { Ac
   .get()
   .json()
 
-const fetchSearchResults = async () => {
+watch(route, async () => {
   await execute()
   if (response?.value) await handleError(response) // Utile pour éviter des traiter les NS_BINDING_ABORTED de Firefox
-}
+})
 
 // Remplissage d'options dans les champs select
 


### PR DESCRIPTION
Les boutons _back_ et _fwd_ des navigateurs mettaient à jour les champs des filtres mais pas les résultats. Cette PR contient le fix.

## :movie_camera: Démo

https://github.com/user-attachments/assets/86e9dfec-97d9-494d-86c0-3d7cff42ad47


## Détails technique

Le souci venait du fait que le changement de route n'était pas observé, on appelait l'API programmatiquement après le  `router.push`. La solution est de simplement observer les changements de la route (qui peuvent aussi venir de l'historique) pour effectuer l'appel API.

Closes #1983 