### PR TITLE
Ingrédients demandés : ne pas passer l'article 16 à 15 quand une requête est traitée

### DIFF
--- a/api/tests/test_declaration.py
+++ b/api/tests/test_declaration.py
@@ -2838,38 +2838,6 @@ class TestSingleDeclaredElementApi(APITestCase):
         self.assertNotEqual(new_declared_plant.id, 99)
 
     @authenticate
-    def test_article_recalculated_on_replace(self):
-        """
-        Vérifier que l'article est recalculé avec un remplacement d'une demande
-        """
-        PopulationFactory(name="Population générale")
-
-        InstructionRoleFactory(user=authenticate.user)
-
-        declaration = DeclarationFactory()
-        declared_microorganism = DeclaredMicroorganismFactory(declaration=declaration, new_species="test", new=True)
-        declaration.assign_calculated_article()
-        declaration.save()
-
-        # on suppose que, avec les nouveaux ingrédients, la déclaration récoit un article 16
-        declaration.refresh_from_db()
-        self.assertEqual(declaration.calculated_article, Declaration.Article.ARTICLE_16)
-        plant = PlantFactory()
-
-        response = self.client.post(
-            reverse("api:declared_element_replace", kwargs={"pk": declared_microorganism.id, "type": "microorganism"}),
-            {"element": {"id": plant.id, "type": "plant"}},
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
-        declaration.refresh_from_db()
-        self.assertEqual(
-            declaration.calculated_article,
-            Declaration.Article.ARTICLE_15,
-            "L'article passe à 15 maintenant qu'il n'y a plus de nouveaux ingrédients",
-        )
-
-    @authenticate
     def test_part_created_on_accept_part(self):
         """
         Vérifier qu'une partie de plante est créée et autorisée quand on accepte une demande
@@ -2928,37 +2896,3 @@ class TestSingleDeclaredElementApi(APITestCase):
         declared_plant.refresh_from_db()
         self.assertEqual(declared_plant.request_status, Addable.AddableStatus.REPLACED)
         self.assertTrue(declared_plant.is_part_request)
-
-    @authenticate
-    def test_article_recalculated_on_accept_part(self):
-        """
-        Vérifier que l'article est recalculé avec une autorisation de partie de plante
-        """
-        InstructionRoleFactory(user=authenticate.user)
-
-        declaration = DeclarationFactory(status=Declaration.DeclarationStatus.AWAITING_INSTRUCTION)
-
-        plant = PlantFactory()
-        unknown_part = PlantPartFactory()
-        self.assertFalse(plant.plant_parts.through.objects.filter(plantpart=unknown_part).exists())
-
-        declared_plant = DeclaredPlantFactory(new=False, declaration=declaration, plant=plant, used_part=unknown_part)
-
-        declaration.assign_calculated_article()
-        declaration.save()
-
-        # on suppose que, avec les nouvelles parties de plantes, la déclaration récoit un article 16
-        declaration.refresh_from_db()
-        self.assertEqual(declaration.calculated_article, Declaration.Article.ARTICLE_16)
-
-        response = self.client.post(
-            reverse("api:declared_element_accept_part", kwargs={"pk": declared_plant.id, "type": "plant"}),
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
-        declaration.refresh_from_db()
-        self.assertEqual(
-            declaration.calculated_article,
-            Declaration.Article.ARTICLE_15,
-            "L'article passe à 15 maintenant qu'il n'y a plus de nouveaux ingrédients",
-        )

--- a/api/views/declaration/declared_element.py
+++ b/api/views/declaration/declared_element.py
@@ -194,16 +194,10 @@ class DeclaredElementActionAbstractView(APIView, ElementMappingMixin):
         element_to_save = self._update_element(element, request)
         element_to_save.save()
 
-        self._post_save_declared_element(element_to_save)
-
         return Response(self.type_serializer(element_to_save, context={"request": request}).data)
 
     @abc.abstractmethod
     def _update_element(self, element, request):
-        pass
-
-    @abc.abstractmethod
-    def _post_save_declared_element(self, element):
         pass
 
 
@@ -281,10 +275,6 @@ class DeclaredElementReplaceView(DeclaredElementActionAbstractView):
 
         return declared_element
 
-    def _post_save_declared_element(self, declared_element):
-        declared_element.declaration.assign_calculated_article()
-        declared_element.declaration.save()
-
 
 class DeclaredElementAcceptPartView(DeclaredElementActionAbstractView):
     def _update_element(self, element, request):
@@ -300,7 +290,3 @@ class DeclaredElementAcceptPartView(DeclaredElementActionAbstractView):
 
         element.request_status = self.type_model.AddableStatus.REPLACED
         return element
-
-    def _post_save_declared_element(self, declared_element):
-        declared_element.declaration.assign_calculated_article()
-        declared_element.declaration.save()


### PR DESCRIPTION
https://www.notion.so/incubateur-masa/Supprimer-le-changement-automatique-d-article-apr-s-remplacement-d-ingr-dient-24fde24614be80228558f446161ec497

Les vrais ajouts devraient garder l'article 16, et les autres devraient prendre le 15. Vu qu'on a du temps limité, on a choisit de laisser la gestion d'article aux instructrices.

Pas de changement visuel