### PR TITLE
RGAA 5.4 : Pour chaque tableau de données ayant un titre, le titre est-il correctement associé au tableau de données ?

### DIFF
--- a/frontend/src/components/ComputedSubstancesInfo.vue
+++ b/frontend/src/components/ComputedSubstancesInfo.vue
@@ -17,13 +17,15 @@
         </li>
       </ul>
     </DsfrAlert>
-    <SubstancesTable v-model="payload" readonly />
+    <SubstancesTable v-model="payload" readonly :title="tableTitle" :noCaption="false" />
   </div>
 </template>
 
 <script setup>
 import { computed } from "vue"
 import SubstancesTable from "@/components/SubstancesTable"
+
+defineProps(["tableTitle"])
 
 const payload = defineModel()
 

--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -25,8 +25,7 @@
         :showElementAuthorization="showElementAuthorization"
       />
 
-      <p class="font-bold mt-8" v-if="payload.computedSubstances.length">Substances contenues dans la composition :</p>
-      <ComputedSubstancesInfo v-model="payload" />
+      <ComputedSubstancesInfo v-model="payload" tableTitle="Substances contenues dans la composition" class="mt-8" />
 
       <h3 class="fr-h6 mt-8!">
         Adresse sur l'étiquetage

--- a/frontend/src/components/ElementDoses.vue
+++ b/frontend/src/components/ElementDoses.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
-    <h2 class="fr-h6 mb-1!">Quantités maximales autorisées par population</h2>
-    <DsfrTable :headers="maxQuantityHeaders" :rows="maxQuantityRows" />
+    <!-- <h2 class="fr-h6 mb-1!">Quantités maximales autorisées par population</h2> -->
+    <DsfrTable
+      :headers="maxQuantityHeaders"
+      :rows="maxQuantityRows"
+      title="Quantités maximales autorisées par population"
+    />
   </div>
 </template>
 
@@ -31,3 +35,12 @@ const quantityCell = (row) => {
     : row.maxQuantity?.toLocaleString("fr-FR") + " " + props.unit
 }
 </script>
+
+<style scoped>
+@reference "../styles/index.css";
+
+.fr-table :deep(.caption) {
+  @apply w-full;
+  font-size: 1.25rem;
+}
+</style>

--- a/frontend/src/components/NewBepiasViews/ProductSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/ProductSection/index.vue
@@ -13,8 +13,11 @@
       <SectionHeader id="composition-produit" icon="ri-capsule-fill" text="Composition produit" />
       <CompositionInfo :useAccordions="true" :showElementAuthorization="true" :model-value="declaration" />
       <div v-if="showComputedSubstances">
-        <p class="font-bold mt-8">Substances contenues dans la composition :</p>
-        <ComputedSubstancesInfo :model-value="declaration" />
+        <ComputedSubstancesInfo
+          :model-value="declaration"
+          tableTitle="Substances contenues dans la composition"
+          class="mt-8"
+        />
       </div>
       <p class="font-bold mt-8" v-else>Pas de substances calculées à partir de la composition</p>
 

--- a/frontend/src/components/SubstancesTable/index.vue
+++ b/frontend/src/components/SubstancesTable/index.vue
@@ -130,4 +130,8 @@ watch(
 .fr-table :deep(td:nth-child(4)) {
   @apply max-w-48;
 }
+/* par defaut DSFR rend .caption 1.5rem */
+.fr-table :deep(.caption) {
+  font-size: 1rem;
+}
 </style>

--- a/frontend/src/views/DeclarationIndividualPage/ProductControlSection.vue
+++ b/frontend/src/views/DeclarationIndividualPage/ProductControlSection.vue
@@ -7,8 +7,11 @@
     <SectionHeader id="composition-produit" icon="ri-capsule-fill" text="Composition produit" />
     <CompositionInfo :useAccordions="true" :showElementAuthorization="true" :model-value="declaration" />
     <div v-if="showComputedSubstances">
-      <p class="font-bold mt-8">Substances contenues dans la composition :</p>
-      <ComputedSubstancesInfo :model-value="declaration" />
+      <ComputedSubstancesInfo
+        :model-value="declaration"
+        tableTitle="Substances contenues dans la composition"
+        class="mt-8"
+      />
     </div>
     <p class="font-bold mt-8" v-else>Pas de substances calculées à partir de la composition</p>
 

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -24,8 +24,13 @@
         </DsfrTabContent>
 
         <DsfrTabContent panel-id="history-content" tab-id="history">
-          <div class="-my-8 mb-4">
-            <DsfrTable :headers="headers" :rows="historyDataDedup" />
+          <div class="-my-4 mb-4">
+            <DsfrTable
+              :headers="headers"
+              :rows="historyDataDedup"
+              title="Historique de l'ingrédient"
+              :no-caption="true"
+            />
           </div>
           <p v-if="element && element.originDeclaration">
             <router-link :to="{ name: 'InstructionPage', params: { declarationId: element.originDeclaration } }">

--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -103,7 +103,12 @@
       </ul>
       <!-- Date de dernière mise à jour de la donnée -->
       <DsfrAccordion title="Historique de l'ingrédient" id="accordion-history">
-        <DsfrTable :headers="historyHeaders" :rows="historyDataDedup"></DsfrTable>
+        <DsfrTable
+          :headers="historyHeaders"
+          :rows="historyDataDedup"
+          title="Historique de l'ingrédient"
+          :no-caption="true"
+        ></DsfrTable>
       </DsfrAccordion>
 
       <div v-if="isInstructor" class="text-right mt-4">

--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -65,7 +65,7 @@
         title="Dosage total des substances actives"
         content="Ce tableau présente les substances actives identifiées dans les ingrédients que vous avez sélectionnés. Une même substance pouvant être introduite par plusieurs sources, la quantité totale par dose journalière recommandée (DJR) est demandée pour certaines substances faisant l'objet d'une règlementation spécifique ou impliquant un risque."
       />
-      <SubstancesTable :hidePrivateComments="true" v-model="payload" />
+      <SubstancesTable :hidePrivateComments="true" v-model="payload" title="Substances actives" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#5.4

On n'avait pas utilisé `title` sur tout les tableaux car c'est difficile d'appliquer le style voulu. Je l'ai ajouté pour ne pas avoir des `caption`s vides et j'ai appliqué le style manuellement pour éviter des changements d'UI.