### PR TITLE
Filtres par dose (écrans SD/ANSES)

### DIFF
--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/IngredientFilterAccordeon.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/IngredientFilterAccordeon.vue
@@ -8,23 +8,136 @@
         </p>
       </template>
       <p>{{ modelValue }}</p>
+      <p>Selected part : {{ selectedPart }}</p>
+
+      <!-- Champs lors qu'il n'y a pas de dose spécifiée -->
+      <div class="flex gap-4 items-end" v-if="!hasDoseFilter">
+        <DsfrSelect v-if="isPlant" label="Partie de plante" v-model="selectedPart" :options="plantPartOptions" />
+        <div>
+          <DsfrButton @click="enableDoseFilter" label="Ajouter une dose" icon="ri-add-line" tertiary />
+        </div>
+      </div>
+
+      <!-- Champs lors qu'on veut spécifier une dose -->
+      <div v-else class="grid grid-cols-12 gap-4 items-center">
+        <div class="col-span-12 md:col-span-3">
+          <DsfrSelect v-if="isPlant" label="Partie de plante" v-model="selectedPart" :options="plantPartOptions" />
+        </div>
+        <div class="col-span-12 md:col-span-3">
+          <DsfrSelect label="Opération" v-model="operation" :options="operationOptions" />
+        </div>
+        <div class="col-span-12 md:col-span-2">
+          <DsfrInputGroup :error-message="firstErrorMsg(v$, 'quantityA')">
+            <NumberField :label="quantityALabel" v-model="quantityA" label-visible :required="true" />
+          </DsfrInputGroup>
+        </div>
+        <div class="col-span-12 md:col-span-2" v-if="showDoubleQuantity">
+          <DsfrInputGroup :error-message="firstErrorMsg(v$, 'quantityB')">
+            <NumberField :label="quantityBLabel" v-model="quantityB" label-visible :required="true" />
+          </DsfrInputGroup>
+        </div>
+        <div class="col-span-12 md:col-span-2">
+          <DsfrSelect v-model="unit" :options="unitOptions" label="Unité de mesure" />
+        </div>
+      </div>
     </DsfrAccordion>
   </DsfrAccordionsGroup>
 </template>
 
 <script setup>
-import { computed, ref } from "vue"
+import NumberField from "@/components/NumberField"
+import { computed, ref, watch } from "vue"
 import { typesMapping, getTypeIcon } from "@/utils/mappings"
+import { useRootStore } from "@/stores/root"
+import { storeToRefs } from "pinia"
+import { firstErrorMsg, errorNumeric } from "@/utils/forms"
+import { useVuelidate } from "@vuelidate/core"
+import { required, helpers } from "@vuelidate/validators"
+import { OPERATION, operationOptions } from "@/utils/mappings.js"
 
 const modelValue = defineModel()
+const emit = defineEmits(["update:modelValue"])
+const { units, plantParts } = storeToRefs(useRootStore())
 const activeIngredientAccordion = ref(0)
 
-const icon = computed(() => getTypeIcon(modelValue.value?.split("||")[0]))
+// Je dois remplir ces parts depuis le modèle (string)
+const selectedPart = ref("")
+const operation = ref(">")
+const quantityA = ref(0)
+const quantityB = ref()
+const unit = ref()
 
