### PR TITLE
Sauvegarder les filtres pour tous les tableaux instruction/visa

### DIFF
--- a/frontend/src/components/NewBepiasViews/ProductSection/InstructionResults.vue
+++ b/frontend/src/components/NewBepiasViews/ProductSection/InstructionResults.vue
@@ -108,8 +108,6 @@ import { useRouter } from "vue-router"
 import { useStorage } from "@vueuse/core"
 
 const router = useRouter()
-const previousQueryParams =
-  router.getPreviousRoute().value.name === "InstructionDeclarations" ? router.getPreviousRoute().value.query : {}
 
 const rules = computed(() => {
   if (decisionCategory.value !== "modify") return {}
@@ -204,7 +202,7 @@ const submitDecision = async () => {
   if (response.value.ok) {
     useToaster().addSuccessMessage("Votre décision a été prise en compte")
     clearLocalStorage()
-    router.push({ name: "InstructionDeclarations", query: previousQueryParams })
+    router.push({ name: "InstructionDeclarations" })
   }
 }
 </script>

--- a/frontend/src/components/NewBepiasViews/ProductSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/ProductSection/index.vue
@@ -55,8 +55,6 @@ import { useRouter } from "vue-router"
 import RequiresAnalysisReportNotice from "@/components/RequiresAnalysisReportNotice"
 
 const router = useRouter()
-const previousVisaQueryParams =
-  router.getPreviousRoute().value.name === "VisaDeclarations" ? router.getPreviousRoute().value.query : {}
 
 const props = defineProps({ declaration: Object, snapshots: Array, role: { type: String, default: "instruction" } })
 
@@ -71,7 +69,7 @@ const showComputedSubstances = computed(() => {
     .some((x) => x.requestStatus === "REPLACED" && x.element?.substances?.length)
 })
 
-const redirectToVisa = () => router.push({ name: "VisaDeclarations", query: previousVisaQueryParams })
+const redirectToVisa = () => router.push({ name: "VisaDeclarations" })
 
 const canInstruct = computed(() => props.declaration?.status === "ONGOING_INSTRUCTION")
 const canVisa = computed(() => props.declaration?.status === "ONGOING_VISA")

--- a/frontend/src/utils/storage.js
+++ b/frontend/src/utils/storage.js
@@ -1,0 +1,20 @@
+import { onMounted, nextTick } from "vue"
+import { useStorage } from "@vueuse/core"
+import { useRouter, useRoute, onBeforeRouteLeave } from "vue-router"
+
+export const useQueryStorage = (storageKey, additionalSetup = () => {}) => {
+  const router = useRouter()
+  const route = useRoute()
+  const savedQuery = useStorage(storageKey, {})
+
+  onMounted(() => {
+    if (savedQuery.value.page) {
+      additionalSetup(savedQuery)
+      nextTick().then(() => router.replace({ query: { ...savedQuery.value } }))
+    }
+  })
+
+  onBeforeRouteLeave(() => {
+    savedQuery.value = route.query
+  })
+}

--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -223,6 +223,7 @@ import CountryField from "@/components/fields/CountryField"
 import DoseFilterModal from "./DoseFilterModal"
 import DateFilterField from "./DateFilterField"
 import { toOptions } from "@/utils/forms.js"
+import { useQueryStorage } from "@/utils/storage"
 
 const store = useRootStore()
 store.fetchDeclarationFieldsData()
@@ -405,6 +406,8 @@ const galenicFormulationOptions = computed(() => toOptions(galenicFormulations.v
 const seeOverflow = ref(false)
 watch(activeAccordion, (x) => setTimeout(() => (seeOverflow.value = x === 0), 500))
 ///////////
+
+useQueryStorage("AdvancedSearchPage", (savedQuery) => (searchTerm.value = savedQuery.value?.recherche))
 </script>
 
 <style scoped>

--- a/frontend/src/views/AdvancedSearchResult/index.vue
+++ b/frontend/src/views/AdvancedSearchResult/index.vue
@@ -3,7 +3,7 @@
     <DsfrBreadcrumb
       :links="[
         { to: { name: 'DashboardPage' }, text: 'Tableau de bord' },
-        { to: previousRoute, text: 'Recherche avancée' },
+        { to: { name: 'AdvancedSearchPage' }, text: 'Recherche avancée' },
         { text: declaration?.name || 'Résultat' },
       ]"
     />
@@ -70,10 +70,6 @@ const isInstructor = computed(() => loggedUser.value?.globalRoles?.some((x) => x
 const isVisor = computed(() => loggedUser.value?.globalRoles?.some((x) => x.name === "VisaRole"))
 
 const router = useRouter()
-const previousRoute = computed(() => {
-  const previousRoute = router.getPreviousRoute().value
-  return previousRoute?.name === "AdvancedSearchPage" ? previousRoute : { name: "AdvancedSearchPage" }
-})
 
 const props = defineProps({
   declarationId: String,

--- a/frontend/src/views/InstructionDeclarationsPage/index.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/index.vue
@@ -108,7 +108,7 @@
 
 <script setup>
 import { useFetch } from "@vueuse/core"
-import { computed, watch, ref, onMounted, nextTick } from "vue"
+import { computed, watch, ref } from "vue"
 import { handleError } from "@/utils/error-handling"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import InstructionDeclarationsTable from "./InstructionDeclarationsTable"
@@ -117,8 +117,7 @@ import { getPagesForPagination } from "@/utils/components"
 import StatusFilter from "@/components/StatusFilter.vue"
 import { orderingOptions, articleOptionsWith15Subtypes } from "@/utils/mappings"
 import PaginationSizeSelect from "@/components/PaginationSizeSelect"
-import { useStorage } from "@vueuse/core"
-import { onBeforeRouteLeave } from "vue-router"
+import { useQueryStorage } from "@/utils/storage"
 
 const router = useRouter()
 const route = useRoute()
@@ -181,18 +180,7 @@ const search = () => {
   fetchSearchResults()
 }
 
-const savedQuery = useStorage("InstructionDeclarationsPage", {})
-
-onMounted(() => {
-  if (savedQuery.value.page) {
-    searchTerm.value = savedQuery.value.recherche
-    nextTick().then(() => router.replace({ query: { ...savedQuery.value } }))
-  }
-})
-
-onBeforeRouteLeave(() => {
-  savedQuery.value = route.query
-})
+useQueryStorage("InstructionDeclarationsPage", (savedQuery) => (searchTerm.value = savedQuery.value.recherche))
 </script>
 
 <style scoped>

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -79,6 +79,7 @@ import { useRoute, useRouter } from "vue-router"
 import { getPagesForPagination } from "@/utils/components"
 import { statusProps } from "@/utils/mappings"
 import MultiselectFilter from "@/components/MultiselectFilter"
+import { useQueryStorage } from "@/utils/storage"
 
 const router = useRouter()
 const route = useRoute()
@@ -157,4 +158,6 @@ const orderingOptions = [
     text: "Date limite de réponse (descendant)",
   },
 ]
+
+useQueryStorage("NewElementsPage")
 </script>

--- a/frontend/src/views/NewVisaPage/index.vue
+++ b/frontend/src/views/NewVisaPage/index.vue
@@ -64,11 +64,9 @@ const props = defineProps({ declarationId: String })
 const route = useRoute()
 const router = useRouter()
 
-const filterQueryParams =
-  router.getPreviousRoute().value?.name === "VisaDeclarations" ? router.getPreviousRoute().value.query : {}
 const breadcrumbLinks = [
   { to: { name: "DashboardPage" }, text: "Tableau de bord" },
-  { to: { name: "VisaDeclarations", query: filterQueryParams }, text: "Déclarations pour visa" },
+  { to: { name: "VisaDeclarations" }, text: "Déclarations pour visa" },
   { text: "Instruction" },
 ]
 

--- a/frontend/src/views/VisaDeclarationsPage/index.vue
+++ b/frontend/src/views/VisaDeclarationsPage/index.vue
@@ -68,6 +68,7 @@ import { getPagesForPagination } from "@/utils/components"
 import StatusFilter from "@/components/StatusFilter"
 import { orderingOptions, articleOptionsWith15Subtypes } from "@/utils/mappings"
 import PaginationSizeSelect from "@/components/PaginationSizeSelect"
+import { useQueryStorage } from "@/utils/storage"
 
 const router = useRouter()
 const route = useRoute()
@@ -107,6 +108,8 @@ const fetchSearchResults = async () => {
 }
 
 watch([page, filteredStatus, ordering, article, limit], fetchSearchResults)
+
+useQueryStorage("VisaDeclarationsPage")
 </script>
 
 <style scoped>


### PR DESCRIPTION
La suite de #2339 

Cette PR fait que tous les tableaux instruction/visa sauvegardent les derniers filtres utilisés.

Maintenant les pages suivantes ont cette fonctionnalité :

<img width="1984" height="1348" alt="Screenshot 2025-08-28 at 13-21-40 Tableau de bord - Compl'Alim" src="https://github.com/user-attachments/assets/db182a5e-30ae-438c-a405-c8d0a893c70d" />

C'est hyper facile d'ajouter cette fonctionnalité maintenant aux vues, alors si jamais besoin de la rajouter aux autres pages, pas de pb.