### PR TITLE
Declaration/instruction : afficher un message quand le bulletin d'analyse est demandé

### DIFF
--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -8,14 +8,6 @@
       v-if="allowArticleChange || payload.article"
       class="mb-2"
     />
-    <div v-if="useCompactAttachmentView">
-      <h3 class="fr-h6 mt-8!">
-        Pièces jointes
-        <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(2))" />
-      </h3>
-      <CompactAttachmentGrid :attachments="payload.attachments" />
-      <!-- TODO: show notice? -->
-    </div>
     <h3 class="fr-h6">
       Informations sur le produit
       <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(0))" />
@@ -41,28 +33,19 @@
         <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(1))" />
       </h3>
       <AddressLine :payload="payload" />
-      <div v-if="!useCompactAttachmentView">
-        <h3 class="fr-h6 mt-8!">
-          Pièces jointes
-          <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(2))" />
-        </h3>
-        <DsfrAlert v-if="ingredientsRequiringAnalysisReport.length" small class="mb-4">
-          <p>Un bulletin d'analyse est nécessaire pour l'utilisation des ingrédients suivants :</p>
-          <ul class="mb-0">
-            <li v-for="ingredient in ingredientsRequiringAnalysisReport" :key="`${ingredient.type}-${ingredient.id}`">
-              {{ ingredient.element.name }}
-            </li>
-          </ul>
-        </DsfrAlert>
-        <div class="grid grid-cols-12 gap-3 mb-8">
-          <FilePreview
-            class="col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-3"
-            v-for="(file, index) in payload.attachments"
-            :key="`file-${index}`"
-            :file="file"
-            readonly
-          />
-        </div>
+      <h3 class="fr-h6 mt-8!">
+        Pièces jointes
+        <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(2))" />
+      </h3>
+      <RequiresAnalysisReportNotice :declaration="payload" class="mb-4" />
+      <div class="grid grid-cols-12 gap-3 mb-8">
+        <FilePreview
+          class="col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-3"
+          v-for="(file, index) in payload.attachments"
+          :key="`file-${index}`"
+          :file="file"
+          readonly
+        />
       </div>
     </div>
   </div>
@@ -73,7 +56,6 @@ export default { name: "DeclarationSummary" }
 </script>
 
 <script setup>
-import { computed } from "vue"
 import AddressLine from "@/components/AddressLine"
 import ProductInfoSegment from "@/components/ProductInfoSegment"
 import ArticleInfoRow from "./ArticleInfoRow"
@@ -83,7 +65,7 @@ import FilePreview from "@/components/FilePreview"
 import { useRouter } from "vue-router"
 import SummaryModificationButton from "./SummaryModificationButton"
 import HistoryBadge from "../History/HistoryBadge.vue"
-import CompactAttachmentGrid from "@/components/CompactAttachmentGrid"
+import RequiresAnalysisReportNotice from "@/components/RequiresAnalysisReportNotice"
 
 const router = useRouter()
 
@@ -93,21 +75,9 @@ defineProps({
   allowArticleChange: Boolean,
   useAccordions: Boolean,
   showElementAuthorization: Boolean,
-  useCompactAttachmentView: Boolean,
 })
 
 const editLink = (tab) => ({ query: { tab } })
-
-const ingredientsRequiringAnalysisReport = computed(() => {
-  return []
-    .concat(
-      payload.value.declaredPlants,
-      payload.value.declaredMicroorganisms,
-      payload.value.declaredIngredients,
-      payload.value.declaredSubstances
-    )
-    .filter((x) => x.element.requiresAnalysisReport)
-})
 </script>
 
 <style scoped>

--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -14,6 +14,7 @@
         <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(2))" />
       </h3>
       <CompactAttachmentGrid :attachments="payload.attachments" />
+      <!-- TODO: show notice? -->
     </div>
     <h3 class="fr-h6">
       Informations sur le produit
@@ -45,6 +46,14 @@
           Pièces jointes
           <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(2))" />
         </h3>
