### PR TITLE
Modif plante : permettre le recherche par texte des parties de plantes

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -102,6 +102,7 @@
           label="Partie(s) autorisée(s)"
           search
           labelKey="name"
+          :filteringKeys="['name']"
         />
         <div class="md:ml-4 md:my-8 md:col-span-2">
           <DsfrTag
@@ -120,6 +121,7 @@
           label="Partie(s) non-autorisée(s)"
           search
           labelKey="name"
+          :filteringKeys="['name']"
         />
         <div class="md:ml-4 md:my-8 md:col-span-2">
           <DsfrTag


### PR DESCRIPTION
Closes https://www.notion.so/incubateur-masa/S-lection-moteur-de-recherche-partie-auto-et-non-auto-23ede24614be80b3a537fdd346169b38

Clef oublié : `filteringKeys` https://vue-ds.fr/composants/DsfrMultiselect

<img width="619" height="610" alt="Screenshot from 2025-08-05 15-38-25" src="https://github.com/user-attachments/assets/74c8673c-d5fb-46d5-bc44-013dbe0b36ef" />
