### PR TITLE
RGAA 3.1 : Dans chaque page web, l’information ne doit pas être donnée uniquement par la couleur. Cette règle est-elle respectée ?

### DIFF
--- a/frontend/src/components/ElementCommentModal.vue
+++ b/frontend/src/components/ElementCommentModal.vue
@@ -24,14 +24,12 @@
         </ul>
       </div>
     </DsfrModal>
-    <DsfrTooltip ref="tooltip" :onHover="true" :content="tooltipContent" class="tooltip-comments">
-      <button @click="infoModalOpened = true" :disabled="!hasInformationToShow">
-        <v-icon
-          :name="hasInformationToShow ? 'ri-chat-4-line' : 'ri-chat-off-line'"
-          :color="hasInformationToShow ? 'rgb(0, 0, 145)' : '#AAA'"
-        ></v-icon>
-      </button>
-    </DsfrTooltip>
+    <button @click="infoModalOpened = true" :disabled="!hasInformationToShow" :title="moreInfoButtonTitle">
+      <v-icon
+        :name="hasInformationToShow ? 'ri-chat-4-line' : 'ri-chat-off-line'"
+        :color="hasInformationToShow ? 'rgb(0, 0, 145)' : '#AAA'"
+      ></v-icon>
+    </button>
   </div>
 </template>
 
@@ -66,16 +64,16 @@ const maxQuantitiesString = computed(() => stringifyMaxQuantities(maxQuantities.
 
 const constitutingSubstances = computed(() => element.value?.substances)
 
-const tooltipContent = computed(() => {
-  let content = ""
+const moreInfoButtonTitle = computed(() => {
+  if (!hasInformationToShow.value) return "Pas d'informations supplementaires sur l'ingrédient " + elementName.value
+  let content = "Cliquez pour voir plus d'informations sur l'ingrédient " + elementName.value + ". "
   if (hasMaxQuantities.value) content += `Quantités maximales : ${maxQuantitiesString.value}. `
   if (element.value?.publicComments) content += `Commentaires : ${element.value?.publicComments}. `
   if (element.value?.privateComments && !props.hidePrivateComments)
     content += `Commentaires privés : ${element.value?.privateComments}. `
-  content = content || "Pas de commentaires. "
 
   if (constitutingSubstances.value && constitutingSubstances.value.length)
-    content += "Cliquez pour plus d'informations sur les substances contenues."
+    content += "Cet ingrédient contient des substances."
 
   return content
 })
@@ -89,15 +87,3 @@ const hasInformationToShow = computed(
     constitutingSubstances.value?.length
 )
 </script>
-
-<style scoped>
-@reference "../styles/index.css";
-
-/* Il est nécessaire de surcharger certains styles di DSFRTooltip car un element a[href] est ajouté */
-div :deep(.tooltip-comments) {
-  @apply bg-none!;
-  @apply flex!;
-  @apply w-full!;
-  @apply justify-center!;
-}
-</style>

--- a/frontend/src/views/FaqPage.vue
+++ b/frontend/src/views/FaqPage.vue
@@ -261,9 +261,9 @@
           </p>
           <p>
             <span aria-hidden="true">💡</span>
-            L'icône d'une bulle de texte en couleur bleue,
+            Le bouton "Cliquez pour voir plus d'informations...", identifié par une bulle de texte en couleur bleue,
             <v-icon name="ri-chat-4-line" color="rgb(0, 0, 145)"></v-icon>
-            , vous permet d'accéder aux informations disponibles sur chaque substance, telles que la quantité maximale
+            , vous permet d'accéder aux informations disponibles sur chaque ingrédient, telles que la quantité maximale
             autorisée ou les recommandations spécifiques pour certaines populations. Quand l'icône est gris et barrée,
             <v-icon name="ri-chat-off-line" color="#AAA"></v-icon>
             , il n'y a pas des informations supplementaires à afficher.


### PR DESCRIPTION
L'audit accessibilité a trouvé que dans notre FAQ il y a du texte qui n'est pas assez explicite.

Avant

<img width="2398" height="158" alt="Screenshot 2025-09-11 at 16-20-08 Foire aux questions - Compl'Alim" src="https://github.com/user-attachments/assets/4e389857-4b53-4258-a87a-68c7f9959baa" />

Ici, on parle d'icône "commentaire" mais on n'affiche pas ce texte nulle part dans l'onglet composition, alors dans leur avis le [critère 3.1](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#3.1) "Dans chaque page web, l’[information](https://accessibilite.numerique.gouv.fr/methode/glossaire/#information-donnee-par-la-couleur) ne doit pas être donnée uniquement par la couleur. Cette règle est-elle respectée ?" n'est pas respectée. 

C'est discutable mais en tout cas ce texte pourrait être amélioré pour les personnes qui utilisent des téchnologies d'assistance, ainsi que les personnes qui n'identifie pas l'icône comme une icône "commentaire". Elle a aussi suggéré d'ajouter l'icône elle-même ainsi que la version barrée pour être le plus aidant possible.

Après

<img width="2380" height="214" alt="Screenshot 2025-09-11 at 16-32-40 Foire aux questions - Compl'Alim" src="https://github.com/user-attachments/assets/c62dcf83-0f73-446f-9ab1-5624ea5e352a" />

Cette PR aussi améliore l'implementation de ce bouton/tooltip. L'audit a retrouvé une anomalié pour le critère 7.1 aussi :

> Le bouton est mal implémenté, il y a deux fonctionnalité interactive au sein du même composant : un lien programmé comme un bouton (rôle non pertinent) contrôlant l'affichage d'une infobulle ET un bouton d'ouverture de modale. Aucun de ces composants n'a de nom accessible, l'image de décoration n'est pas correctement ignorée par les TA. Pour corriger : revoir l'implémentation du composant en deux éléments distincts:
> 1. bouton d'ouverture de modale à l'intitulé accessible explicite hors-contexte (via sr-only) + attribut title pertinent pour afficher le nom du bouton
> 2. infobulle ( si nécessaire)

En enlevant l'infobulle et rajoutant un `title` au bouton, on garde la même fonctionnalité de survol et plus des infos en modal, mais plus accessible aux utilisateurs. J'ai rajouté aussi le nom de l'ingrédient dans le `title` car il faut que c'est explicite hors contexte (par exemple dans une liste de boutons sans voir la présentation de l'écran).

Exemples de la nouvelle presentation

<img width="1506" height="397" alt="Screenshot from 2025-09-11 16-43-43" src="https://github.com/user-attachments/assets/1280b162-1b7b-4b53-a873-cd94eca84663" />
<img width="1506" height="397" alt="Screenshot from 2025-09-11 16-44-05" src="https://github.com/user-attachments/assets/e80d9a52-4ad0-4cef-ada8-256cae1cae50" />
