### PR TITLE
Gestion de l'ancrage dans le premier rendu de la nouvelle interface BEPIAS

### DIFF
--- a/frontend/src/views/NewInstructionPage/index.vue
+++ b/frontend/src/views/NewInstructionPage/index.vue
@@ -48,6 +48,7 @@ import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
+import { useRoute } from "vue-router"
 import { headers } from "@/utils/data-fetching"
 import useToaster from "@/composables/use-toaster"
 import ProgressSpinner from "@/components/ProgressSpinner"
@@ -56,6 +57,7 @@ import AlertsSection from "@/components/AlertsSection"
 import DeclarationSummary from "@/components/DeclarationSummary"
 
 const props = defineProps({ declarationId: String })
+const route = useRoute()
 
 const isFetching = computed(() =>
   [
@@ -167,6 +169,13 @@ onMounted(async () => {
   if (declaration.value) {
     await Promise.all([executeDeclarantFetch(), executeCompanyFetch(), executeSnapshotsFetch()])
     await Promise.all([handleError(declarantResponse), handleError(companyResponse), handleError(snapshotsResponse)])
+
+    if (route.hash) {
+      // La fonction scrollBehavior du router est lancée avant le rendu asynchrone de cette
+      // vue, donc on doit vérifier s'il y a un ancrage dans l'URL pour scroller dessus
+      const el = document.querySelector(route.hash)
+      if (el) el.scrollIntoView({ behavior: "smooth" })
+    }
   }
 })
 </script>


### PR DESCRIPTION
Cette PR fait référence [à ce retour du code review](https://github.com/betagouv/complements-alimentaires/pull/2110#discussion_r2142282307) (merci @hfroot)

## Description technique

Notre Vue-router est initialisé avec une fonction _scrollBehaviour_ qui permet - entre autres - de scroller a un point d'ancrage (par exemple, `url#id-html-à-scroller`). Ce comportement est ici :

```javascript
scrollBehavior(to, from, savedPosition) {
    if (to.hash) return { el: to.hash } // ⬅️ scroll vers l'élément ayant comme ID le to.hash
    ....
```

Le souci étant que pour le premier rendu, cette fonction est exécutée avant que les composants asynchrones soient rendus dans le HTML, ayant comme conséquence ce warning (car l'élément avec l'ID n'est pas trouvé) :  

```bash
[Vue Router warn]: Couldn't find element using selector "#composition-produit" returned by scrollBehavior.
```

La solution la plus simple c'est simplement de passer cette gestion du scroll à la view pour qu'elle le fasse après avoir chargé tout le nécessaire. D'où le fait qu'on l'ait dans _frontend/src/views/NewInstructionPage/index.vue_ à la fin de `onMounted`.

:information_source: Ce fix résout le problème mais n'enlève pas le warning. Ça ne me pose pas de problème (tant que le comportement fonctionne), mais dites-moi ce que vous en pensez.

## :movie_camera: Démo

https://github.com/user-attachments/assets/aa380d7d-21f6-4ded-9b79-b7b4385b920b






Closes #2114 