### PR TITLE
Ajout du texte concernant le retrait du marché dans les attestations

### DIFF
--- a/web/templates/certificates/certificate-art-15.html
+++ b/web/templates/certificates/certificate-art-15.html
@@ -37,6 +37,17 @@
         La déclaration prévue à l’article 15 du décret n°2006-352 vise à informer l’administration
         de la mise sur le marché d’un complément alimentaire.
     </p>
+    {% if effective_withdrawal_date %}
+    <p>
+        Postérieurement à votre déclaration, le {{ withdrawal_date|date:"l j F Y" }} vous avez signalé
+        le retrait du marché du produit indiquant comme date effective le {{ effective_withdrawal_date|date:"l j F Y" }}.
+    </p>
+    {% elif withdrawal_date %}
+    <p>
+        Postérieurement à votre déclaration, le {{ withdrawal_date|date:"l j F Y" }} vous avez signalé
+        le retrait du marché du produit.
+    </p>
+    {% endif %}
     <p>
         Votre produit reste consultable à l’adresse suivante :
         <a href="{{ declaration.producer_url }}">{{ declaration.producer_url }}</a>.

--- a/web/templates/certificates/certificate-art-16.html
+++ b/web/templates/certificates/certificate-art-16.html
@@ -37,6 +37,18 @@
         La déclaration prévue à l’article 16 du décret n°2006-352 vise à informer l’administration
         de la mise sur le marché d’un complément alimentaire.
     </p>
+
+    {% if effective_withdrawal_date %}
+    <p>
+        Postérieurement à votre déclaration, le {{ withdrawal_date|date:"l j F Y" }} vous avez signalé
+        le retrait du marché du produit indiquant comme date effective le {{ effective_withdrawal_date|date:"l j F Y" }}.
+    </p>
+    {% elif withdrawal_date %}
+    <p>
+        Postérieurement à votre déclaration, le {{ withdrawal_date|date:"l j F Y" }} vous avez signalé
+        le retrait du marché du produit.
+    </p>
+    {% endif %}
     <p>
         Votre produit reste consultable à l’adresse suivante :
         <a href="{{ declaration.producer_url }}">{{ declaration.producer_url }}</a>.

--- a/web/templates/certificates/certificate-art-18.html
+++ b/web/templates/certificates/certificate-art-18.html
@@ -46,6 +46,13 @@
     <p>
         La déclaration prévue à l’article 15 du décret n°2006-352 vise à informer l’administration
         de la mise sur le marché d’un complément alimentaire.
+        {% if effective_withdrawal_date %}
+            Postérieurement à votre déclaration, le {{ withdrawal_date|date:"l j F Y" }} vous avez signalé
+            le retrait du marché du produit indiquant comme date effective le {{ effective_withdrawal_date|date:"l j F Y" }}.
+        {% elif withdrawal_date %}
+            Postérieurement à votre déclaration, le {{ withdrawal_date|date:"l j F Y" }} vous avez signalé
+            le retrait du marché du produit.
+        {% endif %}
     </p>
     <p>
         Votre produit reste consultable à l’adresse suivante :

--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -103,6 +103,20 @@ class CertificateView(PdfView):
             )
             last_submission_date = declaration.creation_date
 
+        withdrawal_date = None
+        effective_withdrawal_date = None
+        if declaration.status == Declaration.DeclarationStatus.WITHDRAWN:
+            try:
+                withdrawal_snapshot = declaration.snapshots.filter(action=Snapshot.SnapshotActions.WITHDRAW).latest(
+                    "creation_date"
+                )
+                withdrawal_date = withdrawal_snapshot.creation_date
+                effective_withdrawal_date = withdrawal_snapshot.effective_withdrawal_date
+            except Snapshot.DoesNotExist:
+                logger.error(
+                    f"Declaration with ID {declaration.id} is withdrawn but has no withdrawal snapshots associated with it"
+                )
+
         return {
             "date": date,
             "last_submission_date": last_submission_date,
@@ -120,6 +134,8 @@ class CertificateView(PdfView):
             "mail": mail,
             "signature_title": signature_title,
             "signature_name": signature_name,
+            "withdrawal_date": withdrawal_date,
+            "effective_withdrawal_date": effective_withdrawal_date,
         }
 
     def get_pdf_file_name(self, declaration):


### PR DESCRIPTION
Les attestations contiennent maintenant de l'information concernant les dates de retrait du marché.

## :camera:  Captures d'écran

1- Cas avec une date effective de retrait du marché
![image](https://github.com/user-attachments/assets/36a2217d-e320-44a5-8e24-46647c8165b1)

2- Cas legacy - sans date effective du retrait du marché
![image](https://github.com/user-attachments/assets/6a24bcc9-f793-4cd6-b65c-0db58a3a0897)

3- Cas de l'article 18 (dans le même paragraphe pour éviter un saut de ligne additionnel en bas du document)
![image](https://github.com/user-attachments/assets/0e90d66b-d9ff-49f6-81c6-5e999ef5b612)

Lié à #1997. L'issue sera clos lors que les modifications dans les e-mails automatiques soient faites.