### PR TITLE
Fix du test défectueux

### DIFF
--- a/api/tests/test_declaration_controllers.py
+++ b/api/tests/test_declaration_controllers.py
@@ -169,9 +169,7 @@ class TestDeclarationControllers(APITestCase):
 
         results = response.json()["results"]
         self.assertEqual(len(results), 2)
-        result_ids = (x["id"] for x in results)
-        self.assertIn(ongoing_instruction_1.id, result_ids)
-        self.assertIn(ongoing_instruction_2.id, result_ids)
+        self.assertCountEqual([x["id"] for x in results], [ongoing_instruction_1.id, ongoing_instruction_2.id])
 
         # Requête pour tous les deux
         response = self.client.get(


### PR DESCRIPTION
Closes #2237 

Fix du test qui échoue de façon aléatoire.

La raison était qu'on utilisait des générateurs au lieu d'un tableau dans :

```python
        result_ids = (x["id"] for x in results)
        self.assertIn(ongoing_instruction_1.id, result_ids)
        self.assertIn(ongoing_instruction_2.id, result_ids)
```

Ce qui faisait que si l'ordre était différent, l'élément n'était plus dans le générateur.

Il y a une méthode spécifique pour tester l'intersection de deux tableaux - sans importer l'ordre : [assertCountEqual](https://docs.python.org/3.6/library/unittest.html#unittest.TestCase.assertCountEqual) (malgré son nom, ça ne vérifie pas seulement le count mais aussi les contenus).

En le mettant en place pour ce test on n'a plus le problème.