### PR TITLE
Refacto : faire la recalculation d'article dans un processus asynchrone

### DIFF
--- a/config/tasks.py
+++ b/config/tasks.py
@@ -206,8 +206,7 @@ def recalculate_article_for_ongoing_declarations(declarations, change_reason):
         declaration.assign_calculated_article()
         if previous_article != declaration.calculated_article:
             declaration.save()
-            if change_reason:
-                # il faut faire un refresh pour update_change_reason de retrouver le record à MAJ
-                declaration.refresh_from_db()
-                update_change_reason(declaration, change_reason)
+            # il faut faire un refresh pour update_change_reason de retrouver le record à MAJ
+            declaration.refresh_from_db()
+            update_change_reason(declaration, change_reason)
             logger.info(f"Declaration {declaration.id} article recalculated.")

--- a/config/tasks.py
+++ b/config/tasks.py
@@ -9,6 +9,8 @@ from django.utils import timezone
 from dateutil.relativedelta import relativedelta
 from viewflow import fsm
 
+from simple_history.utils import update_change_reason
+
 from config import email
 from data.etl.transformer_loader import ETL_OPEN_DATA_DECLARATIONS
 from data.models import Declaration, Snapshot
@@ -185,3 +187,27 @@ def export_datasets_to_data_gouv():
     etl.extract_dataset()
     etl.transform_dataset()
     etl.load_dataset()
+
+
+@app.task
+def recalculate_article_for_ongoing_declarations(declarations, change_reason):
+    for declaration in declarations.filter(
+        status__in=(
+            Declaration.DeclarationStatus.DRAFT,
+            Declaration.DeclarationStatus.AWAITING_INSTRUCTION,
+            Declaration.DeclarationStatus.ONGOING_INSTRUCTION,
+            Declaration.DeclarationStatus.AWAITING_VISA,
+            Declaration.DeclarationStatus.ONGOING_VISA,
+            Declaration.DeclarationStatus.OBSERVATION,
+            Declaration.DeclarationStatus.OBJECTION,
+        ),
+    ):
+        previous_article = declaration.calculated_article
+        declaration.assign_calculated_article()
+        if previous_article != declaration.calculated_article:
+            declaration.save()
+            if change_reason:
+                # il faut faire un refresh pour update_change_reason de retrouver le record à MAJ
+                declaration.refresh_from_db()
+                update_change_reason(declaration, change_reason)
+            logger.info(f"Declaration {declaration.id} article recalculated.")

