### PR TITLE
Admin : cache le champ "à surveiller" et rendre le champ SICCRF "utile" non-modifiable

### DIFF
--- a/data/admin/plant.py
+++ b/data/admin/plant.py
@@ -26,6 +26,9 @@ class PartInlineAdmin(admin.TabularInline):
     model = Plant.plant_parts.through
     extra = 1
 
+    fields = ("plantpart", "siccrf_is_useful", "ca_is_useful")
+    readonly_fields = ("siccrf_is_useful",)
+
 
 class SubstanceInlineAdmin(admin.TabularInline):
     model = Plant.substances.through


### PR DESCRIPTION
Avant de vraiment supprimer le champ du modèle, je préfère de le cacher dans l'admin d'abord, pour tester que ce n'est pas nécessaire.

Closes #1928 

## Avant
![Screenshot 2025-05-22 at 17-53-47 test issu 1919 Modification de plante Compl'Alim](https://github.com/user-attachments/assets/0ce3524f-5956-4f04-a6c7-651484b95236)

## Après
![Screenshot 2025-05-22 at 17-53-32 test issu 1919 Modification de plante Compl'Alim](https://github.com/user-attachments/assets/c14f230e-959b-47af-a82f-8de1933e5480)
