### PR TITLE
Notes à destination de l'administration dans la nouvelle interface BEPIAS

### DIFF
--- a/frontend/src/components/AdministrationNotes.vue
+++ b/frontend/src/components/AdministrationNotes.vue
@@ -1,0 +1,49 @@
+<template>
+  <!-- v-slot:content v-if="!declaration.siccrfId" -->
+  <div class="text-left sm:mb-0 sm:flex sm:gap-8">
+    <DsfrInputGroup>
+      <DsfrInput
+        :disabled="disableInstructionNotes"
+        v-model="privateNotesInstruction"
+        is-textarea
+        label-visible
+        label="Notes de l'instruction"
+        @update:modelValue="saveInstructionComment"
+      />
+    </DsfrInputGroup>
+    <DsfrInputGroup>
+      <DsfrInput
+        :disabled="disableVisaNotes"
+        v-model="privateNotesVisa"
+        is-textarea
+        label-visible
+        label="Notes du visa"
+        @update:modelValue="saveVisaComment"
+      />
+    </DsfrInputGroup>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue"
+import { useFetch, useDebounceFn } from "@vueuse/core"
+import { headers } from "@/utils/data-fetching"
+import { handleError } from "@/utils/error-handling"
+
+const declaration = defineModel()
+defineProps({ disableInstructionNotes: Boolean, disableVisaNotes: Boolean })
+
+const privateNotesInstruction = ref(declaration.value?.privateNotesInstruction || "")
+const privateNotesVisa = ref(declaration.value?.privateNotesVisa || "")
+
+const saveInstructionComment = async () => saveComment({ privateNotesInstruction: privateNotesInstruction.value })
+const saveVisaComment = async () => saveComment({ privateNotesVisa: privateNotesVisa.value })
+
+const saveComment = useDebounceFn(async (payload) => {
+  const url = `/api/v1/declarations/${declaration.value?.id}`
+  const { response } = await useFetch(() => url, { headers: headers() })
+    .patch(payload)
+    .json()
+  handleError(response)
+}, 600)
+</script>

--- a/frontend/src/components/AdministrationNotes.vue
+++ b/frontend/src/components/AdministrationNotes.vue
@@ -1,7 +1,6 @@
 <template>
-  <!-- v-slot:content v-if="!declaration.siccrfId" -->
-  <div class="text-left sm:mb-0 sm:flex sm:gap-8">
-    <DsfrInputGroup>
+  <div class="text-left sm:flex sm:gap-8">
+    <DsfrInputGroup class="grow">
       <DsfrInput
         :disabled="disableInstructionNotes"
         v-model="privateNotesInstruction"
@@ -11,7 +10,7 @@
         @update:modelValue="saveInstructionComment"
       />
     </DsfrInputGroup>
-    <DsfrInputGroup>
+    <DsfrInputGroup class="grow">
       <DsfrInput
         :disabled="disableVisaNotes"
         v-model="privateNotesVisa"
@@ -47,3 +46,11 @@ const saveComment = useDebounceFn(async (payload) => {
   handleError(response)
 }, 600)
 </script>
+
+<style scoped>
+@reference "../styles/index.css";
+
+.fr-input-group {
+  @apply grow;
+}
+</style>

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -95,7 +95,7 @@
               <v-icon name="ri-pencil-fill"></v-icon>
               Notes à destination de l'administration
             </h6>
-            <AdministrationNotes class="mb-4" v-model="declaration" :disableVisaNotes="true" />
+            <AdministrationNotes class="mb-4 sm:mb-0" v-model="declaration" :disableVisaNotes="true" />
           </template>
         </TabStepper>
       </div>

--- a/frontend/src/views/InstructionPage/index.vue
+++ b/frontend/src/views/InstructionPage/index.vue
@@ -95,26 +95,7 @@
               <v-icon name="ri-pencil-fill"></v-icon>
               Notes à destination de l'administration
             </h6>
