### PR TITLE
Enlève la dépendance autoprefixer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,6 @@
         "@vue/cli-plugin-eslint": "~5.0.0",
         "@vue/cli-plugin-router": "~5.0.0",
         "@vue/cli-service": "~5.0.0",
-        "autoprefixer": "^10.4.21",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,6 @@
     "@vue/cli-plugin-eslint": "~5.0.0",
     "@vue/cli-plugin-router": "~5.0.0",
     "@vue/cli-service": "~5.0.0",
-    "autoprefixer": "^10.4.21",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.0",


### PR DESCRIPTION
Suite à la mise à jour de Tailwind ([PR](https://github.com/betagouv/complements-alimentaires/pull/2046)) on peut enlever autoprefixer.

D'après [la doc](https://tailwindcss.com/docs/upgrade-guide#using-postcss) : 

> Additionally, in v4 imports and vendor prefixing is now handled for you automatically, so you can remove postcss-import and autoprefixer if they are in your project