### PR TITLE
Filtrage par déclarations à surveiller pour le SD / ANSES

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -278,6 +278,7 @@ class ControllerDeclarationSerializer(serializers.ModelSerializer):
         model = Declaration
         fields = (
             "id",
+            "article",
             "teleicare_declaration_number",
             "siccrf_id",
             "name",

--- a/api/tests/test_declaration_controllers.py
+++ b/api/tests/test_declaration_controllers.py
@@ -184,6 +184,42 @@ class TestDeclarationControllers(APITestCase):
         self.assertEqual(len(results), 3)
 
     @authenticate
+    def test_filter_by_surveillance_only(self):
+        """
+        Il est possible de filtrer par déclarations en statuts à surveiller
+        """
+        ControlRoleFactory(user=authenticate.user)
+
+        # Déclarations à surveiller
+        art_16 = AwaitingInstructionDeclarationFactory(overridden_article=Declaration.Article.ARTICLE_16)
+        art_15_high_risk = AwaitingInstructionDeclarationFactory(
+            overridden_article=Declaration.Article.ARTICLE_15_HIGH_RISK_POPULATION
+        )
+        art_15_warning = AwaitingInstructionDeclarationFactory(
+            overridden_article=Declaration.Article.ARTICLE_15_WARNING
+        )
+
+        # Déclarations sans risque
+        AwaitingInstructionDeclarationFactory(overridden_article=Declaration.Article.ARTICLE_15)
+        AwaitingInstructionDeclarationFactory(overridden_article=Declaration.Article.ARTICLE_18)
+
+        # Requête pour toutes les déclarations
+        response = self.client.get(reverse("api:list_control_declarations") + "?surveillanceOnly=false", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()["results"]
+        self.assertEqual(len(results), 5)
+
+        # Requête pour surveillanceOnly
+        response = self.client.get(reverse("api:list_control_declarations") + "?surveillanceOnly=true", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()["results"]
+
+        self.assertEqual(len(results), 3)
+        self.assertCountEqual([x["id"] for x in results], [art_15_high_risk.id, art_15_warning.id, art_16.id])
+
+    @authenticate
     def test_single_get_not_allowed(self):
         """
         L'endpoint pour une déclaration seule n'est pas accessible sans le rôle de contrôle

--- a/api/utils/filters.py
+++ b/api/utils/filters.py
@@ -9,6 +9,7 @@ from rest_framework.filters import BaseFilterBackend, OrderingFilter
 
 from api.utils.simplified_status import SimplifiedStatusHelper
 from data.choices import CountryChoices
+from data.models import Declaration
 
 
 class BaseNumberInFilter(django_filters.BaseInFilter, django_filters.NumberFilter):
@@ -107,3 +108,18 @@ class DepartmentFilterBackend(BaseFilterBackend):
             queries |= ~Q(country=CountryChoices.FRANCE)
 
         return queryset.filter(queries).distinct()
+
+
+class SurveillanceOnlyFilter(BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        surveillance_only = request.query_params.get("surveillanceOnly", "")
+
+        if surveillance_only == "true":
+            surveillance_articles = [
+                Declaration.Article.ARTICLE_15_WARNING,
+                Declaration.Article.ARTICLE_15_HIGH_RISK_POPULATION,
+                Declaration.Article.ARTICLE_16,
+            ]
+            return queryset.filter(article__in=surveillance_articles)
+
+        return queryset

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -44,7 +44,7 @@ from api.serializers import (
     SimpleUserSerializer,
     SimpleVisorSerializer,
 )
-from api.utils.filters import CamelCaseOrderingFilter, SimplifiedStatusFilter
+from api.utils.filters import CamelCaseOrderingFilter, SimplifiedStatusFilter, SurveillanceOnlyFilter
 from api.utils.search import UnaccentSearchFilter
 from api.views.declaration.declaration_filter_set import DeclarationFilterSet
 from api.views.declaration.declaration_flow import DeclarationFlow
@@ -362,6 +362,7 @@ class ControllerDeclarationsListView(CommonOngoingDeclarationView):
     ordering_fields = ["name", "company_name"]
     serializer_class = ControllerDeclarationSerializer
     filter_backends = [
+        SurveillanceOnlyFilter,
         SimplifiedStatusFilter,
         django_filters.DjangoFilterBackend,
         CamelCaseOrderingFilter,

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/ControlDeclarationsTable.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/ControlDeclarationsTable.vue
@@ -22,6 +22,7 @@ import { isoToPrettyDate } from "@/utils/date"
 import { getStatusTagForCell } from "@/components/NewBepiasViews/DeclarationsTableSection/utils"
 import { useRoute } from "vue-router"
 import TableHeaders from "@/components/TableHeaders"
+import NameCell from "./NameCell"
 
 const route = useRoute()
 const emit = defineEmits(["sort", "filter"])
@@ -62,10 +63,8 @@ const rows = computed(() =>
     rowData: [
       x.id || x.siccrfId || x.teleicareDeclarationNumber,
       {
-        component: "router-link",
-        text: x.name,
-        class: "font-bold",
-        to: { name: "DeclarationIndividualPage", params: { declarationId: x.id } },
+        component: NameCell,
+        declaration: x,
       },
       x.companyName,
       x.brand,

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/NameCell.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/NameCell.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <DsfrBadge :label="warningText" type="warning" small v-if="warningText" />
+    <div>
+      <router-link
+        class="font-bold"
+        :to="{ name: 'DeclarationIndividualPage', params: { declarationId: declaration.id } }"
+      >
+        {{ declaration.name }}
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({ declaration: Object })
+
+import { computed } from "vue"
+
+const warningText = computed(() => {
+  if (props.declaration.article === "ART_15_WARNING") return "À surveiller"
+  if (props.declaration.article === "ART_15_HIGH_RISK_POPULATION") return "Population à risque"
+  if (props.declaration.article === "ART_16") return "Nouvel ingrédient ajouté"
+  return null
+})
+</script>

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/NameCell.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/NameCell.vue
@@ -20,7 +20,7 @@ import { computed } from "vue"
 const warningText = computed(() => {
   if (props.declaration.article === "ART_15_WARNING") return "À surveiller"
   if (props.declaration.article === "ART_15_HIGH_RISK_POPULATION") return "Population à risque"
-  if (props.declaration.article === "ART_16") return "Nouvel ingrédient ajouté"
+  if (props.declaration.article === "ART_16") return "Nouvel ingrédient demandé"
   return null
 })
 </script>

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
@@ -1,6 +1,18 @@
 <template>
   <div>
-    <DsfrAlert title="Recherche et filtrage avancé en construction" />
+    <DsfrAccordionsGroup v-model="activeAccordion" class="mb-8">
+      <DsfrAccordion title="Filtrer les déclarations">
+        <div class="grid grid-cols-3">
+          <div class="col-span-1 sm:col-span-2 md:col-span-3">
+            <DsfrToggleSwitch
+              label="Afficher les déclarations à surveiller uniquement"
+              :modelValue="surveillanceOnly"
+              @update:modelValue="updateSurveillanceOnly"
+            />
+          </div>
+        </div>
+      </DsfrAccordion>
+    </DsfrAccordionsGroup>
     <div v-if="isFetching && !data" class="flex justify-center my-10">
       <ProgressSpinner />
     </div>
@@ -25,6 +37,9 @@ import { useRoute, useRouter } from "vue-router"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import ControlDeclarationsTable from "./ControlDeclarationsTable"
+import { ref } from "vue"
+
+const activeAccordion = ref()
 
 const props = defineProps({ companyId: String })
 
@@ -38,12 +53,13 @@ const page = computed(() => parseInt(route.query.page))
 const ordering = computed(() => route.query.triage)
 const limit = computed(() => parseInt(route.query.limit))
 const simplifiedStatus = computed(() => route.query.simplifiedStatus)
+const surveillanceOnly = computed(() => route.query.surveillanceOnly === "true")
 
 const showPagination = computed(() => data.value?.count > data.value?.results?.length)
 
 // Obtention de la donnée via API
 const url = computed(() => {
-  const apiUrl = `/api/v1/control/declarations/?limit=${limit.value}&offset=${offset.value}&ordering=${ordering.value}&simplifiedStatus=${simplifiedStatus.value}`
+  const apiUrl = `/api/v1/control/declarations/?limit=${limit.value}&offset=${offset.value}&ordering=${ordering.value}&simplifiedStatus=${simplifiedStatus.value}&surveillanceOnly=${surveillanceOnly.value}`
   if (props.companyId) return `${apiUrl}&company=${props.companyId}`
   return apiUrl
 })
@@ -56,7 +72,7 @@ const fetchSearchResults = async () => {
 
 // Mise à jour des paramètres
 const updateQuery = (newQuery) => router.push({ query: { ...route.query, ...{ page: 1 }, ...newQuery } })
-
+const updateSurveillanceOnly = (value) => updateQuery({ surveillanceOnly: value ? "true" : "false" })
 const updatePage = (newPage) => updateQuery({ page: newPage + 1 })
 const updateOrdering = (sortValue) => updateQuery({ triage: sortValue || "-creationDate" })
 const updateFiltering = (filterKey, filterValue) => {
@@ -65,5 +81,5 @@ const updateFiltering = (filterKey, filterValue) => {
   updateQuery(filterQuery)
 }
 
-watch([page, limit, ordering, simplifiedStatus], fetchSearchResults)
+watch([page, limit, ordering, simplifiedStatus, surveillanceOnly], fetchSearchResults)
 </script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -527,6 +527,7 @@ const routes = [
         limit: 10,
         triage: "-creationDate",
         simplifiedStatus: "",
+        surveillanceOnly: "false",
       },
     },
   },


### PR DESCRIPTION
Cette PR ajoute le premier filtre : pouvoir afficher seulement les déclarations contenant un article 15 vigilance, 15 population à risque, ou 16.

## :movie_camera: Démo

https://github.com/user-attachments/assets/5c4d8076-f3f5-4e18-b624-311473ec9895

## Autres détails

On pourra peaufiner le critère "à surveiller" ultérieurement. Il faudra éventuellement aussi penser à afficher l'article lui même dans la vue individuelle.

Lié à #2163 
