### PR TITLE
Enlève le log d'une erreur innécessaire

### DIFF
--- a/api/utils/simplified_status.py
+++ b/api/utils/simplified_status.py
@@ -98,8 +98,4 @@ class SimplifiedStatusHelper:
         else:
             return None
 
-        try:
-            return queryset.latest("creation_date").creation_date
-        except Snapshot.DoesNotExist as e:
-            logger.error(f"Declaration with ID {instance.id} was unable to obtain a simplified_status_date. {e}")
-            return None
+        return queryset.latest("creation_date").creation_date if queryset.exists() else None


### PR DESCRIPTION
Closes #2272 

Dans l'issue #2272 on peut voir que pratiquement toutes les actions du type `submit` (et autres) lèvent cette erreur. Il n'y a pas d'impact fonctionnel pour l'utilisateur·ice, mais ça sature notre Sentry / Kibana.

### Pourquoi l'erreur arrive ? 

Les propriétés `simplified_status` et `simplified_status_date` sont utilisés seulement pour quelques vues du rôle contrôle. Or, on le voit un peu partout dans les logs car lors de la création d'un Snapshot on calcule le JSON de la déclaration à l'instant T. Notamment via :

```python
def create_snapshot(
        self,
        user=None,
        comment="",
        action=None,
        post_validation_status="",
        expiration_days=None,
        blocking_reasons=None,
        effective_withdrawal_date=None,
    ):
        # Sinon on a des imports circulaires
        from data.factories import SnapshotFactory
        from data.models import Snapshot

        SnapshotFactory.create(
            declaration=self,
            user=user,
            status=self.status,
            json_declaration=self.json_representation, # <- C'est cette ligne-ci qui provoque l'exception
            expiration_days=expiration_days,
            comment=comment,
            action=action or Snapshot.SnapshotActions.OTHER,
            post_validation_status=post_validation_status,
            blocking_reasons=blocking_reasons,
            effective_withdrawal_date=effective_withdrawal_date,
        )
```

Dans 

```python
json_declaration=self.json_representation
```

on fait appel à : 

```python
    @property
    def json_representation(self):
        from api.serializers import DeclarationSerializer

        serialized_data = DeclarationSerializer(self).data
        camelized_bytes = CamelCaseJSONRenderer().render(serialized_data)
        return json.loads(camelized_bytes.decode("utf-8"))
```

Qui en appellant le `DeclarationSerializer` tente d'obtenir `simplified_status_date`. Par contre, vu qu'on est dans la création du snapshot il n'existe pas encore. 

En vrai, on n'a pas besoin de ces propriétés. C'est OK si elles sont ignorées - ou plus précisément, c'est OK si `simplified_status` et `simplified_status_date` sont `None` dans ces cas.

En enlevant le log, on assume que ces props peuvent avoir des valeurs `None` et ce n'est pas pourtant une erreur.