### PR TITLE
:bug: Fix pour les déclarations avec des nouveaux ingrédients

### DIFF
--- a/frontend/src/components/RequiresAnalysisReportNotice.vue
+++ b/frontend/src/components/RequiresAnalysisReportNotice.vue
@@ -22,6 +22,6 @@ const ingredientsRequiringAnalysisReport = computed(() => {
       props.declaration.declaredIngredients,
       props.declaration.declaredSubstances
     )
-    .filter((x) => x.element.requiresAnalysisReport)
+    .filter((x) => x.element?.requiresAnalysisReport)
 })
 </script>


### PR DESCRIPTION
dans #2340 j'ai oublié qu'on peut avoir des demandes d'ajout qui n'ont pas d'`element`. Cette PR repare le bug