### PR TITLE
RGAA 1.1, 1.2, 1.3 : améliorations de texte alternatif pour les images

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -2,7 +2,7 @@
   <DsfrHeader :logo-text="logoText" :homeTo="{ name: 'LandingPage' }" :quickLinks="quickLinks">
     <template #operator>
       <div class="flex items-center">
-        <img :src="require('@/assets/logo.svg')" alt="Logo Compl'Alim" class="h-20" />
+        <img :src="require('@/assets/logo.svg')" alt="Compl'Alim" class="h-20" />
 
         <DsfrBadge v-if="environment === 'dev'" :label="environment" type="info" />
         <DsfrBadge v-if="environment === 'demo'" :label="environment" type="new" />

--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -2,7 +2,7 @@
   <div class="border p-4 flex flex-col gap-2">
     <div class="border-b -mx-4 -mt-4 h-32 bg-blue-france-975 flex justify-center items-center">
       <v-icon v-if="isPDF" scale="3" name="ri-file-text-line" />
-      <img v-else :src="file.file" class="object-contain h-32" :alt="`Image téléchargée ${props.file.name}`" />
+      <img v-else :src="file.file" class="object-contain h-32" alt="" />
     </div>
     <div class="fr-text--sm grow mb-0!">{{ props.file.name }}</div>
     <DsfrInputGroup class="max-w-sm" v-if="!hideTypeSelection && !props.readonly">

--- a/frontend/src/views/BlogHomePage.vue
+++ b/frontend/src/views/BlogHomePage.vue
@@ -4,7 +4,7 @@
       <h1 class="mb-2">Nos articles</h1>
       <p>Découvrez notre espace blog et témoignages</p>
     </div>
-    <img class="hidden md:block absolute bottom-0 right-20" src="/static/images/plants.png" />
+    <img class="hidden md:block absolute bottom-0 right-20" src="/static/images/plants.png" alt="" />
   </div>
   <div class="fr-container my-6">
     <div v-if="isFetching" class="flex justify-center">

--- a/frontend/src/views/LandingPage/TaglineBlock.vue
+++ b/frontend/src/views/LandingPage/TaglineBlock.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="bg-blue-france-975 relative">
-    <img class="hidden lg:block absolute scale-75 top-32 left-1" src="/static/images/cloud-left.png" />
-    <img class="hidden md:block absolute scale-75 top-5 right-1" src="/static/images/cloud-right.png" />
-    <img class="hidden md:block absolute bottom-0 right-20" src="/static/images/plants.png" />
+    <img class="hidden lg:block absolute scale-75 top-32 left-1" src="/static/images/cloud-left.png" alt="" />
+    <img class="hidden md:block absolute scale-75 top-5 right-1" src="/static/images/cloud-right.png" alt="" />
+    <img class="hidden md:block absolute bottom-0 right-20" src="/static/images/plants.png" alt="" />
     <div class="relative fr-container py-6 sm:py-10 md:py-16 grid grid-cols-12">
       <div class="col-span-12 md:col-span-8 lg:col-span-6">
         <h1>Vers une circulation de compléments alimentaires sûrs et conformes</h1>

--- a/frontend/src/views/LandingPage/WebinarBlock.vue
+++ b/frontend/src/views/LandingPage/WebinarBlock.vue
@@ -10,6 +10,7 @@
         <img
           src="/static/images/ca-webinar.jpg"
           class="object-scale-down self-center rounded-full bg-white h-40 w-40 border-solid border-4 border-blue-france-main-525"
+          alt=""
         />
       </div>
       <div class="p-6 col-span-12 sm:col-span-8 md:col-span-6">

--- a/frontend/src/views/ProducerFormPage/NewElementCard.vue
+++ b/frontend/src/views/ProducerFormPage/NewElementCard.vue
@@ -24,7 +24,7 @@
       >
         <template v-slot:label>
           <div>
