### PR TITLE
Gestion d'erreur dans les requêtes initiales de la nouvelle interface BEPIAS

### DIFF
--- a/frontend/src/components/DeclarationAlert.vue
+++ b/frontend/src/components/DeclarationAlert.vue
@@ -171,7 +171,14 @@ const instructorDisplayData = computed(() => {
         canDownloadCertificate: true,
       }
     case "WITHDRAWN":
-      return { type: "info", title: "Ce produit a été retiré du marché", canDownloadCertificate: false }
+      return {
+        type: "info",
+        title: "Ce produit a été retiré du marché",
+        canDownloadCertificate: false,
+        body: latestSnapshot.value?.effectiveWithdrawalDate
+          ? `Date effective de retrait du marché : ${isoToPrettyDate(latestSnapshot.value.effectiveWithdrawalDate)}`
+          : null,
+      }
     default:
       return null
   }
@@ -232,7 +239,14 @@ const visorDisplayData = computed(() => {
         canDownloadCertificate: true,
       }
     case "WITHDRAWN":
-      return { type: "info", title: "Ce produit a été retiré du marché", canDownloadCertificate: false }
+      return {
+        type: "info",
+        title: "Ce produit a été retiré du marché",
+        canDownloadCertificate: false,
+        body: latestSnapshot.value?.effectiveWithdrawalDate
+          ? `Date effective de retrait du marché : ${isoToPrettyDate(latestSnapshot.value.effectiveWithdrawalDate)}`
+          : null,
+      }
     default:
       return null
   }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -387,6 +387,10 @@ const routes = [
     },
     children: [
       {
+        path: "",
+        redirect: { name: "InstructionSection" },
+      },
+      {
         name: "InstructionSection",
         path: "instruction",
         component: InstructionSection,

--- a/frontend/src/views/NewInstructionPage/AlertsSection.vue
+++ b/frontend/src/views/NewInstructionPage/AlertsSection.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+    <DsfrAlert
+      class="mb-4"
+      v-if="!assignedToLoggedUser"
+      type="info"
+      :title="
+        isAwaitingInstruction
+          ? 'Cette déclaration n\'est pas encore assignée'
+          : `Cette déclaration est assignée à ${declaration.instructor.firstName} ${declaration.instructor.lastName}`
+      "
+    >
+      <p>Vous pouvez vous assigner cette déclaration pour instruction</p>
+      <DsfrButton
+        class="mt-2"
+        :label="isAwaitingInstruction ? 'Instruire' : 'M\'assigner cette déclaration'"
+        tertiary
+        @click="isAwaitingInstruction ? emit('instruct') : emit('assign')"
+        :disabled="isFetchingInstruction || isFetchingDeclaration"
+      />
+    </DsfrAlert>
+    <DeclarationAlert
+      class="mb-6"
+      v-else-if="!canInstruct"
+      role="instructor"
+      :declaration="declaration"
+      :snapshots="snapshots"
+    />
+    <DeclarationFromTeleicareAlert v-else-if="declaration.siccrfId" />
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue"
+import { useRootStore } from "@/stores/root"
+import { storeToRefs } from "pinia"
+
+const declaration = defineModel()
+
+// « instruct » est utilisé pour passer la déclaration à ONGOING_INSTRUCTION
+// « assign » c'est pour s'assigner une déclaration assignée à une autre instructrice
+const emit = defineEmits(["instruct", "assign"])
+
+const store = useRootStore()
+const { loggedUser } = storeToRefs(store)
+
+const assignedToLoggedUser = computed(() => declaration.value?.instructor?.id === loggedUser.value.id)
+const canInstruct = computed(() => declaration.value?.status === "ONGOING_INSTRUCTION")
+const isAwaitingInstruction = computed(() => declaration.value?.status === "AWAITING_INSTRUCTION")
+</script>

--- a/frontend/src/views/NewInstructionPage/AlertsSection.vue
+++ b/frontend/src/views/NewInstructionPage/AlertsSection.vue
@@ -2,30 +2,30 @@
   <div>
     <DsfrAlert
       class="mb-4"
-      v-if="!assignedToLoggedUser"
+      v-if="!assignedToLoggedUser && (isOngoingInstruction || isAwaitingInstruction)"
       type="info"
       :title="
-        isAwaitingInstruction
-          ? 'Cette déclaration n\'est pas encore assignée'
-          : `Cette déclaration est assignée à ${declaration.instructor.firstName} ${declaration.instructor.lastName}`
+        declaration.instructor
+          ? `Cette déclaration est assignée à ${declaration.instructor.firstName} ${declaration.instructor.lastName}`
+          : 'Cette déclaration n\'est pas encore assignée'
       "
     >
       <p>Vous pouvez vous assigner cette déclaration pour instruction</p>
       <DsfrButton
         class="mt-2"
-        :label="isAwaitingInstruction ? 'Instruire' : 'M\'assigner cette déclaration'"
+        :label="declaration.instructor ? 'M\'assigner cette déclaration' : 'Instruire'"
         tertiary
         @click="isAwaitingInstruction ? emit('instruct') : emit('assign')"
       />
     </DsfrAlert>
+    <DeclarationFromTeleicareAlert v-else-if="declaration.siccrfId" />
     <DeclarationAlert
       class="mb-6"
-      v-else-if="!canInstruct"
+      v-else-if="!isOngoingInstruction"
       role="instructor"
       :declaration="declaration"
       :snapshots="snapshots"
     />
-    <DeclarationFromTeleicareAlert v-else-if="declaration.siccrfId" />
   </div>
 </template>
 
@@ -37,6 +37,7 @@ import DeclarationAlert from "@/components/DeclarationAlert"
 import DeclarationFromTeleicareAlert from "@/components/History/DeclarationFromTeleicareAlert"
 
 const declaration = defineModel()
+defineProps(["snapshots"])
 
 // « instruct » est utilisé pour passer la déclaration à ONGOING_INSTRUCTION
 // « assign » c'est pour s'assigner une déclaration assignée à une autre instructrice
@@ -46,6 +47,6 @@ const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
 
 const assignedToLoggedUser = computed(() => declaration.value?.instructor?.id === loggedUser.value.id)
-const canInstruct = computed(() => declaration.value?.status === "ONGOING_INSTRUCTION")
+const isOngoingInstruction = computed(() => declaration.value?.status === "ONGOING_INSTRUCTION")
 const isAwaitingInstruction = computed(() => declaration.value?.status === "AWAITING_INSTRUCTION")
 </script>

--- a/frontend/src/views/NewInstructionPage/AlertsSection.vue
+++ b/frontend/src/views/NewInstructionPage/AlertsSection.vue
@@ -16,7 +16,6 @@
         :label="isAwaitingInstruction ? 'Instruire' : 'M\'assigner cette déclaration'"
         tertiary
         @click="isAwaitingInstruction ? emit('instruct') : emit('assign')"
-        :disabled="isFetchingInstruction || isFetchingDeclaration"
       />
     </DsfrAlert>
     <DeclarationAlert
@@ -34,6 +33,8 @@
 import { computed } from "vue"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
+import DeclarationAlert from "@/components/DeclarationAlert"
+import DeclarationFromTeleicareAlert from "@/components/History/DeclarationFromTeleicareAlert"
 
 const declaration = defineModel()
 

--- a/frontend/src/views/NewInstructionPage/index.vue
+++ b/frontend/src/views/NewInstructionPage/index.vue
@@ -68,10 +68,6 @@ const isFetching = computed(() =>
   ].some((x) => !!x.value)
 )
 
-// Note : à utiliser dans les text-areas en bas de l'écran
-// const privateNotesInstruction = computed(() => declaration.value?.privateNotesInstruction || "")
-// const privateNotesVisa = computed(() => declaration.value?.privateNotesVisa || "")
-
 const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
 store.fetchDeclarationFieldsData()
@@ -86,7 +82,7 @@ const {
 } = makeRequest(`/api/v1/declarations/${props.declarationId}`)
 
 const {
-  // response: declarantResponse,
+  response: declarantResponse,
   data: declarant,
   execute: executeDeclarantFetch,
   isFetching: isFetchingDeclarant,
@@ -94,7 +90,7 @@ const {
   .get()
   .json()
 const {
-  // response: companyResponse,
+  response: companyResponse,
   data: company,
   execute: executeCompanyFetch,
   isFetching: isFetchingCompany,
@@ -102,7 +98,7 @@ const {
   .get()
   .json()
 const {
-  // response: snapshotsResponse,
+  response: snapshotsResponse,
   data: snapshots,
   execute: executeSnapshotsFetch,
   isFetching: isFetchingSnapshots,
@@ -140,7 +136,7 @@ const {
 
 const instructDeclaration = async () => {
   await executeTakeForInstruction()
-  // $externalResults.value = await handleError(takeResponse)
+  await handleError(takeResponse)
 
   if (takeResponse.value.ok) {
     await executeDeclarationFetch()
@@ -149,7 +145,7 @@ const instructDeclaration = async () => {
 
 const assignToSelf = async () => {
   await executeAssignToSelf()
-  // $externalResults.value = await handleError(response)
+  await handleError(assignResponse)
 
   if (assignResponse.value.ok) {
     await executeDeclarationFetch()
@@ -165,11 +161,12 @@ onMounted(async () => {
 
   // Si on arrive à cette page avec une déclaration déjà assignée à quelqun.e mais en état
   // AWAITING_INSTRUCTION, on la passe directement à ONGOING_INSTRUCTION.
-  // TODO gestion d'erreur
   if (declaration.value?.instructor?.id === loggedUser.value.id && declaration.value.status === "AWAITING_INSTRUCTION")
     await instructDeclaration()
 
-  // TODO gestion d'erreur
-  if (declaration.value) await Promise.all([executeDeclarantFetch(), executeCompanyFetch(), executeSnapshotsFetch()])
+  if (declaration.value) {
+    await Promise.all([executeDeclarantFetch(), executeCompanyFetch(), executeSnapshotsFetch()])
+    await Promise.all([handleError(declarantResponse), handleError(companyResponse), handleError(snapshotsResponse)])
+  }
 })
 </script>

--- a/frontend/src/views/NewInstructionPage/index.vue
+++ b/frontend/src/views/NewInstructionPage/index.vue
@@ -14,8 +14,16 @@
     <div v-else-if="declaration">
       <h1>{{ declaration.name }}</h1>
       <AlertsSection v-model="declaration" @instruct="instructDeclaration" @assign="assignToSelf" />
+      <DeclarationSummary
+        :allowArticleChange="!declaration.siccrfId"
+        :useAccordions="true"
+        :showElementAuthorization="true"
+        :readonly="true"
+        v-model="declaration"
+        v-if="isAwaitingInstruction"
+      />
 
-      <div class="sm:grid sm:grid-cols-12">
+      <div v-else class="sm:grid sm:grid-cols-12">
         <div class="hidden sm:block col-span-3">
           <div class="sticky top-2 sidebar-content">
             <InstructionSidebar v-model="declaration" />
@@ -40,6 +48,7 @@ import useToaster from "@/composables/use-toaster"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import InstructionSidebar from "./InstructionSidebar"
 import AlertsSection from "./AlertsSection"
+import DeclarationSummary from "@/components/DeclarationSummary"
 
 const props = defineProps({ declarationId: String })
 
@@ -122,6 +131,8 @@ const assignToSelf = async () => {
     useToaster().addSuccessMessage("La déclaration vous a été assignée")
   }
 }
+
+const isAwaitingInstruction = computed(() => declaration.value?.status === "AWAITING_INSTRUCTION")
 
 onMounted(async () => {
   await executeDeclarationFetch()


### PR DESCRIPTION
Affiche le message d'erreur si un des éléments des requêtes initiales a une erreur.

## :camera: Démo

Imaginons qu'on lance une exception ici : 
```python
class DeclarationSnapshotListView(ListAPIView):
    model = Snapshot
    serializer_class = SnapshotSerializer
    permission_classes = (CanAccessIndividualDeclaration | IsInstructor | IsVisor,)

    def get_queryset(self):
        raise Exception()
        ...
```

Le message générique d'erreur s'affiche dans le frontend :

https://github.com/user-attachments/assets/66706a79-83eb-4d20-8905-8c2c87926800




Closes #2138 