### PR TITLE
Mettre à jour le lien vers la page accessibilité

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,6 +4,7 @@
     <router-view></router-view>
     <DsfrFooter
       :logo-text="logoText"
+      :a11yComplianceLink="{ name: 'A11yPage' }"
       :cookiesLink="{ name: 'CookiesInfoPage' }"
       :legalLink="{ name: 'LegalNoticesPage' }"
       :personalDataLink="{ name: 'PrivacyPolicyPage' }"


### PR DESCRIPTION
Le défaut lien fournit par `DsfrFooter` est `/a11y` mais le notre a été mis à `/accessibilite`. Cette PR spécifie le router-link vers la page existante.