-const name = computed(() => {
-  const parts = modelValue.value.split("||")
-  const type = typesMapping[parts[0]] || "Ingrédient"
-  const name = parts[1] || "Inconnu"
-  return `${type} : ${name}`
+// Parsing du modèle (qui est un String de filtre dose) et autres utils
+const objectType = computed(() => modelValue.value.split("||")[0])
+const ingredientName = computed(() => modelValue.value.split("||")[1])
+const ingredientId = computed(() => modelValue.value.split("||")[2].split("|")[0])
+const plantPartId = computed(() => isPlant.value && modelValue.value.split("||")[2].split("|")[1])
+const plantPartName = computed(() => isPlant.value && modelValue.value.split("||")[2].split("|")[2])
+const icon = computed(() => getTypeIcon(objectType.value))
+const name = computed(() => `${typesMapping[objectType] || "Ingrédient"} : ${ingredientName.value || "Inconnu"}`)
+
+const isPlant = computed(() => objectType.value === "plant")
+const isMicroorganism = computed(() => objectType.value === "microorganism")
+const isSubstance = computed(() => objectType.value === "substance")
+
+// Utils du formulaire
+const makeQuantityLabel = (suffix) => {
+  let label = operation.value === OPERATION.BT ? "Qté" : "Quantité"
+  if (operation.value === OPERATION.BT) label += ` ${suffix}`
+  if (isMicroorganism.value) label += " (en UFC)"
+  if (isSubstance.value) label += ` (en ${units.value?.find((x) => x.id === parseInt(unit.value))?.name})`
+
+  return label
+}
+const showDoubleQuantity = computed(() => operation.value === OPERATION.BT)
+const quantityALabel = computed(() => makeQuantityLabel("min"))
+const quantityBLabel = computed(() => makeQuantityLabel("max"))
+
+const plantPartOptions = computed(() => {
+  const options = plantParts.value?.map((x) => ({ text: x.name, value: x.id.toString() })) || []
+  options.unshift({ disabled: true, text: "---------" })
+  options.unshift({ value: "", text: "Toutes les parties" })
+  return options
 })
+const unitOptions = computed(() => units.value?.map((x) => ({ text: x.name, value: x.id.toString() })))
+
+// Validation du formulaire
+const state = { quantityA, quantityB }
+const rules = computed(() => ({
+  quantityA: { required, errorNumeric },
+  quantityB: showDoubleQuantity.value
+    ? {
+        required,
+        errorNumeric,
+        minValue: helpers.withMessage("La valeur doit être supérieur à la qté min", (value) => value > quantityA.value),
+      }
+    : {},
+}))
+const v$ = useVuelidate(rules, state)
+
+// Mise à jour du modèle
+
+const updateFilterString = () => {
+  v$.value.$validate()
+  if (v$.value.$error) return
+
+  const commonInitialSection = `${objectType.value}||${ingredientName.value}||${ingredientId.value}`
+  const midSection = isPlant.value
+    ? `|${selectedPart.value || "-"}|${plantParts.value.find((x) => x.id.toString() === selectedPart.value)?.name || "Toutes les parties"}`
+    : ""
+  const endSection = `||${operation.value}||${quantityA.value}||${unit.value || ""}`
+  emit("update:modelValue", `${commonInitialSection}${midSection}${endSection}`)
+}
+watch([selectedPart, quantityA, quantityB, unit, operation], updateFilterString)
+
+// À noter : on considère que s'il y a une unité le filtre dose est actif
+const hasDoseFilter = computed(() => operation.value && unit.value)
+const enableDoseFilter = () => (unit.value = unitOptions.value?.[0]?.value || "")
 </script>
+
+<style scoped>
+@reference "../../../styles/index.css";
+div :deep(.fr-input-group) {
+  @apply -mt-2!;
+}
+</style>

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/IngredientFilterAccordeon.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/IngredientFilterAccordeon.vue
@@ -1,0 +1,30 @@
+<template>
+  <DsfrAccordionsGroup v-model="activeIngredientAccordion">
+    <DsfrAccordion>
+      <template v-slot:title>
+        <p>
+          <v-icon scale="0.85" class="mr-2" :name="icon" />
+          {{ name }}
+        </p>
+      </template>
+      <p>{{ modelValue }}</p>
+    </DsfrAccordion>
+  </DsfrAccordionsGroup>
+</template>
+
+<script setup>
+import { computed, ref } from "vue"
+import { typesMapping, getTypeIcon } from "@/utils/mappings"
+
+const modelValue = defineModel()
+const activeIngredientAccordion = ref(0)
+
+const icon = computed(() => getTypeIcon(modelValue.value?.split("||")[0]))
+
+const name = computed(() => {
+  const parts = modelValue.value.split("||")
+  const type = typesMapping[parts[0]] || "Ingrédient"
+  const name = parts[1] || "Inconnu"
+  return `${type} : ${name}`
+})
+</script>

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/IngredientFilterAccordeon.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/IngredientFilterAccordeon.vue
@@ -11,31 +11,36 @@
       <!-- Champs lors qu'il n'y a pas de dose spécifiée -->
       <div class="flex gap-4 items-end" v-if="!hasDoseFilter">
         <DsfrSelect v-if="isPlant" label="Partie de plante" v-model="selectedPart" :options="plantPartOptions" />
-        <div>
+        <div class="mb-2">
           <DsfrButton @click="enableDoseFilter" label="Ajouter une dose" icon="ri-add-line" tertiary />
         </div>
       </div>
 
       <!-- Champs lors qu'on veut spécifier une dose -->
-      <div v-else class="grid grid-cols-12 gap-4 items-center">
-        <div class="col-span-12 md:col-span-3">
-          <DsfrSelect v-if="isPlant" label="Partie de plante" v-model="selectedPart" :options="plantPartOptions" />
+      <div v-else>
+        <div class="grid grid-cols-12 gap-4 items-center">
+          <div class="col-span-12 md:col-span-3" v-if="isPlant">
+            <DsfrSelect label="Partie de plante" v-model="selectedPart" :options="plantPartOptions" />
+          </div>
+          <div class="col-span-12 md:col-span-3">
+            <DsfrSelect label="Opération" v-model="operation" :options="operationOptions" />
+          </div>
+          <div class="col-span-12 md:col-span-2">
+            <DsfrInputGroup :error-message="firstErrorMsg(v$, 'quantityA')">
+              <NumberField :label="quantityALabel" v-model="quantityA" label-visible :required="true" />
+            </DsfrInputGroup>
+          </div>
+          <div class="col-span-12 md:col-span-2" v-if="showDoubleQuantity">
+            <DsfrInputGroup :error-message="firstErrorMsg(v$, 'quantityB')">
+              <NumberField :label="quantityBLabel" v-model="quantityB" label-visible :required="true" />
+            </DsfrInputGroup>
+          </div>
+          <div class="col-span-12 md:col-span-2" v-if="!isMicroorganism && !isSubstance">
+            <DsfrSelect v-model="unit" :options="unitOptions" label="Unité de mesure" />
+          </div>
         </div>
-        <div class="col-span-12 md:col-span-3">
-          <DsfrSelect label="Opération" v-model="operation" :options="operationOptions" />
-        </div>
-        <div class="col-span-12 md:col-span-2">
-          <DsfrInputGroup :error-message="firstErrorMsg(v$, 'quantityA')">
-            <NumberField :label="quantityALabel" v-model="quantityA" label-visible :required="true" />
-          </DsfrInputGroup>
-        </div>
-        <div class="col-span-12 md:col-span-2" v-if="showDoubleQuantity">
-          <DsfrInputGroup :error-message="firstErrorMsg(v$, 'quantityB')">
-            <NumberField :label="quantityBLabel" v-model="quantityB" label-visible :required="true" />
-          </DsfrInputGroup>
-        </div>
-        <div class="col-span-12 md:col-span-2">
-          <DsfrSelect v-model="unit" :options="unitOptions" label="Unité de mesure" />
+        <div class="mt-2">
+          <DsfrButton @click="removeDoseFilter" label="Enlever la dose" icon="ri-close-line" tertiary />
         </div>
       </div>
     </DsfrAccordion>
@@ -54,6 +59,7 @@ import { required, helpers } from "@vuelidate/validators"
 import { OPERATION, operationOptions } from "@/utils/mappings.js"
 
 const modelValue = defineModel()
+
 const emit = defineEmits(["update:modelValue"])
 const { units, plantParts } = storeToRefs(useRootStore())
 const activeIngredientAccordion = ref(0)
@@ -80,18 +86,23 @@ const extractQuantityB = () => {
 const quantityB = ref(extractQuantityB())
 
 const extractUnit = () => {
-  const segments = modelValue.value?.split("||")
+  const segments = modelValue.value?.split("****")[0].split("||")
   if (!segments || segments.length < 6) return null
   return segments[5]
 }
 const unit = ref(extractUnit())
+
+const extractEnforcedUnit = () => {
+  return modelValue.value?.includes("****") ? modelValue.value.split("****")[1] : null
+}
+const enforcedUnit = ref(extractEnforcedUnit())
 
 // Parsing du modèle (qui est un String de filtre dose) et autres utils
 
 const ingredientName = computed(() => modelValue.value.split("||")[1])
 const ingredientId = computed(() => modelValue.value.split("||")[2].split("|")[0])
 const icon = computed(() => getTypeIcon(objectType.value))
-const name = computed(() => `${typesMapping[objectType] || "Ingrédient"} : ${ingredientName.value || "Inconnu"}`)
+const name = computed(() => `${typesMapping[objectType.value] || "Ingrédient"} : ${ingredientName.value || "Inconnu"}`)
 
 // Utils du formulaire
 const makeQuantityLabel = (suffix) => {
@@ -138,14 +149,16 @@ const updateFilterString = () => {
   const midSection = isPlant.value
     ? `|${selectedPart.value || "-"}|${plantParts.value.find((x) => x.id.toString() === selectedPart.value)?.name || "Toutes les parties"}`
     : ""
-  const endSection = `||${operation.value}||${quantityA.value}${showDoubleQuantity.value ? "|" + quantityB.value : ""}||${unit.value || ""}`
+  let endSection = `||${operation.value}||${quantityA.value}${showDoubleQuantity.value ? "|" + quantityB.value : ""}||${unit.value || ""}`
+  if (enforcedUnit.value) endSection += `****${enforcedUnit.value}`
   emit("update:modelValue", `${commonInitialSection}${midSection}${endSection}`)
 }
 watch([selectedPart, quantityA, quantityB, unit, operation], updateFilterString)
 
 // À noter : on considère que s'il y a une unité le filtre dose est actif
 const hasDoseFilter = computed(() => operation.value && unit.value)
-const enableDoseFilter = () => (unit.value = unitOptions.value?.[0]?.value || "")
+const enableDoseFilter = () => (unit.value = enforcedUnit.value || unitOptions.value?.[0]?.value || "")
+const removeDoseFilter = () => (unit.value = null)
 </script>
 
 <style scoped>

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
@@ -85,7 +85,13 @@
 
     <hr class="mt-6 mb-0" />
 
-    <IngredientFilterAccordeon v-for="dose in doses" :key="dose" :modelValue="dose" @remove="removeIngredient" />
+    <IngredientFilterAccordeon
+      v-for="(dose, idx) in doses"
+      @update:modelValue="updateDoseStrings(idx, $event)"
+      :key="`dose-accordeon-${idx}`"
+      :modelValue="doses[idx]"
+      @remove="removeIngredient"
+    />
 
     <div v-if="isFetching && !data" class="flex justify-center my-10">
       <ProgressSpinner />
@@ -290,6 +296,12 @@ const addIngredient = async (ingredient) => {
 }
 const removeIngredient = (ingredient) => {
   const newDoses = doses.value.filter((x) => x !== ingredient)
+  updateDoses(newDoses)
+}
+
+const updateDoseStrings = (index, newValue) => {
+  const newDoses = [...doses.value]
+  newDoses[index] = newValue
   updateDoses(newDoses)
 }
 </script>

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
@@ -20,6 +20,18 @@
         />
       </DsfrFieldset>
     </div>
+    <!-- Zone des filtres actifs -->
+    <div class="mb-4">
+      <DsfrTag
+        v-for="(item, idx) in activeFilters"
+        :key="`active-filters-${idx}`"
+        :label="item.text"
+        tagName="button"
+        @click="item.callback"
+        :aria-label="`Retirer le filtre « ${item.text} »`"
+        class="mx-1 fr-tag--dismiss"
+      ></DsfrTag>
+    </div>
 
     <DsfrAccordionsGroup v-model="activeAccordion">
       <DsfrAccordion title="Filtrer les déclarations">
@@ -71,18 +83,9 @@
       </DsfrAccordion>
     </DsfrAccordionsGroup>
 
-    <!-- Zone des filtres actifs -->
-    <div class="my-4">
-      <DsfrTag
-        v-for="(item, idx) in activeFilters"
-        :key="`active-filters-${idx}`"
-        :label="item.text"
-        tagName="button"
-        @click="item.callback"
-        :aria-label="`Retirer le filtre « ${item.text} »`"
-        class="mx-1 fr-tag--dismiss"
-      ></DsfrTag>
-    </div>
+    <hr class="mt-6 mb-0" />
+
+    <IngredientFilterAccordeon v-for="dose in doses" :key="dose" :modelValue="dose" @remove="removeIngredient" />
 
     <div v-if="isFetching && !data" class="flex justify-center my-10">
       <ProgressSpinner />
@@ -114,6 +117,7 @@ import { storeToRefs } from "pinia"
 import { toOptions } from "@/utils/forms.js"
 import ElementAutocomplete from "@/components/ElementAutocomplete.vue"
 import { typesMapping } from "@/utils/mappings"
+import IngredientFilterAccordeon from "./IngredientFilterAccordeon"
 
 const store = useRootStore()
 store.fetchDeclarationFieldsData()

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
@@ -168,7 +168,7 @@ const url = computed(() => {
   if (searchTermProduct.value) apiUrl += `&search_name=${searchTermProduct.value}`
   if (searchTermBrand.value) apiUrl += `&search_brand=${searchTermBrand.value}`
   if (searchTermCompany.value) apiUrl += `&search_company=${searchTermCompany.value}`
-  if (doses.value) for (let i = 0; i < doses.value.length; i++) apiUrl += `&dose=${doses.value[i]}`
+  if (doses.value) for (let i = 0; i < doses.value.length; i++) apiUrl += `&dose=${doses.value[i].split("****")[0]}`
 
   return apiUrl
 })
@@ -284,11 +284,25 @@ const addIngredient = async (ingredient) => {
   // Temporairement on traite les ajouts d'ingrédients comme ayant une dose supérieure à 0
   // Par la suite on pourra spécifier également la dose précise recherchée et la partie de
   // plante
+  const ingredientTypes = [
+    "form_of_supply",
+    "aroma",
+    "additive",
+    "active_ingredient",
+    "non_active_ingredient",
+    "ingredient",
+    "other_ingredient",
+  ]
+  const doseType = ingredientTypes.includes(ingredient.objectType) ? "ingredient" : ingredient.objectType
   let newFilterString = `${ingredient.objectType}||${ingredient.name}||${ingredient.id}`
 
   if (ingredient.objectType === "plant") newFilterString += "|-|Toutes les parties"
 
   newFilterString += "||>||0||"
+
+  // Si on a besoin de restreindre l'unité à une unité spécifique, on peut le faire en la
+  // mettant après ****
+  if (ingredient.objectType === "substance") newFilterString += `****${ingredient.unit}`
 
   clearSearch()
   updateDoses([...doses.value, newFilterString])

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
@@ -126,7 +126,6 @@ import { typesMapping } from "@/utils/mappings"
 import IngredientFilterAccordeon from "./IngredientFilterAccordeon"
 
 const store = useRootStore()
-store.fetchDeclarationFieldsData()
 const { populations, conditions, galenicFormulations } = storeToRefs(store)
 
 const activeAccordion = ref()

--- a/frontend/src/utils/mappings.js
+++ b/frontend/src/utils/mappings.js
@@ -374,3 +374,14 @@ export const getCompanyActivitiesString = (activities) =>
     .map((x) => allActivities.find((y) => y.value === x).label)
     .sort((a, b) => a.localeCompare(b))
     .join(", ")
+
+export const OPERATION = { GT: ">", GTE: "≥", LT: "<", LTE: "≤", EQ: "=", BT: "≬" }
+
+export const operationOptions = [
+  { text: "Dose supérieure à (>)", value: OPERATION.GT },
+  { text: "Dose supérieure ou égale à (≥)", value: OPERATION.GTE },
+  { text: "Dose inférieure à (<)", value: OPERATION.LT },
+  { text: "Dose inférieure ou égale à (≤)", value: OPERATION.LTE },
+  { text: "Dose égale à (=)", value: OPERATION.EQ },
+  { text: "Dose entre deux valeurs", value: OPERATION.BT },
+]

--- a/frontend/src/views/AdvancedSearchPage/DoseFilterModal.vue
+++ b/frontend/src/views/AdvancedSearchPage/DoseFilterModal.vue
@@ -148,8 +148,8 @@ import { useVuelidate } from "@vuelidate/core"
 import { required, helpers } from "@vuelidate/validators"
 import { firstErrorMsg, errorNumeric } from "@/utils/forms"
 import { useFetch } from "@vueuse/core"
+import { OPERATION, operationOptions } from "@/utils/mappings.js"
 
-const OPERATION = { GT: ">", GTE: "≥", LT: "<", LTE: "≤", EQ: "=", BT: "≬" }
 const { units, plantParts } = storeToRefs(useRootStore())
 
 const filterString = defineModel()
@@ -203,14 +203,6 @@ const plantPartOptions = computed(() => {
   return options
 })
 const unitOptions = computed(() => units.value?.map((x) => ({ text: x.name, value: x.id.toString() })))
-const operationOptions = [
-  { text: "Dose supérieure à (>)", value: OPERATION.GT },
-  { text: "Dose supérieure ou égale à (≥)", value: OPERATION.GTE },
-  { text: "Dose inférieure à (<)", value: OPERATION.LT },
-  { text: "Dose inférieure ou égale à (≤)", value: OPERATION.LTE },
-  { text: "Dose égale à (=)", value: OPERATION.EQ },
-  { text: "Dose entre deux valeurs", value: OPERATION.BT },
-]
 
 // Gestion du filtre
 

--- a/frontend/src/views/CompanyDetails/index.vue
+++ b/frontend/src/views/CompanyDetails/index.vue
@@ -41,7 +41,9 @@ import ProgressSpinner from "@/components/ProgressSpinner"
 import InfoTable from "@/components/InfoTable.vue"
 import DeclarationsTableSection from "@/components/NewBepiasViews/DeclarationsTableSection"
 import { setDocumentTitle } from "@/utils/document"
+import { useRootStore } from "@/stores/root"
 
+useRootStore().fetchDeclarationFieldsData()
 const router = useRouter()
 const previousRoute = computed(() => {
   const previousRoute = router.getPreviousRoute().value

--- a/frontend/src/views/DeclarationSearchPage/index.vue
+++ b/frontend/src/views/DeclarationSearchPage/index.vue
@@ -7,7 +7,7 @@
       ]"
     />
     <h1 class="fr-h3">Tableau des compléments alimentaires</h1>
-    <DeclarationsTableSection />
+    <DeclarationsTableSection v-if="store.initialDataLoaded" />
   </div>
 </template>
 
@@ -15,5 +15,6 @@
 import DeclarationsTableSection from "@/components/NewBepiasViews/DeclarationsTableSection"
 import { useRootStore } from "@/stores/root"
 
-useRootStore().fetchDeclarationFieldsData()
+const store = useRootStore()
+store.fetchDeclarationFieldsData()
 </script>

--- a/frontend/src/views/DeclarationSearchPage/index.vue
+++ b/frontend/src/views/DeclarationSearchPage/index.vue
@@ -13,4 +13,7 @@
 
 <script setup>
 import DeclarationsTableSection from "@/components/NewBepiasViews/DeclarationsTableSection"
+import { useRootStore } from "@/stores/root"
+
+useRootStore().fetchDeclarationFieldsData()
 </script>


### PR DESCRIPTION
Cette PR permet de filtrer par la dose des ingrédients sélectionnés.

## :movie_camera:  Démo

### Cas avec une substance (avec et sans dose)

Dans la substance on ne peut pas choisir l'unité, on utilise celle qui est déjà spécifiée.

https://github.com/user-attachments/assets/8b9b8ea7-d0cf-4713-960c-a10c9be2807d

### Cas avec une plante (avec et sans dose)

https://github.com/user-attachments/assets/b84d2ea6-71ce-492e-a642-137cb20485c9

### Cas en spécifiant une partie de plante

https://github.com/user-attachments/assets/466ae26e-446d-45dc-87c2-a8243642c5f4

### Cas avec un micro-organisme (avec et sans dose)

Comme pour la substance, on ne choisit pas l'unité - on utilise toujours UFC

https://github.com/user-attachments/assets/c6c43c0a-1d22-4dc7-be25-650b2374c0f2

### Cas pour un autre ingrédient (avec et sans dose)

https://github.com/user-attachments/assets/97713b5f-352a-4feb-8dbf-847acfd17fb9

## Détails techniques

Le principal composant est `IngredientFilterAccordeon.vue`, qui prend la chaîne de caractères utilisé déjà pour les filtres dose et rend la UI qui permet de la modifier. Un ajout à la fin de `****<id-unité>` permet de restreindre l'unité utilisé pour la dose.

Côté backend un tout petit changement permet d'envoyer plusieurs queryparams `dose` dans l'URL de l'API, afin de pouvoir les combiner.






Lié à #2163