--- a/config/tests/test_article_recalculation.py
+++ b/config/tests/test_article_recalculation.py
@@ -1,0 +1,87 @@
+from django.test import TestCase
+
+from unittest.mock import patch
+
+from config.tasks import recalculate_article_for_ongoing_declarations
+from data.factories import (
+    AuthorizedDeclarationFactory,
+    OngoingInstructionDeclarationFactory,
+)
+from data.models import Declaration
+
+
+def set_article_15(self):
+    self.calculated_article = Declaration.Article.ARTICLE_15
+
+
+def set_article_16(self):
+    self.calculated_article = Declaration.Article.ARTICLE_16
+
+
+class TestArticleRecalculation(TestCase):
+    @patch.object(Declaration, "assign_calculated_article", set_article_15)
+    def setUp(self):
+        self.authorized_declaration = AuthorizedDeclarationFactory.create(name="authorized")
+        self.authorized_declaration.assign_calculated_article()
+        self.authorized_declaration.save()
+
+        self.ongoing_instruction_declaration = OngoingInstructionDeclarationFactory.create(name="awaiting instruction")
+        self.ongoing_instruction_declaration.assign_calculated_article()
+        self.ongoing_instruction_declaration.save()
+
+    def test_setup(self):
+        self.assertEqual(self.authorized_declaration.calculated_article, Declaration.Article.ARTICLE_15)
+        self.assertEqual(self.ongoing_instruction_declaration.calculated_article, Declaration.Article.ARTICLE_15)
+
+    @patch.object(Declaration, "assign_calculated_article", set_article_16)
+    def test_recalculate_for_ongoing_declarations(self):
+        """
+        Les déclarations en cours sont modifiées mais non pas celles qui sont finalisées
+        """
+        recalculate_article_for_ongoing_declarations(Declaration.objects.all(), "change reason")
+
+        self.authorized_declaration.refresh_from_db()
+        self.assertEqual(
+            self.authorized_declaration.calculated_article,
+            Declaration.Article.ARTICLE_15,
+            "La déclaration autorisée n'est pas modifiée",
+        )
+        self.ongoing_instruction_declaration.refresh_from_db()
+        self.assertEqual(
+            self.ongoing_instruction_declaration.calculated_article,
+            Declaration.Article.ARTICLE_16,
+            "La déclaration en cours est MAJ",
+        )
+
+    @patch.object(Declaration, "assign_calculated_article", set_article_16)
+    def test_only_save_recalculated_articles(self):
+        """
+        Avoir une ligne dans l'historique que pour les déclarations où l'article a changé
+        """
+        self.assertEqual(self.authorized_declaration.history.count(), 3)
+        self.assertEqual(self.ongoing_instruction_declaration.history.count(), 3)
+
+        recalculate_article_for_ongoing_declarations(Declaration.objects.all(), "change reason")
+
+        self.assertEqual(
+            self.authorized_declaration.history.count(),
+            3,
+            "Sans modif, la déclaration autorisée n'a pas de lignes en plus dans l'historique",
+        )
+        self.assertEqual(
+            self.ongoing_instruction_declaration.history.count(),
+            4,
+            "Avec modif, la déclaration en cours a une ligne en plus dans l'historique",
+        )
+
+    @patch.object(Declaration, "assign_calculated_article", set_article_16)
+    def test_history_change_reason(self):
+        """
+        Quand un article est recalculé, c'est possible de sauvegarder un message comme raison de changement
+        """
+        change_reason = "change reason"
+        self.assertNotEqual(self.ongoing_instruction_declaration.history.first().history_change_reason, change_reason)
+
+        recalculate_article_for_ongoing_declarations(Declaration.objects.all(), change_reason)
+
+        self.assertEqual(self.ongoing_instruction_declaration.history.first().history_change_reason, change_reason)

--- a/data/admin/abstract_admin.py
+++ b/data/admin/abstract_admin.py
@@ -31,9 +31,8 @@ class RecomputeDeclarationArticleAtIngredientSaveMixin:
         super().save_model(request, obj, form, change)
         # recalcul de l'article pour les déclarations concernées
         if change and form["is_risky"]._has_changed():
-            ids = getattr(obj, self.declaredingredient_set).values_list("declaration_id", flat=True)
-            declarations_using_ingredient = Declaration.objects.filter(id__in=ids)
+            ids_using_ingredient = getattr(obj, self.declaredingredient_set).values_list("declaration_id", flat=True)
             tasks.recalculate_article_for_ongoing_declarations(
-                declarations_using_ingredient,
+                Declaration.objects.filter(id__in=ids_using_ingredient),
                 f"Article recalculé après modification via l'admin de {obj.name} ({obj.object_type} id {obj.id})",
             )


### PR DESCRIPTION
En préparation pour #1835 on s'est dit que c'est pas mal de mettre cette tâche dans le fond. Aujourd'hui, l'ingrédient le plus populaire est utilisé environ 550 fois dans des déclarations en cours. Qui n'est pas énorme mais avec cette refacto on n'a pas besoin suivre si le nombre ralentit la réponse à venir suivant une modif d'ingrédient.

Aussi modifié:

- ajouter statut "ONGOING_VISA" aux statuts à prendre pour le recalcul d'article
- ajouter un message pour la raison de changement qui indique quelle modification d'ingrédient a effectué le changement d'article

La raison de changement est visible dans l'historique d'une déclaration dans l'admin :

![Screenshot 2025-05-06 at 19-21-07 Historique de changement Déclaration « Test PDF gen 1418 » Compl'Alim](https://github.com/user-attachments/assets/2b405f0e-5ee2-44a7-89c7-9e9fdaf66f93)

À faire dans une autre PR:

- recalculer l'article pour plus de changements (ajd que "is_risky" est suivi)
- recalculer l'article pour les changements via la nouvelle interface

Effet secondaire : si il y a une erreur avec la recalculation, ce serait difficile de le forcer sans remettre la valeur changé et faire le changement de nouveau. Est-ce que c'est un recours suffisant pour l'instant ? Peut-être si ça devient un problème on pourrait avoir moyen de forcer la recalculation pour toutes les déclarations qui utilisent l'ingrédient sur la page admin de le modification de l'ingrédient...
