### PR TITLE
RGAA 5.3 : Pour chaque tableau de mise en forme, le contenu linéarisé reste-t-il compréhensible ?

### DIFF
--- a/frontend/src/components/ProductInfoSegment/SummaryInfoSegment.vue
+++ b/frontend/src/components/ProductInfoSegment/SummaryInfoSegment.vue
@@ -1,8 +1,8 @@
 <template>
-  <div v-if="props.value" class="sm:flex border-b last:border-0 py-1 gap-4">
-    <div class="sm:flex-[0_0_30%] font-bold sm:text-right">{{ props.label }}</div>
-    <div class="sm:flex-auto">{{ props.value }}</div>
-  </div>
+  <tr v-if="props.value" class="sm:flex border-b last:border-0 py-1 gap-4">
+    <th scope="row" class="sm:flex-[0_0_30%] font-bold sm:text-right">{{ props.label }}</th>
+    <td class="sm:flex-auto">{{ props.value }}</td>
+  </tr>
 </template>
 
 <script setup>

--- a/frontend/src/components/ProductInfoSegment/index.vue
+++ b/frontend/src/components/ProductInfoSegment/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <table role="presentation" class="w-full">
     <SummaryInfoSegment
       v-if="!!payload.teleicareDeclarationNumber"
       label="Identifiant Teleicare"
@@ -20,7 +20,7 @@
     <SummaryInfoSegment label="Conditionnement" :value="payload.conditioning" />
     <SummaryInfoSegment label="Durabilité minimale / DLUO (en mois)" :value="payload.minimumDuration" />
     <SummaryInfoSegment label="Objectifs / effets" :value="effectsNames" />
-  </div>
+  </table>
 </template>
 
 <script setup>


### PR DESCRIPTION
https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#5.3

Proposition de l'audit:

> Le tableau de présentation n'est pas correctement structuré. Pour corriger : structurer le tableau de présentation avec des balises `<table role="presentation">`, `<tr> `et `<th>`

Changement visuel très mineur

Je ne connaît pas d'autre tableau comme ça dans notre code à modifier

Avant

<img width="2206" height="970" alt="Screenshot 2025-09-11 at 17-04-28 Soumettre - Déclaration « test text change » - Compl'Alim" src="https://github.com/user-attachments/assets/136dd4a9-a772-4ee8-9206-5189ef39b097" />

Après

<img width="2206" height="970" alt="Screenshot 2025-09-11 at 17-06-26 Soumettre - Déclaration « test text change » - Compl'Alim" src="https://github.com/user-attachments/assets/36cb1bdd-2f5d-4226-9e76-84b0b6aec140" />
