### PR TITLE
Enlève les filtres admin nécessitant des requêtes longues

### DIFF
--- a/data/admin/declaration.py
+++ b/data/admin/declaration.py
@@ -271,7 +271,7 @@ class DeclarationForm(ChangeReasonFormMixin):
 class DeclarationAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
     form = DeclarationForm
     list_display = ("id", "name", "status", "company", "author")
-    list_filter = ("status", "company", "author")
+    list_filter = ("status",)
     list_select_related = ["author", "company"]
     readonly_fields = ("declared_in_teleicare", "teleicare_declaration_number")
 


### PR DESCRIPTION
Les filtres dans l'admin "entreprise" et  "auteur" font une requête complète des deux tables pour afficher les noms dans la colonne à droite. Ces filtres ne sont pas utilisables (de leur nombre de résultats) et nécessitent des requêtes longues.

Cette PR enlève ces filtres.

Le filtre restant est celui du statut :

<img width="463" height="414" alt="image" src="https://github.com/user-attachments/assets/7f70a4f0-8569-47ac-a0c0-69879b6c84fc" />


Closes #2380