### PR TITLE
:bug: Réparer bug ou une modif partie de plante non-auto vers partie auto n'est pas pris en compte

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -164,6 +164,7 @@ class DeclaredPlantSerializer(DeclaredIngredientCommonSerializer):
             "preparation",
             "is_part_request",
         )
+        read_only_fields = ("is_part_request",)
 
 
 class DeclaredMicroorganismSerializer(DeclaredIngredientCommonSerializer):


### PR DESCRIPTION
lié https://www.notion.so/incubateur-masa/Pb-de-hausse-de-nombre-de-d-clarations-suite-au-changement-de-r-gles-partie-de-plante-24dde24614be80bb8c52df0cb4d2f1f5?source=copy_link

En gros, de temps en temps les déclarations sont soumises avec une partie de plante autorisée mais elle est traitée comme une demande d'ajout.

Comment reproduire le bug :

- Ajouter une plante avec une nouvelle partie
- Sauvegarder la déclaration (par ex en passant à la prochaine étape)
- Revenir à l'onglet compo
- Selectionner une partie autorisée sur la même plante
- Sauvegarder

:arrow_right: Bug : dans l'onglet soumettre on voit que la partie est toujours indiquée comme nouvelle, même si dans l'onglet compo ce n'est pas le cas.

La raison : on reprends le payload existant, on le modifie, et après on fait un PUT avec toutes les données. Alors `is_part_request` est copié depuis l'ancienne valeur.

Ce n'est pas un pb à l'inverse au cause d'un autre bug : la logique de `DeclaredListSerializer` ne marche pas comme prévu, on perds l'id dans `validated_data` car on n'a pas `IdPassthrough` sur les serializers des declared elements. Alors les elements sont toujours recrée avec chaque requête PUT.

Dans le cas où on modifie une partie autorisée à une partie non-autorisée, on passe alors par la logique `DeclaredPlant.save` definie dans `models/declaration.py`, et l'ajout est marquée comme `is_part_request`.