### PR TITLE
Calculation article : ne pas appliquer l'article 16 pour les substances calculées non-autorisées

### DIFF
--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -577,7 +577,6 @@ class Declaration(Historisable, TimeStampable):
                 any(self.declared_plants.filter(plant__status=IngredientStatus.NOT_AUTHORIZED))
                 or any(self.declared_microorganisms.filter(microorganism__status=IngredientStatus.NOT_AUTHORIZED))
                 or any(self.declared_substances.filter(substance__status=IngredientStatus.NOT_AUTHORIZED))
-                or any(self.computed_substances.filter(substance__status=IngredientStatus.NOT_AUTHORIZED))
                 or any(self.declared_ingredients.filter(ingredient__status=IngredientStatus.NOT_AUTHORIZED))
             )
 


### PR DESCRIPTION
https://www.notion.so/incubateur-masa/Ne-pas-assigner-article-16-pour-les-substances-calcul-es-25dde24614be8029963af8858aa776cb?source=copy_link

Pas de changement visuel