### PR TITLE
Permet de chercher des substances non-standalone dans le formulaire des ingrédients

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -136,6 +136,7 @@
           :hideSearchButton="true"
           @selected="selectOption"
           type="substance"
+          :searchAll="true"
           :required="false"
         />
         <div class="md:ml-4 md:my-7 md:col-span-2">


### PR DESCRIPTION
Il n'était pas possible de sélectionner des substances non utilisables dans la composition côté pro. Or, il faut pouvoir les lier à des ingrédients dans le formulaire à destination des chargées de mission.

## :movie_camera: Démo

https://github.com/user-attachments/assets/52fc4b83-db8a-4009-beb9-d8ee8801feae

Closes #2007


