### PR TITLE
Déclaration : afficher une alerte aux déclarants sur l'onglet pièces jointes pour les préparations avec de l'alcool

### DIFF
--- a/api/serializers/preparation.py
+++ b/api/serializers/preparation.py
@@ -11,5 +11,6 @@ class PreparationSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "name_en",
+            "contains_alcohol",
         ]
         read_only_fields = fields

--- a/frontend/src/views/ProducerFormPage/AttachmentTab.vue
+++ b/frontend/src/views/ProducerFormPage/AttachmentTab.vue
@@ -2,6 +2,17 @@
   <div>
     <DsfrAlert class="mb-4" small type="error" v-if="validationError">{{ validationError }}</DsfrAlert>
     <SectionTitle title="Étiquetage" sizeTag="h6" icon="ri-price-tag-2-fill" />
+    <DsfrAlert
+      v-if="containsAlcohol"
+      class="mb-4"
+      title="Votre complément alimentaire contient de l'alcool en tant qu'ingrédient"
+      type="warning"
+    >
+      <p>
+        Avez-vous bien pensé à porter l'avertissement "déconseillé aux enfants de moins de 12 ans, femmes enceintes et
+        allaitantes" sur votre étiquetage ?
+      </p>
+    </DsfrAlert>
     <DsfrInputGroup>
       <DsfrFileUpload
         label="Veuillez nous transmettre l'étiquetage de votre produit (format PDF ou image)"
@@ -36,6 +47,8 @@
 
 <script setup>
 import { ref, computed } from "vue"
+import { useRootStore } from "@/stores/root"
+import { storeToRefs } from "pinia"
 import FileGrid from "./FileGrid"
 import SectionTitle from "@/components/SectionTitle"
 import RequiresAnalysisReportNotice from "@/components/RequiresAnalysisReportNotice"
@@ -43,6 +56,8 @@ import RequiresAnalysisReportNotice from "@/components/RequiresAnalysisReportNot
 const acceptedTypes = ["image/jpeg", "image/gif", "image/png", "application/pdf"]
 const props = defineProps(["externalResults"])
 const payload = defineModel()
+
+const { preparations } = storeToRefs(useRootStore())
 
 const needsEuProof = computed(() => {
   return []
@@ -120,4 +135,10 @@ const toBase64 = (file) => {
     reader.onerror = reject
   })
 }
+
+const containsAlcohol = computed(() => {
+  const plantPreparationsUsed = payload.value.declaredPlants.map((plant) => plant.preparation)
+  const preparationsInfo = preparations.value.filter((p) => plantPreparationsUsed.includes(p.id))
+  return preparationsInfo.some((p) => p.containsAlcohol)
+})
 </script>


### PR DESCRIPTION
Cible : Pour éviter les aller-retours sur l'instruction de visa sur la manque de ces informations sur l’étiquetage du produit.

Il faut vérifier que toutes les préparations avec l'alcool sont bien marqués dans l'admin.

Cette PR ajoute les infos `contains_alcohol` au serializer PreparationSerializer. Cet endpoint est ouvert, mais je crois que ces infos ne sont pas sensibles ?

<img width="2506" height="918" alt="Screenshot 2025-09-16 at 15-46-18 Pièces jointes - Déclaration « test text change » - Compl'Alim" src="https://github.com/user-attachments/assets/a7e998de-ce14-4829-a4fb-30d3e774ed87" />
