### PR TITLE
Effacement du code du critère spécifique "à risque" pour l'inclure dans la donnée

### DIFF
--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -481,10 +481,7 @@ class Declaration(Historisable, TimeStampable):
 
     @property
     def risky_ingredients(self):
-        return self.declared_ingredients.exclude(new=True).filter(
-            Q(ingredient__is_risky=True)
-            | Q(ingredient__name__iregex="([^A-Za-z]+|^)vin([^A-Za-z]+|$)|alcool|vinaigre")
-        )
+        return self.declared_ingredients.exclude(new=True).filter(Q(ingredient__is_risky=True))
 
     @property
     def risky_plants(self):


### PR DESCRIPTION
Tous les ingrédients concernés ont été flagués "à risque" : https://compl-alim.beta.gouv.fr/admin/data/ingredient/?is_risky__exact=1 sur `prod`, `demo` et `staging`
