### PR TITLE
Modification du texte du tooltip lors qu'il n'y a pas de commentaires mais il y a des substances

### DIFF
--- a/frontend/src/components/ElementCommentModal.vue
+++ b/frontend/src/components/ElementCommentModal.vue
@@ -71,8 +71,13 @@ const tooltipContent = computed(() => {
   if (hasMaxQuantities.value) content += `Quantités maximales : ${maxQuantitiesString.value}. `
   if (element.value?.publicComments) content += `Commentaires : ${element.value?.publicComments}. `
   if (element.value?.privateComments && !props.hidePrivateComments)
-    content += `Commentaires privés : ${element.value?.privateComments}.`
-  return content || "Pas de commentaires"
+    content += `Commentaires privés : ${element.value?.privateComments}. `
+  content = content || "Pas de commentaires. "
+
+  if (constitutingSubstances.value && constitutingSubstances.value.length)
+    content += "Cliquez pour plus d'informations sur les substances contenues."
+
+  return content
 })
 
 const infoModalOpened = ref(false)


### PR DESCRIPTION
Lors que la modale du bouton des commentaires a de l'information sur les substances, le tooltip affiche que cette information est présente.

## :movie_camera:  Démo

https://github.com/user-attachments/assets/a47cc3ad-aa27-4eac-ba6d-958cfda08073

## Détails

Dans la modale affichée après avoir cliqué sur le bouton des commentaires (:speech_balloon:) on montre :
- Les commentaires publics et privés (si la personne identifiée en a les droits
- Les substances dans la composition
- Les doses max par population

Or, dans le cas où un ingrédient n'a pas de commentaires, n'a pas de doses max par population, mais a bien des substances, le message de la popover était simplement « _pas de commentaires_ », ce qui laissé penser qu'aucune information ne se trouvait derrière.

Cette PR modifie le message du tooltip : « _Pas de commentaires. Cliquez pour plus d'informations sur les substances contenues._ »



Closes #2015 