### PR TITLE
Fix du bug concernant la longueur de la raison de changement

### DIFF
--- a/config/tasks.py
+++ b/config/tasks.py
@@ -7,9 +7,8 @@ from django.db.models import Count, F, Max, Q
 from django.utils import timezone
 
 from dateutil.relativedelta import relativedelta
-from viewflow import fsm
-
 from simple_history.utils import update_change_reason
+from viewflow import fsm
 
 from config import email
 from data.etl.transformer_loader import ETL_OPEN_DATA_DECLARATIONS
@@ -208,5 +207,8 @@ def recalculate_article_for_ongoing_declarations(declarations, change_reason):
             declaration.save()
             # il faut faire un refresh pour update_change_reason de retrouver le record à MAJ
             declaration.refresh_from_db()
+            if len(change_reason) > 100:
+                logger.warn(f"change_reason '{change_reason}' too long. Truncating to 100 characters.")
+                change_reason = change_reason[:100]
             update_change_reason(declaration, change_reason)
             logger.info(f"Declaration {declaration.id} article recalculated.")

--- a/config/tests/test_article_recalculation.py
+++ b/config/tests/test_article_recalculation.py
@@ -1,6 +1,6 @@
-from django.test import TestCase
-
 from unittest.mock import patch
+
+from django.test import TestCase
 
 from config.tasks import recalculate_article_for_ongoing_declarations
 from data.factories import (
@@ -77,11 +77,15 @@ class TestArticleRecalculation(TestCase):
     @patch.object(Declaration, "assign_calculated_article", set_article_16)
     def test_history_change_reason(self):
         """
-        Quand un article est recalculé, c'est possible de sauvegarder un message comme raison de changement
+        Quand un article est recalculé, c'est possible de sauvegarder un message comme raison de changement.
+        Si le message est trop long les premiers 100 caractères seront sauvegardés.
         """
-        change_reason = "change reason"
-        self.assertNotEqual(self.ongoing_instruction_declaration.history.first().history_change_reason, change_reason)
+        long_reason = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ornare lacus id quam sodales, eget tellus."
+        truncated_reason = (
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ornare lacus id quam sodales, eg"
+        )
+        self.assertNotEqual(self.ongoing_instruction_declaration.history.first().history_change_reason, long_reason)
 
-        recalculate_article_for_ongoing_declarations(Declaration.objects.all(), change_reason)
+        recalculate_article_for_ongoing_declarations(Declaration.objects.all(), long_reason)
 
-        self.assertEqual(self.ongoing_instruction_declaration.history.first().history_change_reason, change_reason)
+        self.assertEqual(self.ongoing_instruction_declaration.history.first().history_change_reason, truncated_reason)

--- a/data/etl/teleicare_ingredients/utils.py
+++ b/data/etl/teleicare_ingredients/utils.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.db.models import (
     CharField,
     FloatField,
@@ -10,6 +12,8 @@ from simple_history.exceptions import NotHistoricalModelError
 from simple_history.utils import update_change_reason
 
 from data.models.ingredient_status import IngredientStatus
+
+logger = logging.getLogger(__name__)
 
 
 def pre_import_treatments(field, value):
@@ -92,6 +96,9 @@ def clean_text(dirty_text):
 
 def update_or_create_object(model, object_definition, default_extra_fields, change_message):
     model_object, created = model.objects.update_or_create(**object_definition, defaults=default_extra_fields)
+    if len(change_message) > 100:
+        logger.warn(f"change_message '{change_message}' too long. Truncating to 100 characters.")
+        change_message = change_message[:100]
     try:
         update_change_reason(model_object, change_message)
     except NotHistoricalModelError:


### PR DESCRIPTION
Les raisons de changement sont limitées à 100 caractères. Or, certaines de ces raisons sont générées programmatiquement et dépassent cette limite (lien Sentry dans #2103).

Avec cette PR nous aurons un log lorsque ceci arrive, et la raison sauvegardée sera trunquée aux premiers 100 caractères.

Closes #2103 