### PR TITLE
Modification ingrédient : ajouter lien vers les déclarations en cours

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -243,6 +243,23 @@
         </DsfrInputGroup>
       </div>
     </DsfrFieldset>
+    <DsfrAlert v-if="element" class="mt-0 mb-8">
+      <p>Cette modification pourrait impacter des déclarations en cours qui utilisent cet ingrédient.</p>
+      <p>
+        <router-link
+          :to="{
+            name: 'AdvancedSearchPage',
+            query: {
+              composition: `${element.id}||${element.name}||${type}`,
+              status: 'AWAITING_INSTRUCTION,ONGOING_INSTRUCTION,AWAITING_VISA,ONGOING_VISA,OBJECTION,OBSERVATION',
+            },
+          }"
+          target="_blank"
+        >
+          Voir les déclarations en cours
+        </router-link>
+      </p>
+    </DsfrAlert>
     <div class="flex gap-x-2 mt-4">
       <DsfrButton label="Enregistrer ingrédient" @click="saveElement" />
     </div>

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -244,7 +244,7 @@
       </div>
     </DsfrFieldset>
     <DsfrAlert v-if="element" class="mt-0 mb-8">
-      <p>Cette modification pourrait impacter des déclarations en cours qui utilisent cet ingrédient.</p>
+      <p>Des modifications pourrait impacter les déclarations en cours qui utilisent cet ingrédient.</p>
       <p>
         <router-link
           :to="{


### PR DESCRIPTION
Vu que les modifications des ingrédients pourraient avoir un impact sur les déclarations en cours, notamment l'article calculé, j'ai ajouté un lien vers ces déclarations sur la page modif d'ingrédient. Ça pourrait aider les instructrices d'identifier l'impact de la modification avant de le mettre en place.

![Screenshot 2025-05-19 at 12-58-00 Modification ingrédient - Compl'Alim](https://github.com/user-attachments/assets/ac10d000-e969-4fc2-a860-55a87796673e)
