### PR TITLE
Utilisation de l'icône spécifié dans SolicitationsHolder

### DIFF
--- a/frontend/src/views/CollaboratorsPage/SolicitationsHolder.vue
+++ b/frontend/src/views/CollaboratorsPage/SolicitationsHolder.vue
@@ -3,7 +3,7 @@
     <SectionTitle :title="title" :icon="icon" />
     <div v-for="solicitation in solicitations" :key="solicitation.id">
       <div class="flex items-center">
-        <v-icon class="size-4" name="ri-chat-download-line" />
+        <v-icon class="size-4" :name="icon" />
 
         <div class="ml-2">
           <div>{{ solicitation.senderName }}</div>


### PR DESCRIPTION
L'icône dans l'encart des solicitations pour les rôles de l'entreprise était toujours `ri-chat-download-line` même si on en spécifiait une différente.

## :camera: Capture d'écran

Après
![image](https://github.com/user-attachments/assets/8a7bda0a-25ad-44a8-a273-c471f8a3be2e)

Avant
![image](https://github.com/user-attachments/assets/e5b3e660-e8fa-4c91-a371-e73bc9d1e5d8)


Closes #2055