+        <DsfrAlert v-if="ingredientsRequiringAnalysisReport.length" small class="mb-4">
+          <p>Un bulletin d'analyse est nécessaire pour l'utilisation des ingrédients suivants :</p>
+          <ul class="mb-0">
+            <li v-for="ingredient in ingredientsRequiringAnalysisReport" :key="`${ingredient.type}-${ingredient.id}`">
+              {{ ingredient.element.name }}
+            </li>
+          </ul>
+        </DsfrAlert>
         <div class="grid grid-cols-12 gap-3 mb-8">
           <FilePreview
             class="col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-3"
@@ -64,6 +73,7 @@ export default { name: "DeclarationSummary" }
 </script>
 
 <script setup>
+import { computed } from "vue"
 import AddressLine from "@/components/AddressLine"
 import ProductInfoSegment from "@/components/ProductInfoSegment"
 import ArticleInfoRow from "./ArticleInfoRow"
@@ -87,6 +97,17 @@ defineProps({
 })
 
 const editLink = (tab) => ({ query: { tab } })
+
+const ingredientsRequiringAnalysisReport = computed(() => {
+  return []
+    .concat(
+      payload.value.declaredPlants,
+      payload.value.declaredMicroorganisms,
+      payload.value.declaredIngredients,
+      payload.value.declaredSubstances
+    )
+    .filter((x) => x.element.requiresAnalysisReport)
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/NewBepiasViews/ProductSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/ProductSection/index.vue
@@ -4,6 +4,7 @@
       <ArticleInfoRow :modelValue="declaration" :allowChange="true" class="mb-4" />
 
       <SectionHeader id="pieces-jointes" icon="ri-attachment-fill" text="Pièces jointes" />
+      <RequiresAnalysisReportNotice :declaration="declaration" />
       <CompactAttachmentGrid :attachments="declaration.attachments" />
 
       <SectionHeader id="dernier-commentaire" icon="ri-chat-2-fill" text="Dernier commentaire" />
@@ -51,6 +52,7 @@ import ArticleInfoRow from "@/components/DeclarationSummary/ArticleInfoRow"
 import VisaValidationSegment from "../VisaValidationSegment"
 import { computed } from "vue"
 import { useRouter } from "vue-router"
+import RequiresAnalysisReportNotice from "@/components/RequiresAnalysisReportNotice"
 
 const router = useRouter()
 const previousVisaQueryParams =

--- a/frontend/src/components/RequiresAnalysisReportNotice.vue
+++ b/frontend/src/components/RequiresAnalysisReportNotice.vue
@@ -1,0 +1,27 @@
+<template>
+  <DsfrAlert v-if="ingredientsRequiringAnalysisReport.length" small class="mb-4">
+    <p>Un bulletin d'analyse est nécessaire pour l'utilisation des ingrédients suivants :</p>
+    <ul class="mb-0">
+      <li v-for="ingredient in ingredientsRequiringAnalysisReport" :key="`${ingredient.type}-${ingredient.id}`">
+        {{ ingredient.element.name }}
+      </li>
+    </ul>
+  </DsfrAlert>
+</template>
+
+<script setup>
+import { computed } from "vue"
+
+const props = defineProps(["declaration"])
+
+const ingredientsRequiringAnalysisReport = computed(() => {
+  return []
+    .concat(
+      props.declaration.declaredPlants,
+      props.declaration.declaredMicroorganisms,
+      props.declaration.declaredIngredients,
+      props.declaration.declaredSubstances
+    )
+    .filter((x) => x.element.requiresAnalysisReport)
+})
+</script>

--- a/frontend/src/views/ProducerFormPage/AttachmentTab.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentTab.vue
@@ -17,9 +17,9 @@
 
     <SectionTitle title="Autres" class="mt-10!" sizeTag="h6" icon="ri-attachment-2" />
 
-    <DsfrAlert v-if="ingredientsRequiringAnalysisReport.length">
+    <DsfrAlert v-if="ingredientsRequiringAnalysisReport.length" small>
       <p>Un bulletin d'analyse est nécessaire pour l'utilisation des ingrédients suivants :</p>
-      <ul>
+      <ul class="mb-0">
         <li v-for="ingredient in ingredientsRequiringAnalysisReport" :key="`${ingredient.type}-${ingredient.id}`">
           {{ ingredient.element.name }}
         </li>

--- a/frontend/src/views/ProducerFormPage/AttachmentTab.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentTab.vue
@@ -17,14 +17,7 @@
 
     <SectionTitle title="Autres" class="mt-10!" sizeTag="h6" icon="ri-attachment-2" />
 
-    <DsfrAlert v-if="ingredientsRequiringAnalysisReport.length" small>
-      <p>Un bulletin d'analyse est nécessaire pour l'utilisation des ingrédients suivants :</p>
-      <ul class="mb-0">
-        <li v-for="ingredient in ingredientsRequiringAnalysisReport" :key="`${ingredient.type}-${ingredient.id}`">
-          {{ ingredient.element.name }}
-        </li>
-      </ul>
-    </DsfrAlert>
+    <RequiresAnalysisReportNotice :declaration="payload" />
 
     <DsfrInputGroup>
       <DsfrFileUpload
@@ -45,6 +38,7 @@
 import { ref, computed } from "vue"
 import FileGrid from "./FileGrid"
 import SectionTitle from "@/components/SectionTitle"
+import RequiresAnalysisReportNotice from "@/components/RequiresAnalysisReportNotice"
 
 const acceptedTypes = ["image/jpeg", "image/gif", "image/png", "application/pdf"]
 const props = defineProps(["externalResults"])
@@ -126,15 +120,4 @@ const toBase64 = (file) => {
     reader.onerror = reject
   })
 }
