### PR TITLE
Envoi de la date effective de retrait du marché aux paramètres Brevo

### DIFF
--- a/api/tests/test_flow_emails.py
+++ b/api/tests/test_flow_emails.py
@@ -197,12 +197,17 @@ class TestDeclarationFlow(APITestCase):
         """
         declaration = AuthorizedDeclarationFactory(author=authenticate.user)
         template_number = 8
+        payload = {"effective_withdrawal_date": "2026-05-08"}
 
-        self.client.post(reverse("api:withdraw", kwargs={"pk": declaration.id}), format="json")
+        self.client.post(reverse("api:withdraw", kwargs={"pk": declaration.id}), payload, format="json")
+        declaration.refresh_from_db()
+        brevo_parameters = declaration.brevo_parameters
+
+        self.assertEqual(brevo_parameters["EFFECTIVE_WITHDRAWAL_DATE"], "vendredi 8 mai 2026")
 
         mocked_brevo.assert_called_once_with(
             template_number,
-            declaration.brevo_parameters,
+            brevo_parameters,
             declaration.author.email,
             declaration.author.get_full_name(),
         )

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.db.models import Case, Min, Q, Value, When
 from django.db.models.functions import Coalesce
 from django.template.defaultfilters import filesizeformat
+from django.utils.formats import date_format
 
 from dateutil.relativedelta import relativedelta
 from djangorestframework_camel_case.render import CamelCaseJSONRenderer
@@ -286,25 +287,34 @@ class Declaration(Historisable, TimeStampable):
         Dictionnaire utilisé dans les différentes communications emails avec
         l'API Brevo
         """
+        status = Declaration.DeclarationStatus
         try:
             expiration_days = (
-                self.snapshots.filter(
-                    status__in=[
-                        Declaration.DeclarationStatus.OBSERVATION,
-                        Declaration.DeclarationStatus.OBJECTION,
-                    ]
-                )
+                self.snapshots.filter(status__in=[status.OBSERVATION, status.OBJECTION])
                 .latest("creation_date")
                 .expiration_days
             )
         except Exception as _:
             expiration_days = ""
+
+        effective_withdrawal_date = None
+        if self.status == status.WITHDRAWN:
+            try:
+                snapshot_withdrawal_date = (
+                    self.snapshots.filter(status=status.WITHDRAWN).latest("creation_date").effective_withdrawal_date
+                )
+                effective_withdrawal_date = (
+                    date_format(snapshot_withdrawal_date, "l j F Y") if snapshot_withdrawal_date else None
+                )
+            except Exception as _:
+                pass
         return {
             "PRODUCT_NAME": self.name,
             "COMPANY_NAME": self.company.social_name if self.company else "",
             "DECLARATION_LINK": self.producer_url,
             "DECLARATION_ID": self.id,
             "EXPIRATION_DAYS": expiration_days,
+            "EFFECTIVE_WITHDRAWAL_DATE": effective_withdrawal_date,
         }
 
     @property


### PR DESCRIPTION
Cette modification permet de montrer la date effective de retrait du marché dans l'email envoyé aux pros.

## :camera: Capture d'écran

![image](https://github.com/user-attachments/assets/a98d0618-a3e5-404a-9820-d93193b2bd69)



Closes #1997 