### PR TITLE
Ajout des icônes dans les entêtes de la nouvelle interface BEPIAS

### DIFF
--- a/frontend/src/views/NewInstructionPage/HistorySection/index.vue
+++ b/frontend/src/views/NewInstructionPage/HistorySection/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="bg-grey-975! p-6" v-if="snapshots">
-    <h2 id="declarant-e">Historique</h2>
+    <SectionHeader icon="ri-history-fill" text="Historique" />
 
     <div v-if="!snapshots" class="flex justify-center items-center min-h-60">
       <ProgressSpinner />
@@ -22,6 +22,7 @@
 <script setup>
 import ProgressSpinner from "@/components/ProgressSpinner"
 import SnapshotItem from "@/components/SnapshotItem"
+import SectionHeader from "../SectionHeader"
 
 defineProps({ snapshots: Array })
 

--- a/frontend/src/views/NewInstructionPage/IdentitySection/index.vue
+++ b/frontend/src/views/NewInstructionPage/IdentitySection/index.vue
@@ -1,16 +1,18 @@
 <template>
   <div>
     <div class="bg-grey-975! p-6">
-      <h2 id="declarant-e">Déclarant·e</h2>
+      <SectionHeader id="declarant-e" text="Déclarant·e" icon="ri-user-fill" />
       <DsfrAlert small description="Ce segment est en construction" class="mb-6" />
-      <h2 id="produit">Informations sur le produit</h2>
+      <SectionHeader id="produit" text="Informations sur le produit" icon="ri-file-info-fill" />
       <DsfrAlert small description="Ce segment est en construction" class="mb-6" />
-      <h2 id="entreprise">Identité de l’entreprise</h2>
+      <SectionHeader id="entreprise" text="Identité de l’entreprise" icon="ri-building-4-fill" />
       <DsfrAlert small description="Ce segment est en construction" class="mb-6" />
     </div>
   </div>
 </template>
 
 <script setup>
+import SectionHeader from "../SectionHeader"
+
 defineProps({ declarant: Object, company: Object })
 </script>

--- a/frontend/src/views/NewInstructionPage/InstructionSection/index.vue
+++ b/frontend/src/views/NewInstructionPage/InstructionSection/index.vue
@@ -1,22 +1,25 @@
 <template>
   <div>
     <div class="bg-grey-975! p-6">
-      <h2 id="pieces-jointes">Pièces jointes</h2>
+      <SectionHeader id="pieces-jointes" icon="ri-attachment-fill" text="Pièces jointes" />
       <CompactAttachmentGrid :attachments="declaration.attachments" />
-      <h2 id="dernier-commentaire">Dernier commentaire</h2>
+
+      <SectionHeader id="dernier-commentaire" icon="ri-chat-2-fill" text="Dernier commentaire" />
       <LastComment class="mb-6" :snapshot="lastSnapshot" />
-      <h2 id="composition-produit">Composition produit</h2>
+
+      <SectionHeader id="composition-produit" icon="ri-capsule-fill" text="Composition produit" />
       <CompositionInfo :useAccordions="true" :showElementAuthorization="true" :model-value="declaration" />
       <div v-if="showComputedSubstances">
         <p class="font-bold mt-8">Substances contenues dans la composition :</p>
         <ComputedSubstancesInfo :model-value="declaration" />
       </div>
       <p class="font-bold mt-8" v-else>Pas de substances calculées à partir de la composition</p>
-      <h2 id="resultat-instruction">Résultat de l'instruction</h2>
+
+      <SectionHeader id="resultat-instruction" icon="ri-todo-fill" text="Résultat de l'instruction" />
       <InstructionResults :model-value="declaration" :readonly="!canInstruct" />
     </div>
     <div class="p-6">
-      <h2 id="notes">Notes à destination de l'administration</h2>
+      <SectionHeader id="notes" icon="ri-ball-pen-fill" text="Notes à destination de l'administration" />
       <DsfrAlert small description="Ce segment est en construction" class="mb-6" />
     </div>
   </div>
@@ -28,6 +31,7 @@ import LastComment from "./LastComment"
 import InstructionResults from "./InstructionResults"
 import CompositionInfo from "@/components/CompositionInfo"
 import ComputedSubstancesInfo from "@/components/ComputedSubstancesInfo"
+import SectionHeader from "../SectionHeader"
 import { computed } from "vue"
 
 const props = defineProps({ declaration: Object, snapshots: Array })

--- a/frontend/src/views/NewInstructionPage/SectionHeader.vue
+++ b/frontend/src/views/NewInstructionPage/SectionHeader.vue
@@ -1,0 +1,10 @@
+<template>
+  <h2>
+    <v-icon :name="icon" scale="1.4" class="block mt-[6px] mr-2 float-left" />
+    {{ text }}
+  </h2>
+</template>
+
+<script setup>
+defineProps(["icon", "text"])
+</script>


### PR DESCRIPTION
Ajout des icônes présents dans le Figma pour les entêtes

## :camera: Captures d'écran

![image](https://github.com/user-attachments/assets/74ae1bd4-1c32-41eb-98b0-edbf9bc305fe)
![image](https://github.com/user-attachments/assets/fa28e692-fde8-4cb6-afa4-07bc8291eba4)
![image](https://github.com/user-attachments/assets/52d2ea07-38f4-43ea-a046-90257c4c9af5)

## Détails techniques

J'ai ajouté un nouveau petit composant pour les entêtes de la nouvelle interface : `SectionHeader.vue`.

Closes #2128 