### PR TITLE
Fix du test instable `test_created_csv_is_json_compliant`

### DIFF
--- a/data/tests/test_open_data.py
+++ b/data/tests/test_open_data.py
@@ -94,8 +94,12 @@ class IngredientTestCase(TestCase):
             os.path.join(settings.MEDIA_ROOT, self.etl_test.dataset_name + ".csv"), delimiter=";"
         )
         self.assertEqual(len(open_data_jdd), 3)
-        substance_loaded = json.loads(open_data_jdd["substances"][1])
-        self.assertEqual(substance_loaded[0]["nom"], "Vitamine C")
+
+        def is_vitamin_c(substance):
+            json_substance = json.loads(substance)
+            return "nom" in json_substance[0] and json_substance[0]["nom"] == "Vitamine C"
+
+        substance_loaded = json.loads(next(x for x in open_data_jdd["substances"] if is_vitamin_c(x)))
         self.assertEqual(substance_loaded[0]["quantité_par_djr"], 10)
         self.assertEqual(substance_loaded[0]["unite"], "mg")
 


### PR DESCRIPTION
Le souci était juste l'ordre du tableau `open_data_jdd["substances"]`, où les substances n'étaient pas toujours dans le même index.

Souvent la vitamine C se trouvait dans l'index `1` : 

```python
0                                         [{}, {}, {}]
1    [{"nom": "Vitamine C", "quantité_par_djr": 10....
2                                         [{}, {}, {}]
```
Mais des fois ça passait à la première position : 

```python
0    [{"nom": "Vitamine C", "quantité_par_djr": 10....
1                                         [{}, {}, {}]
2                                         [{}, {}, {}]
```

et du coup la ligne `substance_loaded = json.loads(open_data_jdd["substances"][1])` ne prenait pas le bon élément de la liste.

Avec cette PR on cherche à l'intérieur de la liste l'élément correspondant à la Vitamine C.

Closes #2194