-            <div class="text-left mb-4 sm:mb-0 sm:flex sm:gap-8">
-              <DsfrInputGroup>
-                <DsfrInput
-                  v-model="privateNotesInstruction"
-                  is-textarea
-                  label-visible
-                  label="Notes de l'instruction"
-                  @update:modelValue="saveComment"
-                />
-              </DsfrInputGroup>
-              <DsfrInputGroup>
-                <DsfrInput
-                  :disabled="true"
-                  v-model="privateNotesVisa"
-                  is-textarea
-                  label-visible
-                  label="Notes du visa"
-                />
-              </DsfrInputGroup>
-            </div>
+            <AdministrationNotes class="mb-4" v-model="declaration" :disableVisaNotes="true" />
           </template>
         </TabStepper>
       </div>
@@ -127,13 +108,14 @@ import TabStepper from "@/components/TabStepper"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import { onMounted, computed, ref } from "vue"
-import { useFetch, useDebounceFn } from "@vueuse/core"
+import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import DeclarationSummary from "@/components/DeclarationSummary"
 import IdentityTab from "@/components/IdentityTab"
 import HistoryTab from "@/components/HistoryTab"
 import DecisionTab from "./DecisionTab"
+import AdministrationNotes from "@/components/AdministrationNotes"
 import { headers } from "@/utils/data-fetching"
 import DeclarationAlert from "@/components/DeclarationAlert"
 import { tabTitles } from "@/utils/mappings"
@@ -166,8 +148,7 @@ const {
   execute: executeDeclarationFetch,
   isFetching: isFetchingDeclaration,
 } = useFetch(`/api/v1/declarations/${props.declarationId}`, { immediate: false }).get().json()
