### PR TITLE
RGAA 12.7 : liens d'evitement

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,14 @@
 <template>
   <div :class="lowContrastMode ? 'bg-grey-975!' : ''">
-    <AppHeader :logo-text="logoText" />
-    <router-view></router-view>
+    <DsfrSkipLinks
+      :links="[
+        { id: 'main-content', text: 'Aller au contenu principal' },
+        { id: 'navigation', text: 'Aller au menu' },
+        { id: 'footer', text: 'Aller au pied de page' },
+      ]"
+    />
+    <AppHeader :logo-text="logoText" id="navigation" />
+    <router-view id="main-content"></router-view>
     <DsfrFooter
       :logo-text="logoText"
       :a11yComplianceLink="{ name: 'A11yPage' }"
@@ -12,6 +19,7 @@
         { label: 'Conditions générales d’utilisation', to: { name: 'CGUPage' } },
         { label: 'Mesures d\'impact', to: { name: 'StatsPage' } },
       ]"
+      id="footer"
     >
       <template v-slot:description>
         <p>Compl'Alim</p>


### PR DESCRIPTION
https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#12.7

Quand on arrive sur une page, si on fait une tabulation, les liens d'évitement apparaissent pour rendre la navigation aux gros blocs plus rapide.

![Screenshot from 2025-07-07 16-38-26](https://github.com/user-attachments/assets/78eeabf4-e991-4692-a524-049fb78cfe5a)