-
-const ingredientsRequiringAnalysisReport = computed(() => {
-  return []
-    .concat(
-      payload.value.declaredPlants,
-      payload.value.declaredMicroorganisms,
-      payload.value.declaredIngredients,
-      payload.value.declaredSubstances
-    )
-    .filter((x) => x.element.requiresAnalysisReport)
-})
 </script>

--- a/frontend/src/views/ProducerFormPage/AttachmentTab.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentTab.vue
@@ -17,6 +17,15 @@
 
     <SectionTitle title="Autres" class="mt-10!" sizeTag="h6" icon="ri-attachment-2" />
 
+    <DsfrAlert v-if="ingredientsRequiringAnalysisReport.length">
+      <p>Un bulletin d'analyse est nécessaire pour l'utilisation des ingrédients suivants :</p>
+      <ul>
+        <li v-for="ingredient in ingredientsRequiringAnalysisReport" :key="`${ingredient.type}-${ingredient.id}`">
+          {{ ingredient.element.name }}
+        </li>
+      </ul>
+    </DsfrAlert>
+
     <DsfrInputGroup>
       <DsfrFileUpload
         :label="otherAttachmentsLabel"
@@ -117,4 +126,15 @@ const toBase64 = (file) => {
     reader.onerror = reject
   })
 }
+
+const ingredientsRequiringAnalysisReport = computed(() => {
+  return []
+    .concat(
+      payload.value.declaredPlants,
+      payload.value.declaredMicroorganisms,
+      payload.value.declaredIngredients,
+      payload.value.declaredSubstances
+    )
+    .filter((x) => x.element.requiresAnalysisReport)
+})
 </script>


### PR DESCRIPTION
Lié à https://www.notion.so/incubateur-masa/Ajout-champ-Pi-ces-joindre-type-bulletin-d-analyse-223de24614be80999094e4872d2f5c55

## Vue onglet PJs

... avec un ingrédient
<img width="2400" height="1548" alt="Screenshot 2025-08-27 at 12-07-49 Pièces jointes - Déclaration « test title » - Compl'Alim" src="https://github.com/user-attachments/assets/09fd10f5-cc55-4105-a2b9-891a9ec97f06" />

... avec plusieurs ingrédients
<img width="2400" height="1604" alt="Screenshot 2025-08-27 at 12-08-11 Pièces jointes - Déclaration « test title » - Compl'Alim" src="https://github.com/user-attachments/assets/a8afa2af-dba6-45db-b0d5-3a9e1d78e110" />

## Vue sommaire
<img width="2646" height="1412" alt="Screenshot 2025-08-27 at 12-08-24 Soumettre - Déclaration « test title » - Compl'Alim" src="https://github.com/user-attachments/assets/3b4349b5-7d69-4766-ac33-890312c48f7f" />

## Vue instruction/visa
<img width="2530" height="884" alt="Screenshot 2025-08-27 at 12-19-00 test analysis report notice - Instruction - Compl'Alim" src="https://github.com/user-attachments/assets/9785e880-dbe8-4cd9-acac-9d015ab7622d" />
