### PR TITLE
Remet la complétion automatique de l'adresse pour les nouvelles déclarations

### DIFF
--- a/api/serializers/company.py
+++ b/api/serializers/company.py
@@ -22,6 +22,8 @@ class SimpleCompanySerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "social_name",
+            "address",
+            "additional_details",
             "postal_code",
             "city",
             "cedex",

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -15,7 +15,7 @@ from data.factories import (
 )
 from data.factories.user import UserFactory
 
-from .utils import ProjectAPITestCase
+from .utils import ProjectAPITestCase, authenticate
 
 User = get_user_model()
 
@@ -46,6 +46,17 @@ class TestGetLoggedUser(ProjectAPITestCase):
         self.assertEqual(response.data.get("last_name"), user.last_name)
         self.assertEqual(response.data.get("companies"), [])
         self.assertIn("id", response.data)
+
+    @authenticate
+    def test_user_companies_address(self):
+        company = CompanyFactory(address="1 rue de la Paix", postal_code="75002", city="Paris")
+        DeclarantRoleFactory(user=authenticate.user, company=company)
+
+        response = self.get(self.url()).data
+        self.assertEqual(len(response.get("companies")), 1)
+        self.assertEqual(response.get("companies")[0]["address"], "1 rue de la Paix")
+        self.assertEqual(response.get("companies")[0]["postal_code"], "75002")
+        self.assertEqual(response.get("companies")[0]["city"], "Paris")
 
     def test_authenticated_logged_user_call_with_roles(self):
         """Ensure that roles are added to the JSON representation of the user"""


### PR DESCRIPTION
Closes #2288 

Fix pour le souci de l'autocomplete lors d'une nouvelle déclaration.

## :movie_camera: Démo

https://github.com/user-attachments/assets/cb7a6d9a-7fde-40cf-8755-12465f449df7

