### PR TITLE
:zap: Mise en pause de la tâche d'extraction du JDD open-data

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -45,10 +45,10 @@ app.conf.beat_schedule = {
         "task": "config.tasks.approve_declarations",
         "schedule": daily_workweek,
     },
-    "export_datasets_to_data_gouv": {
-        "task": "config.tasks.export_datasets_to_data_gouv",
-        "schedule": midnights,
-    },
+    # "export_datasets_to_data_gouv": {
+    #     "task": "config.tasks.export_datasets_to_data_gouv",
+    #     "schedule": midnights,
+    # },
 }
 
 app.conf.timezone = "Europe/Paris"


### PR DESCRIPTION
Cette PR est un fix temporaire pour éviter que la plateforme de prod ne tombe chaque nuit vers minuit.
Le jeu de données n'est de toutes façons pas mis à jour actuellement (à cause du down de la plateforme).

Le fix de l'extraction du JDD open-data est prévu [ici](https://github.com/betagouv/complements-alimentaires/issues/2198) 

Un message apparaît sur [data.gouv.fr](https://www.data.gouv.fr/datasets/declarations-de-complements-alimentaires/) : 
"La mise à jour quotidienne du jeu de données est en pause jusqu'à septembre 2025 et résolution d'un souci technique."