### PR TITLE
:bug: Déclaration : permettre la suppression de quantités non-obligatoires

### DIFF
--- a/frontend/src/components/NumberField.vue
+++ b/frontend/src/components/NumberField.vue
@@ -5,6 +5,7 @@
 <script setup>
 const [model] = defineModel({
   set(value) {
+    if (value === "") return null
     const parseableNumber = value.indexOf(",") > -1 ? value.replace(",", ".") : value
     const parsedResult = parseFloat(parseableNumber)
     return isNaN(parsedResult) ? value : parsedResult


### PR DESCRIPTION
https://mattermost.incubateur.net/ruche/pl/s3kenetgytgdbccjrppqe7bcir

Quand on interagit avec le champ `NumberField`, il pourrait envoyer une chaîne de caractères vide `""`. DRF ne permets pas `allow_blank` sur les champs `FloatField` alors je modifie le front pour envoyer `null` au lieu de `""`