### PR TITLE
Ajout de la date effective du retrait du marché dans l'historique

### DIFF
--- a/frontend/src/components/SnapshotItem.vue
+++ b/frontend/src/components/SnapshotItem.vue
@@ -93,10 +93,16 @@ const actionText = computed(() => {
     REQUEST_VISA: `a demandé un visa pour passer à l'état « ${statusProps[props.snapshot.postValidationStatus]?.label} »`,
     APPROVE_VISA: `a mis la déclaration en état « ${statusProps[props.snapshot.postValidationStatus]?.label} »`,
     REFUSE_VISA: `a refusé le visa pour passer à l'état « ${statusProps[props.snapshot.postValidationStatus]?.label} »`,
-    WITHDRAW: "a retiré le produit du marché",
+    WITHDRAW: getWithdrawalText(props.snapshot),
   }
   return mapping[props.snapshot.action] ? `${fullName.value} ${mapping[props.snapshot.action]}.` : null
 })
+
+const getWithdrawalText = (snapshot) => {
+  const baseText = "a retiré le produit du marché"
+  if (!snapshot.effectiveWithdrawalDate) return baseText
+  return `${baseText} (date effective : ${isoToPrettyDate(snapshot.effectiveWithdrawalDate)})`
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## :camera: Capture d'écran

![image](https://github.com/user-attachments/assets/1d27ccbd-d57b-42e9-842f-a7e976b40529)

## Détails techniques

Assez simple car la date effective de retrait du marché était déjà sérialisée. Lors qu'elle est présente, on l'affiche. Si elle n'est pas là, on affiche le même texte qu'avant (comme ci-dessous)

![image](https://github.com/user-attachments/assets/a3de2015-107b-4588-a031-5d36754c143b)


Closes #2010
