### PR TITLE
Fix de la hauteur du div de l'autocomplete

### DIFF
--- a/frontend/src/components/ElementAutocomplete.vue
+++ b/frontend/src/components/ElementAutocomplete.vue
@@ -26,7 +26,7 @@
     <ul
       v-show="displayOptions"
       ref="optionsList"
-      class="list-none absolute m-0 right-0 z-1 left-0 bg-white box-shadow max-h-17 scroll pointer p-0!"
+      class="list-none absolute m-0 right-0 z-1 max-h-80 left-0 bg-white box-shadow scroll pointer p-0!"
       :class="{
         'at-the-top': displayAtTheTop,
         'z-10': true,
@@ -216,10 +216,6 @@ watch(searchTerm, fetchAutocompleteResults)
   box-shadow:
     0px 16px 16px -16px rgba(0, 0, 0, 0.32),
     0px 8px 16px rgba(0, 0, 0, 0.1);
-}
-
-.max-h-17 {
-  max-height: 17rem;
 }
 
 .scroll {


### PR DESCRIPTION
Correction de la classe utilisée pour la hauteur maximale de l'encart contenant les résultats de l'autocomplete.

## :movie_camera: Démo


https://github.com/user-attachments/assets/f2a45ece-11c5-4aee-94e9-b5c494a3c2f6



Closes #2068 