-            <img src="/static/images/flags/fr.svg" class="w-5 mr-1 -mt-1 inline rounded-sm" />
+            <img src="/static/images/flags/fr.svg" class="w-5 mr-1 -mt-1 inline rounded-sm" alt="" />
             {{ getAuthorizationModeInFrench("FR") }}
           </div>
         </template>
@@ -38,7 +38,7 @@
       >
         <template v-slot:label>
           <div>
-            <img src="/static/images/flags/eu.svg" class="w-5 mr-1 -mt-1 inline rounded-sm" />
+            <img src="/static/images/flags/eu.svg" class="w-5 mr-1 -mt-1 inline rounded-sm" alt="" />
             {{ getAuthorizationModeInFrench("EU") }}
           </div>
         </template>

--- a/frontend/src/views/ProducerHomePage/DeclarationBlock.vue
+++ b/frontend/src/views/ProducerHomePage/DeclarationBlock.vue
@@ -9,7 +9,7 @@
       <img
         style="max-width: 90%; max-height: 90%; object-fit: contain"
         src="/static/images/illustrations/declaration-illustration.png"
-        alt="Professionnelle effectuant sa déclaration"
+        alt=""
       />
     </div>
   </div>

--- a/frontend/src/views/ProducerHomePage/SearchBlock.vue
+++ b/frontend/src/views/ProducerHomePage/SearchBlock.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="bg-blue-france-975 relative">
-    <img class="hidden lg:block absolute scale-75 top-32 left-1" src="/static/images/cloud-left.png" />
-    <img class="hidden md:block absolute scale-75 top-5 right-1" src="/static/images/cloud-right.png" />
-    <img class="hidden md:block absolute bottom-0 right-20" src="/static/images/plants.png" />
+    <img class="hidden lg:block absolute scale-75 top-32 left-1" src="/static/images/cloud-left.png" alt="" />
+    <img class="hidden md:block absolute scale-75 top-5 right-1" src="/static/images/cloud-right.png" alt="" />
+    <img class="hidden md:block absolute bottom-0 right-20" src="/static/images/plants.png" alt="" />
     <div class="fr-container relative p-6 py-6 sm:py-10 md:py-14 grid grid-cols-12">
       <div class="col-span-12 md:col-span-8 lg:col-span-5">
         <h1>Tester ma composition de compléments alimentaires</h1>

--- a/web/templates/certificates/certificate-base-template.html
+++ b/web/templates/certificates/certificate-base-template.html
@@ -35,9 +35,9 @@
             <tr>
                 <td>
                     {% if declaration.teleicare_declaration_number %}
-                    <img width="160" src="{% static '../../static/images/certificate/republique-francaise-logo.png' %}" alt="">
+                    <img width="160" src="{% static '../../static/images/certificate/republique-francaise-logo.png' %}" alt="République Française">
                     {% else %}
-                    <img width="160" src="{% static '../../static/images/certificate/masa.png' %}" alt="">
+                    <img width="160" src="{% static '../../static/images/certificate/masa.png' %}" alt="Ministère de l'Agriculture et de la Souveraineté Alimentaire">
                     {% endif %}
                 </td>
                 <td align="right" style="font-weight: bold; font-size: 1.7em; font-family: 'Marianne-Bold'">

--- a/web/templates/summary.html
+++ b/web/templates/summary.html
@@ -336,9 +336,9 @@
             <div class="composition-section">
                 <figure>
                     {% if attachment.has_pdf_extension %}
-                    <img class="keep-with-next" width="70" src="{% static 'images/pdf-file.png' %}">
+                    <img class="keep-with-next" width="70" src="{% static 'images/pdf-file.png' %}" alt="">
                     {% else %}
-                    <img class="keep-with-next" width="220" src="{{ attachment.file.url }}">
+                    <img class="keep-with-next" width="220" src="{{ attachment.file.url }}" alt="">
                     {% endif %}
                     <figcaption class="bold-marianne" style="display: block;">
                         {{ attachment.type_display }} ({{ attachment.name }})


### PR DESCRIPTION
https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#1.1

Les images décoratives reçoivent un `alt=""` pour être ignorer par les lecteurs d'écran.

