### PR TITLE
Ajout de l'information du mandataire s'il y en a un dans l'attestation

### DIFF
--- a/web/templates/certificates/certificate-art-15.html
+++ b/web/templates/certificates/certificate-art-15.html
@@ -8,7 +8,11 @@
     <p>
         La Direction générale {{ direction }} atteste que
         <span style="text-align: center; font-family: 'Marianne-Bold'; font-weight: bold;">
-            {% if declaration.company %}{{ declaration.company.social_name }}{% endif %}
+            {% if declaration.mandated_company %}
+            l'entreprise mandataire {{ declaration.mandated_company.social_name }}
+            {% else if declaration.company %}
+            {{ declaration.company.social_name }}
+            {% endif %}
         </span>
         a effectué {% if declaration.teleicare_id %}sur la plateforme TELEICARE,{% endif %}
         le {{ last_submission_date|date:"l j F Y" }}, la déclaration mentionnée à l’article 15 du décret

--- a/web/templates/certificates/certificate-art-15.html
+++ b/web/templates/certificates/certificate-art-15.html
@@ -10,7 +10,7 @@
         <span style="text-align: center; font-family: 'Marianne-Bold'; font-weight: bold;">
             {% if declaration.mandated_company %}
             l'entreprise mandataire {{ declaration.mandated_company.social_name }}
-            {% else if declaration.company %}
+            {% elif declaration.company %}
             {{ declaration.company.social_name }}
             {% endif %}
         </span>

--- a/web/templates/certificates/certificate-art-16.html
+++ b/web/templates/certificates/certificate-art-16.html
@@ -10,7 +10,7 @@
         <span style="text-align: center; font-family: 'Marianne-Bold'; font-weight: bold;">
             {% if declaration.mandated_company %}
             l'entreprise mandataire {{ declaration.mandated_company.social_name }}
-            {% else if declaration.company %}
+            {% elif declaration.company %}
             {{ declaration.company.social_name }}
             {% endif %}
         </span>

--- a/web/templates/certificates/certificate-art-16.html
+++ b/web/templates/certificates/certificate-art-16.html
@@ -8,7 +8,11 @@
     <p>
         La Direction générale {{ direction }} atteste que
         <span style="text-align: center; font-family: 'Marianne-Bold'; font-weight: bold;">
-            {% if declaration.company %}{{ declaration.company.social_name }}{% endif %}
+            {% if declaration.mandated_company %}
+            l'entreprise mandataire {{ declaration.mandated_company.social_name }}
+            {% else if declaration.company %}
+            {{ declaration.company.social_name }}
+            {% endif %}
         </span>
         a effectué {% if declaration.teleicare_id %}sur la plateforme TELEICARE,{% endif %}
         le {{ last_submission_date|date:"l j F Y" }}, la déclaration mentionnée à l’article 16 du décret

--- a/web/templates/certificates/certificate-art-18.html
+++ b/web/templates/certificates/certificate-art-18.html
@@ -10,7 +10,7 @@
         <span style="text-align: center; font-family: 'Marianne-Bold'; font-weight: bold;">
             {% if declaration.mandated_company %}
             l'entreprise mandataire {{ declaration.mandated_company.social_name }}
-            {% else if declaration.company %}
+            {% elif declaration.company %}
             {{ declaration.company.social_name }}
             {% endif %}
         </span>

--- a/web/templates/certificates/certificate-art-18.html
+++ b/web/templates/certificates/certificate-art-18.html
@@ -8,7 +8,11 @@
     <p>
         La Direction générale de l'alimentation (DGAL) atteste que
         <span style="text-align: center; font-family: 'Marianne-Bold'; font-weight: bold;">
-            {% if declaration.company %}{{ declaration.company.social_name }}{% endif %}
+            {% if declaration.mandated_company %}
+            l'entreprise mandataire {{ declaration.mandated_company.social_name }}
+            {% else if declaration.company %}
+            {{ declaration.company.social_name }}
+            {% endif %}
         </span>
         a effectué, le {{ last_submission_date|date:"l j F Y" }}, la déclaration prévue par les dispositions
         du décret n°2006-352 du 20 mars 2006 relatif aux compléments alimentaires pour le produit :

--- a/web/templates/certificates/certificate-rejected.html
+++ b/web/templates/certificates/certificate-rejected.html
@@ -14,7 +14,7 @@
     <p>
         Le {{ last_submission_date|date:"l j F Y" }}, vous avez déclaré{% if declaration.teleicare_id %}, sur la plateforme TELEICARE,{% endif %} la mise sur le marché du produit :
         <span style="font-family: 'Marianne-Bold'; font-weight: bold;">
-            {{ declaration.name }} / {{ declaration.galenic_formulation }}
+            {{ declaration.name }} / {{ declaration.galenic_formulation }} / {{ declaration.company.social_name }}
         </span>
     <p>
         Des objections ont été émises à l’égard de cette déclaration. A la suite de ces objections, vous m’avez fait part de vos observations.

--- a/web/templates/certificates/certificate-submitted-art-anses.html
+++ b/web/templates/certificates/certificate-submitted-art-anses.html
@@ -10,7 +10,7 @@
         <span style="text-align: center; font-family: 'Marianne-Bold'; font-weight: bold;">
             {% if declaration.mandated_company %}
             l'entreprise mandataire {{ declaration.mandated_company.social_name }}
-            {% else if declaration.company %}
+            {% elif declaration.company %}
             {{ declaration.company.social_name }}
             {% endif %}
         </span>

--- a/web/templates/certificates/certificate-submitted-art-anses.html
+++ b/web/templates/certificates/certificate-submitted-art-anses.html
@@ -8,7 +8,11 @@
     <p>
         La Direction générale de l'alimentation (DGAL) atteste que
         <span style="text-align: center; font-family: 'Marianne-Bold'; font-weight: bold;">
-            {% if declaration.company %}{{ declaration.company.social_name }}{% endif %}
+            {% if declaration.mandated_company %}
+            l'entreprise mandataire {{ declaration.mandated_company.social_name }}
+            {% else if declaration.company %}
+            {{ declaration.company.social_name }}
+            {% endif %}
         </span>
         a effectué, le {{ last_submission_date|date:"l j F Y" }}, la déclaration pour le produit :
     </p>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/89ec2374-2e54-4427-be6d-fa9892145859)

Cette info n'est pas indiquée aussi clairement dans web/templates/certificates/certificate-rejected.html et web/templates/certificates/certificate-objected.html