### PR TITLE
Téchnique : mettre l'id et type d'ingrédient avant le nom dans la raison de changement pour ne pas perdre des infos

### DIFF
--- a/api/serializers/common_ingredient.py
+++ b/api/serializers/common_ingredient.py
@@ -163,7 +163,7 @@ class CommonIngredientModificationSerializer(serializers.ModelSerializer):
                 ids_using_ingredient += getattr(instance, field_name).values_list("declaration_id", flat=True)
             tasks.recalculate_article_for_ongoing_declarations(
                 Declaration.objects.filter(id__in=ids_using_ingredient),
-                f"Article recalculé après modification via l'interface de {instance.name} ({instance.object_type} id {instance.id})",
+                f"Article recalculé après modification via l'interface de {instance.object_type} id {instance.id} : {instance.name}",
             )
 
 

--- a/data/admin/abstract_admin.py
+++ b/data/admin/abstract_admin.py
@@ -34,5 +34,5 @@ class RecomputeDeclarationArticleAtIngredientSaveMixin:
             ids_using_ingredient = getattr(obj, self.declaredingredient_set).values_list("declaration_id", flat=True)
             tasks.recalculate_article_for_ongoing_declarations(
                 Declaration.objects.filter(id__in=ids_using_ingredient),
-                f"Article recalculé après modification via l'admin de {obj.name} ({obj.object_type} id {obj.id})",
+                f"Article recalculé après modification via l'admin de {obj.object_type} id {obj.id} : {obj.name}",
             )

--- a/data/admin/substance.py
+++ b/data/admin/substance.py
@@ -205,7 +205,7 @@ class SubstanceAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
             declarations = Declaration.objects.filter(id__in=declared_substances_ids.union(computed_substances_ids))
             tasks.recalculate_article_for_ongoing_declarations(
                 declarations,
-                f"Article recalculé après modification via l'admin de {obj.name} ({obj.object_type} id {obj.id})",
+                f"Article recalculé après modification via l'admin de {obj.object_type} id {obj.id} : {obj.name}",
             )
 
     @staticmethod


### PR DESCRIPTION
Lié à #2103, suite à un changement d'un ingrédient qui impacte l'article calculé des déclarations, il y a un message laissé dans l'historique de la décla pour aider avec la trace des modifs. Mais les noms des ingrédients peuvent être assez longs, alors je change le message pour mettre l'id et type avant le nom. Comme ça on va tjs avoir les infos pour faire la trace. Je n'ai pas touché le début du message pour rendre l'analyse dans metabase plus facile (genre on peut chercher l'historique pour les messages qui commencent avec "Article recalculé après modification via l'interface de" pour identifier toutes les modifs avant et après ce changement de format)

![Screenshot 2025-06-12 at 13-52-18 Historique de changement Déclaration « Un CA » Compl'Alim](https://github.com/user-attachments/assets/aaee563b-35bb-4fb1-8d6b-b6ce0101b83d)
