### PR TITLE
Admin, substance : bloquer la modification de l'unité pour les substance existantes

### DIFF
--- a/data/admin/substance.py
+++ b/data/admin/substance.py
@@ -206,3 +206,9 @@ class SubstanceAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
                 declarations,
                 f"Article recalculé après modification via l'admin de {obj.name} ({obj.object_type} id {obj.id})",
             )
+
+    @staticmethod
+    def get_readonly_fields(request, obj):
+        if obj:
+            return [*SubstanceAdmin.readonly_fields, "unit"]
+        return SubstanceAdmin.readonly_fields


### PR DESCRIPTION
Closes #1836 

Cette logique réfléchit la logique de la nouvelle interface.

La raison c'est parce que on suppose que l'unité rentrée dans des déclarations par les pros est la même que l'unité indiquée sur la substance. Si elle est modifiée, on n'a pas la logique aujourd'hui pour modifier les quantités rentrées par les pros pour les aligner avec la nouvelle unité.

Si un jour c'est nécessaire, le besoin sera remontée et on peut décider quoi faire (manip à la main, conversion de quantités...) ce jour là.

## Nouvelle substance

Unité toujours modifiable

![Screenshot 2025-05-19 at 12-19-41 Ajout de substance active Compl'Alim](https://github.com/user-attachments/assets/25079b10-46f2-4df2-92fe-4e5b631a3fb1)

## Substance existante

Unité non-modifiable

![Screenshot 2025-05-19 at 12-19-55 vitamine B12 Modification de substance active Compl'Alim](https://github.com/user-attachments/assets/9a864555-7e15-4c36-8db8-872834b44ee5)

