### PR TITLE
Changements à la nouvelle interface BEPIAS après tests

### DIFF
--- a/frontend/src/components/DeclarationSummary/ArticleInfoRow.vue
+++ b/frontend/src/components/DeclarationSummary/ArticleInfoRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex justify-between items-center border-2 p-2">
+  <div class="flex justify-between items-center border p-2">
     <DsfrModal
       :actions="[{ label: 'Valider', onClick: changeArticle }]"
       @close="articleModalOpened = false"

--- a/frontend/src/views/NewInstructionPage/InstructionSection/InstructionResults.vue
+++ b/frontend/src/views/NewInstructionPage/InstructionSection/InstructionResults.vue
@@ -13,8 +13,14 @@
             v-model="decisionCategory"
             :value="category.value"
             name="decisionCategory"
-            :label="category.title"
-          />
+          >
+            <template v-slot:label>
+              <div>
+                <v-icon :color="category.color" :name="category.icon" aria-hidden />
+                {{ category.title }}
+              </div>
+            </template>
+          </DsfrRadioButton>
         </DsfrInputGroup>
       </div>
 
@@ -128,10 +134,14 @@ const v$ = useVuelidate(rules, { comment, proposal, reasons, delayDays }, { $ext
 
 const decisionCategories = [
   {
+    icon: "ri-checkbox-circle-fill",
+    color: "green",
     value: "approve",
     title: "Approbation : la déclaration est conforme.",
   },
   {
+    icon: "ri-close-circle-fill",
+    color: "red",
     value: "modify",
     title: "Des changements sont nécessaires : la déclaration n’est pas finalisée.",
   },

--- a/frontend/src/views/NewInstructionPage/InstructionSection/InstructionResults.vue
+++ b/frontend/src/views/NewInstructionPage/InstructionSection/InstructionResults.vue
@@ -129,11 +129,11 @@ const v$ = useVuelidate(rules, { comment, proposal, reasons, delayDays }, { $ext
 const decisionCategories = [
   {
     value: "approve",
-    title: "Approbation : la déclaration peut être transmise.",
+    title: "Approbation : la déclaration est conforme.",
   },
   {
     value: "modify",
-    title: "Des changements sont nécessaires : la déclaration ne peut pas être transmise en l'état.",
+    title: "Des changements sont nécessaires : la déclaration n’est pas finalisée.",
   },
 ]
 

--- a/frontend/src/views/NewInstructionPage/InstructionSection/index.vue
+++ b/frontend/src/views/NewInstructionPage/InstructionSection/index.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
     <div class="bg-grey-975! p-6">
+      <ArticleInfoRow :modelValue="declaration" :allowChange="true" class="mb-4" />
+
       <SectionHeader id="pieces-jointes" icon="ri-attachment-fill" text="Pièces jointes" />
       <CompactAttachmentGrid :attachments="declaration.attachments" />
 
@@ -34,6 +36,7 @@ import CompositionInfo from "@/components/CompositionInfo"
 import ComputedSubstancesInfo from "@/components/ComputedSubstancesInfo"
 import AdministrationNotes from "@/components/AdministrationNotes"
 import SectionHeader from "../SectionHeader"
+import ArticleInfoRow from "@/components/DeclarationSummary/ArticleInfoRow"
 import { computed } from "vue"
 
 const props = defineProps({ declaration: Object, snapshots: Array })


### PR DESCRIPTION
Suite au retour des tests BEPIAS, cette PR fait trois choses :

1. Rajouter l’article au-dessus des PJ + la possibilité de le modifier directement,
![image](https://github.com/user-attachments/assets/d41a134c-51cc-4404-842f-fba4062664c1)

2. Changer les libellés pour l'instruction, et
3. Remettre les pastilles de couleur pour l'instruction
![image](https://github.com/user-attachments/assets/7e534b6a-6931-4e4d-bb0d-8af525bb38cb)


---


Closes #2206 