-const privateNotesInstruction = ref(declaration.value?.privateNotesInstruction || "")
-const privateNotesVisa = ref(declaration.value?.privateNotesVisa || "")
+
 const {
   response: declarantResponse,
   data: declarant,
@@ -192,22 +173,9 @@ const {
   .get()
   .json()
 
-// Sauvegarde du commentaire privé
-const saveComment = useDebounceFn(async () => {
-  const { response } = await useFetch(() => `/api/v1/declarations/${declaration.value?.id}`, {
-    headers: headers(),
-  })
-    .patch({ privateNotesInstruction: privateNotesInstruction.value })
-    .json()
-  handleError(response)
-}, 600)
-
 onMounted(async () => {
   await executeDeclarationFetch()
   handleError(declarationResponse)
-
-  privateNotesInstruction.value = declaration.value?.privateNotesInstruction || ""
-  privateNotesVisa.value = declaration.value?.privateNotesVisa || ""
 
   // Si on arrive à cette page avec une déclaration déjà assignée à quelqun.e mais en état
   // AWAITING_INSTRUCTION, on la passe directement à ONGOING_INSTRUCTION.

--- a/frontend/src/views/NewInstructionPage/InstructionSection/index.vue
+++ b/frontend/src/views/NewInstructionPage/InstructionSection/index.vue
@@ -20,7 +20,8 @@
     </div>
     <div class="p-6">
       <SectionHeader id="notes" icon="ri-ball-pen-fill" text="Notes à destination de l'administration" />
-      <AdministrationNotes :model-value="declaration" :disableVisaNotes="true" />
+      <AdministrationNotes v-if="!declaration.siccrfId" :model-value="declaration" :disableVisaNotes="true" />
+      <p v-else>Déclaration importée depuis Téléicare, les commentaires ne sont pas disponibles.</p>
     </div>
   </div>
 </template>

--- a/frontend/src/views/NewInstructionPage/InstructionSection/index.vue
+++ b/frontend/src/views/NewInstructionPage/InstructionSection/index.vue
@@ -20,7 +20,7 @@
     </div>
     <div class="p-6">
       <SectionHeader id="notes" icon="ri-ball-pen-fill" text="Notes à destination de l'administration" />
-      <DsfrAlert small description="Ce segment est en construction" class="mb-6" />
+      <AdministrationNotes :model-value="declaration" :disableVisaNotes="true" />
     </div>
   </div>
 </template>
@@ -31,6 +31,7 @@ import LastComment from "./LastComment"
 import InstructionResults from "./InstructionResults"
 import CompositionInfo from "@/components/CompositionInfo"
 import ComputedSubstancesInfo from "@/components/ComputedSubstancesInfo"
+import AdministrationNotes from "@/components/AdministrationNotes"
 import SectionHeader from "../SectionHeader"
 import { computed } from "vue"
 

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -69,7 +69,7 @@
               <v-icon name="ri-pencil-fill"></v-icon>
               Notes à destination de l'administration
             </h6>
-            <AdministrationNotes class="mb-4" v-model="declaration" :disableInstructionNotes="true" />
+            <AdministrationNotes class="mb-4 sm:mb-0" v-model="declaration" :disableInstructionNotes="true" />
           </template>
         </TabStepper>
       </div>

--- a/frontend/src/views/VisaPage/index.vue
+++ b/frontend/src/views/VisaPage/index.vue
@@ -69,26 +69,7 @@
               <v-icon name="ri-pencil-fill"></v-icon>
               Notes à destination de l'administration
             </h6>
-            <div class="text-left mb-4 sm:mb-0 sm:flex sm:gap-8">
-              <DsfrInputGroup>
-                <DsfrInput
-                  :disabled="true"
-                  v-model="privateNotesInstruction"
-                  is-textarea
-                  label-visible
-                  label="Notes de l'instruction"
-                />
-              </DsfrInputGroup>
-              <DsfrInputGroup>
-                <DsfrInput
-                  @update:modelValue="saveComment"
-                  v-model="privateNotesVisa"
-                  is-textarea
-                  label-visible
-                  label="Notes du visa"
-                />
-              </DsfrInputGroup>
-            </div>
+            <AdministrationNotes class="mb-4" v-model="declaration" :disableInstructionNotes="true" />
           </template>
         </TabStepper>
       </div>
@@ -101,7 +82,7 @@ import TabStepper from "@/components/TabStepper"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import { onMounted, computed, ref } from "vue"
-import { useFetch, useDebounceFn } from "@vueuse/core"
+import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import DeclarationSummary from "@/components/DeclarationSummary"
@@ -109,6 +90,7 @@ import IdentityTab from "@/components/IdentityTab"
 import HistoryTab from "@/components/HistoryTab"
 import DeclarationAlert from "@/components/DeclarationAlert"
 import VisaValidationTab from "./VisaValidationTab"
+import AdministrationNotes from "@/components/AdministrationNotes"
 import { headers } from "@/utils/data-fetching"
 import { tabTitles } from "@/utils/mappings"
 import { useRouter } from "vue-router"
@@ -160,14 +142,9 @@ const {
   .get()
   .json()
 
-const privateNotesInstruction = ref(declaration.value?.privateNotesInstruction || "")
-const privateNotesVisa = ref(declaration.value?.privateNotesVisa || "")
 onMounted(async () => {
   await executeDeclarationFetch()
   handleError(declarationResponse)
-
-  privateNotesInstruction.value = declaration.value?.privateNotesInstruction || ""
-  privateNotesVisa.value = declaration.value?.privateNotesVisa || ""
 
   // Si on arrive à cette page avec une déclaration déjà assignée à quelqun.e mais en état
   // AWAITING_VISA, on la passe directement à ONGOING_VISA.
@@ -182,16 +159,6 @@ onMounted(async () => {
   handleError(snapshotsResponse)
   isFetching.value = false
 })
-
-// Sauvegarde du commentaire privé
-const saveComment = useDebounceFn(async () => {
-  const { response } = await useFetch(() => `/api/v1/declarations/${declaration.value?.id}`, {
-    headers: headers(),
-  })
-    .patch({ privateNotesVisa: privateNotesVisa.value })
-    .json()
-  handleError(response)
-}, 600)
 
 // Tab management
 const components = computed(() => {


### PR DESCRIPTION
## :information_source: PR basée sur la branche 2131-identity-product

Ajout de la section _notes de l'administration_ pour la nouvelle interface BEPIAS

## :camera: Captures d'écran

![image](https://github.com/user-attachments/assets/adf1b5d4-013e-4726-ba47-2bff10e0470e)

Lors qu'une déclaration a été importée depuis Téléicare :

![image](https://github.com/user-attachments/assets/c81fba7f-08b0-4dbb-919d-48e4c7e6c03c)

## Détails techniques

Comme pour les autres PRs, j'ai factorisé la section des commentaires à destination de l'administration dans _frontend/src/views/InstructionPage/index.vue_ dans _frontend/src/components/AdministrationNotes.vue_, qui est utilisée après dans : 
- _frontend/src/views/InstructionPage/index.vue_
- _frontend/src/views/NewInstructionPage/InstructionSection/index.vue_
- _frontend/src/views/VisaPage/index.vue_

Closes #2137 