### PR TITLE
Meilleur wording pour la relation Teleicare <-> Complalim sans relation 

### DIFF
--- a/data/admin/teleicare_etablissement_to_complalim_company_relation.py
+++ b/data/admin/teleicare_etablissement_to_complalim_company_relation.py
@@ -29,7 +29,7 @@ class EtablissementToCompanyRelationAdmin(admin.ModelAdmin):
             change_reason = (
                 f"Transfert des déclarations de l'entreprise {old_company_id} à l'entreprise {new_company_id}"
             )
-            declarations_to_move = Declaration.objects.filter(company_id=old_company_id)
+            declarations_to_move = Declaration.objects.filter(company_id=old_company_id).exclude(siccrf_id=None)
             for declaration in declarations_to_move:
                 declaration.company_id = new_company_id
                 declaration.save()


### PR DESCRIPTION
Nous nous sommes interrogés en séminaires sur ces objets relations qui n'avaient pas d'entreprise Teleicare liés.
C'est dans le cas où cette table à été utilisée pour enregistrer une changement de SIRET (sans que celui-ci ne soit lié à une entreprise Teleicare).

Le wording change donc légérement pour intégrer cette possibilité.

<img width="1471" height="48" alt="Capture d’écran du 2025-07-11 14-47-31" src="https://github.com/user-attachments/assets/dea69826-5c9e-4151-8e89-3fc57dddd782" />

<img width="1471" height="48" alt="Capture d’écran du 2025-07-11 14-47-31" src="https://github.com/user-attachments/assets/a221706c-b70a-4ba3-ac5b-bdabd8561bae" />
