### PR TITLE
Les déclarations de mon entreprise : ajouter lien pour dupliquer la déclaration pour les déclarants

### DIFF
--- a/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
@@ -12,12 +12,17 @@
 
 <script setup>
 import { computed } from "vue"
+import { useRootStore } from "@/stores/root"
 import { timeAgo } from "@/utils/date"
 import { getStatusTagForCell } from "@/utils/components"
 import CompanyTableCell from "@/components/CompanyTableCell"
 import DeclarationName from "@/components/DeclarationName.vue"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
+const store = useRootStore()
+
+const hasDeclarationRoleForCompany = (company) =>
+  store.loggedUser.companies?.find((x) => x.id === company.id)?.roles?.find((x) => x.name === "DeclarantRole")
 
 const headers = ["ID", "Nom du produit", "Entreprise", "Auteur", "État", "Date de création", ""]
 const rows = computed(() =>
@@ -38,11 +43,13 @@ const rows = computed(() =>
       x.author ? `${x.author.firstName} ${x.author.lastName}` : "",
       getStatusTagForCell(x.status, true),
       timeAgo(x.creationDate),
-      {
-        component: "router-link",
-        text: "Dupliquer",
-        to: { name: "NewDeclaration", query: { duplicate: x.id } },
-      },
+      hasDeclarationRoleForCompany(x.company)
+        ? {
+            component: "router-link",
+            text: "Dupliquer",
+            to: { name: "NewDeclaration", query: { duplicate: x.id } },
+          }
+        : null,
     ],
   }))
 )

--- a/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/CompanyDeclarationsTable.vue
@@ -19,7 +19,7 @@ import DeclarationName from "@/components/DeclarationName.vue"
 
 const props = defineProps({ data: { type: Object, default: () => {} } })
 
-const headers = ["ID", "Nom du produit", "Entreprise", "Auteur", "État", "Date de création"]
+const headers = ["ID", "Nom du produit", "Entreprise", "Auteur", "État", "Date de création", ""]
 const rows = computed(() =>
   props.data?.results?.map((x) => ({
     rowData: [
@@ -38,6 +38,11 @@ const rows = computed(() =>
       x.author ? `${x.author.firstName} ${x.author.lastName}` : "",
       getStatusTagForCell(x.status, true),
       timeAgo(x.creationDate),
+      {
+        component: "router-link",
+        text: "Dupliquer",
+        to: { name: "NewDeclaration", query: { duplicate: x.id } },
+      },
     ],
   }))
 )


### PR DESCRIPTION
ETQ déclarant pour une entreprise, je veux avoir l'option de dupliquer une déclaration sur la page "les déclarations de mon entreprise", comme je peux sur la page "mes déclarations"

NB: sur cette page on a les déclarations des entreprises dont j'ai un rôle gestionnaire ainsi que un rôle déclarant. Si je ne suis pas déclarant de l'entreprise, je ne dois pas voir l'option de dupliquer la déclaration.

## Exemple avec des rôles melangés

![Screenshot 2025-05-28 at 16-36-33 Les déclarations de mon entreprise - Compl'Alim](https://github.com/user-attachments/assets/492ee212-6415-40c0-a291-0fdf58cd6b54)

## Exemple que gestionnaire

![Screenshot 2025-05-28 at 16-42-32 Les déclarations de mon entreprise - Compl'Alim](https://github.com/user-attachments/assets/da8b9bec-327f-4d82-ab27-117be804ae85)
