### PR TITLE
RGAA 8.6 : rendre les titres des pages pertinentes

### DIFF
--- a/frontend/src/utils/document.js
+++ b/frontend/src/utils/document.js
@@ -1,0 +1,4 @@
+export const setDocumentTitle = (parts) => {
+  parts.push("Compl'Alim")
+  document.title = parts.join(" - ")
+}

--- a/frontend/src/views/AdvancedSearchResult/index.vue
+++ b/frontend/src/views/AdvancedSearchResult/index.vue
@@ -58,6 +58,7 @@ import ProgressSpinner from "@/components/ProgressSpinner"
 import { statusProps } from "@/utils/mappings"
 
 import DeclarationSummary from "@/components/DeclarationSummary"
+import { setDocumentTitle } from "@/utils/document"
 
 const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
@@ -89,5 +90,6 @@ const {
 onMounted(async () => {
   await executeDeclarationFetch()
   handleError(declarationResponse)
+  setDocumentTitle([declaration.value.name, "Résultat de recherche"])
 })
 </script>

--- a/frontend/src/views/BlogPostPage.vue
+++ b/frontend/src/views/BlogPostPage.vue
@@ -23,6 +23,7 @@
 import { computed, watch } from "vue"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
+import { setDocumentTitle } from "@/utils/document"
 
 const props = defineProps({
   id: String,
@@ -51,7 +52,7 @@ const author = computed(() => {
 fetchBlogPost()
 
 watch(blogPost, (post) => {
-  if (post) document.title = `${post.title} - Compl'Alim`
+  if (post) setDocumentTitle([post.title])
 })
 </script>
 

--- a/frontend/src/views/CompanyDetails/index.vue
+++ b/frontend/src/views/CompanyDetails/index.vue
@@ -40,6 +40,7 @@ import { getCompanyActivitiesString } from "@/utils/mappings"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import InfoTable from "@/components/InfoTable.vue"
 import DeclarationsTableSection from "@/components/NewBepiasViews/DeclarationsTableSection"
+import { setDocumentTitle } from "@/utils/document"
 
 const router = useRouter()
 const previousRoute = computed(() => {
@@ -61,7 +62,7 @@ const {
 onMounted(async () => {
   await executeCompanyFetch()
   handleError(companyResponse)
-  document.title = `${company.value?.socialName} - Détail de l'entreprise - Compl'Alim`
+  setDocumentTitle([company.value?.socialName, "Détail de l'entreprise"])
 })
 
 const identityItems = computed(() => {

--- a/frontend/src/views/CompanyPage.vue
+++ b/frontend/src/views/CompanyPage.vue
@@ -39,6 +39,7 @@ import useToaster from "@/composables/use-toaster"
 import SectionTitle from "@/components/SectionTitle"
 import CompanyForm from "@/components/CompanyForm"
 import TabularDataDisplayer from "@/components/TabularDataDisplayer"
+import { setDocumentTitle } from "@/utils/document"
 
 const route = useRoute()
 const rootStore = useRootStore()
@@ -102,6 +103,7 @@ const {
 onMounted(async () => {
   await execute()
   await handleError(response)
+  setDocumentTitle([company.value.socialName, "Mon entreprise"])
 })
 
 // Gère la réponse du component enfant

--- a/frontend/src/views/DeclarationIndividualPage/index.vue
+++ b/frontend/src/views/DeclarationIndividualPage/index.vue
@@ -29,7 +29,7 @@
 
 <script setup>
 import { useRoute } from "vue-router"
-import { computed, onMounted } from "vue"
+import { computed, onMounted, watch } from "vue"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
@@ -137,6 +137,16 @@ onMounted(async () => {
     if (el) el.scrollIntoView({ behavior: "smooth" })
   }
 
-  setDocumentTitle([declaration.value.name, company.value.socialName || "Résultat entreprise"])
+  setDocumentTitleFromRoute()
 })
+
+const setDocumentTitleFromRoute = () => {
+  const companyName = company.value.socialName || "Résultat entreprise"
+  if (route.name.includes("History")) setDocumentTitle(["Historique", declaration.value.name, companyName])
+  else if (route.name.includes("Identity"))
+    setDocumentTitle(["Identité produit et entreprise", declaration.value.name, companyName])
+  else setDocumentTitle([declaration.value.name, companyName])
+}
+
+watch(route, setDocumentTitleFromRoute)
 </script>

--- a/frontend/src/views/DeclarationIndividualPage/index.vue
+++ b/frontend/src/views/DeclarationIndividualPage/index.vue
@@ -35,6 +35,7 @@ import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import NavSidebar from "./NavSidebar"
 import { useRootStore } from "@/stores/root"
+import { setDocumentTitle } from "@/utils/document"
 
 const store = useRootStore()
 store.fetchDeclarationFieldsData()
@@ -136,6 +137,6 @@ onMounted(async () => {
     if (el) el.scrollIntoView({ behavior: "smooth" })
   }
 
-  document.title = `${declaration.value.name} - ${company.value.socialName || "Résultat entreprise"} - Compl'Alim`
+  setDocumentTitle([declaration.value.name, company.value.socialName || "Résultat entreprise"])
 })
 </script>

--- a/frontend/src/views/DeclaredElementPage/index.vue
+++ b/frontend/src/views/DeclaredElementPage/index.vue
@@ -89,7 +89,7 @@ const getElementFromApi = async () => {
 
 getElementFromApi()
 watch(element, (newElement) => {
-  setDocumentTitle([newElement?.newName || newElement?.element?.name])
+  setDocumentTitle([newElement?.newName || newElement?.element?.name, "Nouvel ingrédient"])
   additionalFields.value = JSON.parse(JSON.stringify(element.value))
   additionalFields.value.new = false
 })

--- a/frontend/src/views/DeclaredElementPage/index.vue
+++ b/frontend/src/views/DeclaredElementPage/index.vue
@@ -50,6 +50,7 @@ import ElementAlert from "./ElementAlert"
 import ReplacementSearch from "./ReplacementSearch"
 import ElementCard from "@/components/ElementCard"
 import ElementSynonyms from "./ElementSynonyms"
+import { setDocumentTitle } from "@/utils/document"
 
 const props = defineProps({ type: String, id: String })
 const store = useRootStore()
@@ -88,7 +89,7 @@ const getElementFromApi = async () => {
 
 getElementFromApi()
 watch(element, (newElement) => {
-  document.title = `${newElement?.newName || newElement?.element?.name} - Compl'Alim`
+  setDocumentTitle([newElement?.newName || newElement?.element?.name])
   additionalFields.value = JSON.parse(JSON.stringify(element.value))
   additionalFields.value.new = false
 })

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -40,12 +40,13 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue"
+import { computed, onMounted, ref } from "vue"
 import { getTypeIcon, getTypeInFrench, unSlugifyType, getApiType } from "@/utils/mappings"
 import { useRoute } from "vue-router"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import FormFields from "./FormFields"
+import { setDocumentTitle } from "@/utils/document"
 
 const props = defineProps({ urlComponent: String })
 
@@ -63,14 +64,20 @@ const typeName = computed(() => getTypeInFrench(type.value))
 const url = computed(() => `/api/v1/${apiType.value}s/${elementId.value}?history=true`)
 const { data: element, response, execute } = useFetch(url, { immediate: false }).get().json()
 
+const pageTitle = computed(() => (isNewIngredient.value ? "Nouvel ingrédient" : "Modification ingrédient"))
+
 const getElementFromApi = async () => {
-  if (!type.value || !elementId.value) return // create new ingredient
+  const titleParts = [pageTitle.value]
+  if (!type.value || !elementId.value) {
+    setDocumentTitle(titleParts)
+    return // create new ingredient
+  }
   await execute()
   await handleError(response)
+  if (element.value?.name) titleParts.push(element.value.name)
+  setDocumentTitle(titleParts)
 }
 getElementFromApi()
-
-const pageTitle = computed(() => (isNewIngredient.value ? "Nouvel ingrédient" : "Modification ingrédient"))
 
 const breadcrumbLinks = computed(() => {
   const links = []

--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -143,6 +143,7 @@ import ElementAutocomplete from "@/components/ElementAutocomplete"
 import ReportIssueBlock from "./ReportIssueBlock.vue"
 import ElementDoses from "@/components/ElementDoses.vue"
 import RegulatoryWarning from "@/components/RegulatoryWarning.vue"
+import { setDocumentTitle } from "@/utils/document"
 
 const store = useRootStore()
 const route = useRoute()
@@ -233,7 +234,7 @@ if (router.options.history.state.back && router.options.history.state.back.index
 getElementFromApi()
 
 watch(element, (newElement) => {
-  if (newElement) document.title = `${newElement.name} - Compl'Alim`
+  if (newElement) setDocumentTitle([newElement.name])
 })
 
 watch(route, getElementFromApi)

--- a/frontend/src/views/ElementSearchResultsPage/index.vue
+++ b/frontend/src/views/ElementSearchResultsPage/index.vue
@@ -59,6 +59,7 @@ import { handleError } from "@/utils/error-handling"
 import { slugifyType } from "@/utils/mappings"
 import { getPagesForPagination } from "@/utils/components"
 import RegulatoryWarning from "@/components/RegulatoryWarning"
+import { setDocumentTitle } from "@/utils/document"
 
 const router = useRouter()
 const route = useRoute()
@@ -92,6 +93,7 @@ const { data, response, isFetching, execute } = useFetch(
 const fetchSearchResults = async () => {
   await execute()
   await handleError(response)
+  setDocumentTitle([currentSearch.value, "Résultats de recherche"])
 }
 
 const goToSelectedOption = (option) => {

--- a/frontend/src/views/NewInstructionPage/index.vue
+++ b/frontend/src/views/NewInstructionPage/index.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from "vue"
+import { computed, onMounted, watch } from "vue"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import { useRootStore } from "@/stores/root"
@@ -61,6 +61,7 @@ import ProgressSpinner from "@/components/ProgressSpinner"
 import BepiasSidebar from "@/components/NewBepiasViews/BepiasSidebar"
 import AlertsSection from "@/components/AlertsSection"
 import DeclarationSummary from "@/components/DeclarationSummary"
+import { setDocumentTitle } from "@/utils/document"
 
 const props = defineProps({ declarationId: String })
 const route = useRoute()
@@ -201,5 +202,16 @@ onMounted(async () => {
     const el = document.querySelector(route.hash)
     if (el) el.scrollIntoView({ behavior: "smooth" })
   }
+
+  setDocumentTitleFromRoute()
 })
+
+const setDocumentTitleFromRoute = () => {
+  if (route.name.includes("History")) setDocumentTitle(["Historique", declaration.value.name, "Instruction"])
+  else if (route.name.includes("Identity"))
+    setDocumentTitle(["Identité produit et entreprise", declaration.value.name, "Instruction"])
+  else setDocumentTitle([declaration.value.name, "Instruction"])
+}
+
+watch(route, setDocumentTitleFromRoute)
 </script>

--- a/frontend/src/views/NewVisaPage/index.vue
+++ b/frontend/src/views/NewVisaPage/index.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from "vue"
+import { computed, onMounted, watch } from "vue"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import { useRootStore } from "@/stores/root"
@@ -65,6 +65,7 @@ import ProgressSpinner from "@/components/ProgressSpinner"
 import BepiasSidebar from "@/components/NewBepiasViews/BepiasSidebar"
 import DeclarationSummary from "@/components/DeclarationSummary"
 import DeclarationAlert from "@/components/DeclarationAlert"
+import { setDocumentTitle } from "@/utils/document"
 
 const props = defineProps({ declarationId: String })
 const route = useRoute()
@@ -180,5 +181,16 @@ onMounted(async () => {
     const el = document.querySelector(route.hash)
     if (el) el.scrollIntoView({ behavior: "smooth" })
   }
+
+  setDocumentTitleFromRoute()
 })
+
+const setDocumentTitleFromRoute = () => {
+  if (route.name.includes("History")) setDocumentTitle(["Historique", declaration.value.name, "Visa"])
+  else if (route.name.includes("Identity"))
+    setDocumentTitle(["Identité produit et entreprise", declaration.value.name, "Visa"])
+  else setDocumentTitle([declaration.value.name, "Visa"])
+}
+
+watch(route, setDocumentTitleFromRoute)
 </script>

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -115,6 +115,7 @@ import FormWrapper from "@/components/FormWrapper"
 import { headers } from "@/utils/data-fetching"
 import useToaster from "@/composables/use-toaster"
 import { tabTitles } from "@/utils/mappings"
+import { setDocumentTitle } from "@/utils/document"
 
 // Il y a deux refs qui stockent des erreurs. $externalResults sert
 // lors qu'on sauvegarde la déclaration (POST ou PUT) mais qu'on ne change
@@ -198,6 +199,7 @@ watch(data, () => {
     const successMessage = "Votre déclaration a été dupliquée. Merci de renseigner les pièces jointes."
     savePayload({ successMessage })
   } else payload.value = data.value
+  setDocumentTitleForTab(selectedTabIndex.value, data)
 })
 
 const hasNewElements = computed(() => {
@@ -351,9 +353,17 @@ const takeDeclaration = async () => {
 
 const onWithdrawal = () => router.replace({ name: "DeclarationsHomePage", query: { status: "WITHDRAWN,AUTHORIZED" } })
 
+const setDocumentTitleForTab = (tabIdx, fromData) => {
+  const declarationTitle = isNewDeclaration.value ? "Nouvelle démarche" : `Déclaration « ${fromData.value.name} »`
+  setDocumentTitle([titles.value[tabIdx].title, declarationTitle])
+}
+
 watch(
   () => route.query.tab,
-  (tab) => (selectedTabIndex.value = parseInt(tab))
+  (tab) => {
+    selectedTabIndex.value = parseInt(tab)
+    setDocumentTitleForTab(selectedTabIndex.value, payload)
+  }
 )
 
 const performDuplication = (originalDeclaration) => {


### PR DESCRIPTION
Ce changement modifie `document.title` pour plusieurs cas. Le changement est le plus visible quand on regarde l'historique de notre navigateur.

RGAA 8.6 https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#8.6

Avant
<img width="1697" height="364" alt="Screenshot from 2025-08-05 17-12-33" src="https://github.com/user-attachments/assets/a71bc0a5-0e11-4466-b5b1-ad9079c10e19" />


Après
<img width="1697" height="364" alt="Screenshot from 2025-08-05 17-11-44" src="https://github.com/user-attachments/assets/11e0cbca-2917-4c6a-ac52-51d0631dd4b1" />

À faire : MAJ titre quand on utilise la pagination et/ou les filtres