### PR TITLE
Declaration : afficher les champs supplementaires pour toutes les plantes inactives ainsi que actives

### DIFF
--- a/api/views/declaration/declaration_flow_validations.py
+++ b/api/views/declaration/declaration_flow_validations.py
@@ -65,7 +65,7 @@ def validate_mandatory_fields(declaration) -> tuple[list, list]:
 
 def declared_plant_is_complete(plant):
     if not plant.active:
-        return True
+        return plant.used_part and plant.quantity and plant.unit
     return plant.used_part and plant.quantity and plant.unit and plant.preparation
 
 

--- a/frontend/src/components/ElementCard.vue
+++ b/frontend/src/components/ElementCard.vue
@@ -61,7 +61,7 @@
             :options="store.preparations?.map((preparation) => ({ text: preparation.name, value: preparation.id }))"
             v-model.number="model.preparation"
             defaultUnselectedText=""
-            :required="true"
+            :required="model.active"
           />
         </div>
       </div>
@@ -136,7 +136,8 @@ const plantParts = computed(() => {
 })
 
 const showFields = computed(() => {
-  if (model.value.active && ["plant", "microorganism"].indexOf(props.objectType) >= 0) return true
+  if (props.objectType === "plant") return true
+  if (model.value.active && props.objectType === "microorganism") return true
   if (
     model.value.active &&
     ["active_ingredient", "form_of_supply", "substance"].indexOf(props.objectType) >= 0 &&


### PR DESCRIPTION
Besoin décrit ici : https://www.notion.so/incubateur-masa/Informations-iso-entre-plantes-actives-et-non-actives-1c0de24614be8052bd5dc3b15fa19bd7?pvs=4

Les pros devraient renseigner les champs partie de plante, quantité et unité pour toutes les plantes, actives et non-actives. J'ai laissé le champ "préparation" pour les deux pour cohérence mais je l'ai rendu optionnel pour les plantes non-actives, vu que cette information n'est pas utilisé côté BEPIAS.

![Screenshot 2025-05-22 at 18-38-54 Ma déclaration - Compl'Alim](https://github.com/user-attachments/assets/75e8b3cf-1817-4cc6-8425-d2edc83534a9)
![Screenshot 2025-05-22 at 18-39-02 Ma déclaration - Compl'Alim](https://github.com/user-attachments/assets/59f09977-29a8-490b-9289-d4009720b2a5)