### PR TITLE
RGAA 8.6 : Pour chaque page web ayant un titre de page, ce titre est-il pertinent ?

### DIFF
--- a/frontend/src/utils/document.js
+++ b/frontend/src/utils/document.js
@@ -1,4 +1,8 @@
-export const setDocumentTitle = (parts) => {
+// multiPage est un objet avec: number, total, term
+export const setDocumentTitle = (parts, multiPage) => {
+  if (multiPage && multiPage.total > 1) {
+    parts.splice(1, 0, `${multiPage.term} ${multiPage.number} sur ${multiPage.total}`)
+  }
   parts.push("Compl'Alim")
   document.title = parts.join(" - ")
 }

--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -224,6 +224,7 @@ import DoseFilterModal from "./DoseFilterModal"
 import DateFilterField from "./DateFilterField"
 import { toOptions } from "@/utils/forms.js"
 import { useQueryStorage } from "@/utils/storage"
+import { setDocumentTitle } from "@/utils/document"
 
 const store = useRootStore()
 store.fetchDeclarationFieldsData()
@@ -373,6 +374,11 @@ const { response, data, isFetching, execute } = useFetch(apiUrl, { headers: { Ac
 watch(route, async () => {
   await execute()
   if (response?.value) await handleError(response) // Utile pour éviter des traiter les NS_BINDING_ABORTED de Firefox
+  setDocumentTitle(["Recherche avancée"], {
+    number: page.value,
+    total: pages.value.length,
+    term: "page",
+  })
 })
 
 // Remplissage d'options dans les champs select

--- a/frontend/src/views/BlogHomePage.vue
+++ b/frontend/src/views/BlogHomePage.vue
@@ -41,6 +41,7 @@ import BlogCard from "@/components/BlogCard"
 import { useFetch } from "@vueuse/core"
 import { handleError } from "@/utils/error-handling"
 import { getPagesForPagination } from "@/utils/components"
+import { setDocumentTitle } from "@/utils/document"
 
 const route = useRoute()
 const router = useRouter()
@@ -66,6 +67,11 @@ const { data, response, execute, isFetching } = useFetch(url, { immediate: false
 const fetchCurrentPage = async () => {
   await execute()
   await handleError(response)
+  setDocumentTitle(["Articles de blog"], {
+    number: page.value,
+    total: pages.value.length,
+    term: "page",
+  })
 }
 
 // Route management

--- a/frontend/src/views/CompanyDeclarationsPage/index.vue
+++ b/frontend/src/views/CompanyDeclarationsPage/index.vue
@@ -100,6 +100,7 @@ import CompanyDeclarationsTable from "./CompanyDeclarationsTable"
 import ProgressSpinner from "@/components/ProgressSpinner"
 import StatusFilter from "@/components/StatusFilter.vue"
 import { orderingOptionsPro } from "@/utils/mappings"
+import { setDocumentTitle } from "@/utils/document"
 
 const route = useRoute()
 const store = useRootStore()
@@ -151,6 +152,11 @@ const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
   await execute()
   await handleError(response)
+  setDocumentTitle(["Les déclarations de mon entreprise"], {
+    number: page.value,
+    total: pages.value.length,
+    term: "page",
+  })
 }
 
 const search = () => {

--- a/frontend/src/views/CompanySearchPage/index.vue
+++ b/frontend/src/views/CompanySearchPage/index.vue
@@ -103,6 +103,7 @@ import ControlCompanyTable from "./ControlCompanyTable"
 import jsonDepartments from "@/utils/departments.json"
 import { allActivities } from "@/utils/mappings"
 import PaginatedExcelDownload from "@/components/PaginatedExcelDownload"
+import { setDocumentTitle } from "@/utils/document"
 
 const MAX_EXPORT_RESULTS = 2000
 
@@ -148,6 +149,11 @@ const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
   await execute()
   await handleError(response)
+  setDocumentTitle(["Les entreprises"], {
+    number: page.value,
+    total: pages.value.length,
+    term: "page",
+  })
 }
 
 // Export Excel

--- a/frontend/src/views/DashboardPage/index.vue
+++ b/frontend/src/views/DashboardPage/index.vue
@@ -35,6 +35,7 @@ import { storeToRefs } from "pinia"
 import ActionGrid from "./ActionGrid"
 import RoleBarBlock from "./RoleBarBlock"
 import { useRoute, useRouter } from "vue-router"
+import { setDocumentTitle } from "@/utils/document"
 
 const store = useRootStore()
 const router = useRouter()
@@ -69,6 +70,10 @@ onMounted(redirectIfInvalidCompany)
 watch(route, redirectIfInvalidCompany)
 
 const onChangeCompany = (id) => router.push({ query: { company: id } })
+
+watch(company, () => {
+  setDocumentTitle(["Tableau de bord", company.value.socialName])
+})
 
 const supervisorActions = computed(() => [
   {

--- a/frontend/src/views/DeclarationsHomePage/index.vue
+++ b/frontend/src/views/DeclarationsHomePage/index.vue
@@ -111,6 +111,7 @@ import { getPagesForPagination } from "@/utils/components"
 import { orderingOptionsPro } from "@/utils/mappings"
 import PaginationSizeSelect from "@/components/PaginationSizeSelect"
 import StatusFilter from "@/components/StatusFilter"
+import { setDocumentTitle } from "@/utils/document"
 
 const store = useRootStore()
 const { loggedUser } = storeToRefs(store)
@@ -169,6 +170,11 @@ const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
   await execute()
   await handleError(response)
+  setDocumentTitle(["Mes déclarations"], {
+    number: page.value,
+    total: pages.value.length,
+    term: "page",
+  })
 }
 
 const search = () => {

--- a/frontend/src/views/ElementSearchResultsPage/index.vue
+++ b/frontend/src/views/ElementSearchResultsPage/index.vue
@@ -93,7 +93,11 @@ const { data, response, isFetching, execute } = useFetch(
 const fetchSearchResults = async () => {
   await execute()
   await handleError(response)
-  setDocumentTitle([currentSearch.value, "Résultats de recherche"])
+  setDocumentTitle([currentSearch.value, "Résultats de recherche"], {
+    number: page.value,
+    total: pages.value.length,
+    term: "page",
+  })
 }
 
 const goToSelectedOption = (option) => {

--- a/frontend/src/views/InstructionDeclarationsPage/index.vue
+++ b/frontend/src/views/InstructionDeclarationsPage/index.vue
@@ -118,6 +118,7 @@ import StatusFilter from "@/components/StatusFilter.vue"
 import { orderingOptions, articleOptionsWith15Subtypes } from "@/utils/mappings"
 import PaginationSizeSelect from "@/components/PaginationSizeSelect"
 import { useQueryStorage } from "@/utils/storage"
+import { setDocumentTitle } from "@/utils/document"
 
 const router = useRouter()
 const route = useRoute()
@@ -168,6 +169,11 @@ const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
   await execute()
   await handleError(response)
+  setDocumentTitle(["Instruction"], {
+    number: page.value,
+    total: pages.value.length,
+    term: "page",
+  })
 }
 
 watch(

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -80,6 +80,7 @@ import { getPagesForPagination } from "@/utils/components"
 import { statusProps } from "@/utils/mappings"
 import MultiselectFilter from "@/components/MultiselectFilter"
 import { useQueryStorage } from "@/utils/storage"
+import { setDocumentTitle } from "@/utils/document"
 
 const router = useRouter()
 const route = useRoute()
@@ -113,6 +114,11 @@ const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
   await execute()
   await handleError(response)
+  setDocumentTitle(["Nouveaux ingrédients"], {
+    number: page.value,
+    total: pages.value.length,
+    term: "page",
+  })
 }
 
 watch([page, statusFilter, typeFilter, declarationStatusFilter, limit, ordering], fetchSearchResults)

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -99,7 +99,7 @@ import StatusChangeErrorDisplay from "./StatusChangeErrorDisplay"
 import TabStepper from "@/components/TabStepper"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
-import { ref, computed, watch } from "vue"
+import { ref, computed, watch, onMounted } from "vue"
 import ProductTab from "./ProductTab"
 import CompositionTab from "./CompositionTab"
 import SummaryTab from "./SummaryTab"
@@ -354,8 +354,18 @@ const takeDeclaration = async () => {
 const onWithdrawal = () => router.replace({ name: "DeclarationsHomePage", query: { status: "WITHDRAWN,AUTHORIZED" } })
 
 const setDocumentTitleForTab = (tabIdx, fromData) => {
-  const declarationTitle = isNewDeclaration.value ? "Nouvelle démarche" : `Déclaration « ${fromData.value.name} »`
-  setDocumentTitle([titles.value[tabIdx].title, declarationTitle])
+  let declarationTitle = isNewDeclaration.value ? "Nouvelle démarche" : `Déclaration « ${fromData.value.name} »`
+  if (readonly.value) declarationTitle = `Détails de ma déclaration « ${fromData.value.name} »`
+  setDocumentTitle(
+    [titles.value[tabIdx].title, declarationTitle],
+    readonly.value
+      ? undefined
+      : {
+          number: tabIdx + 1,
+          total: titles.value.length,
+          term: "étape",
+        }
+  )
 }
 
 watch(
@@ -365,6 +375,8 @@ watch(
     setDocumentTitleForTab(selectedTabIndex.value, payload)
   }
 )
+
+onMounted(() => setDocumentTitleForTab(selectedTabIndex.value, payload))
 
 const performDuplication = (originalDeclaration) => {
   // Prendre uniquement les champs pertinents. C'est préférable d'utiliser une

--- a/frontend/src/views/VisaDeclarationsPage/index.vue
+++ b/frontend/src/views/VisaDeclarationsPage/index.vue
@@ -69,6 +69,7 @@ import StatusFilter from "@/components/StatusFilter"
 import { orderingOptions, articleOptionsWith15Subtypes } from "@/utils/mappings"
 import PaginationSizeSelect from "@/components/PaginationSizeSelect"
 import { useQueryStorage } from "@/utils/storage"
+import { setDocumentTitle } from "@/utils/document"
 
 const router = useRouter()
 const route = useRoute()
@@ -105,6 +106,11 @@ const { response, data, isFetching, execute } = useFetch(url).get().json()
 const fetchSearchResults = async () => {
   await execute()
   await handleError(response)
+  setDocumentTitle(["Visa"], {
+    number: page.value,
+    total: pages.value.length,
+    term: "page",
+  })
 }
 
 watch([page, filteredStatus, ordering, article, limit], fetchSearchResults)


### PR DESCRIPTION
Retour audit :

> Le titre de la page n'est pas explicite. Pour corriger : ajouter une information indiquant le numéro de l'étape en cours.
> ex de correction:
>Soumettre - étape 3 sur 4 - Nouvelle déclaration - Compl'Alim

Ça rend l'historique dans le navigateur plus facile à comprendre - mais surtout pour les pages comme résultats de recherche.

TODO: ajouter une indication quand on ajout un nouvel ingrédient que ça va ajouter un étape dans le parcours (pour ne pas avoir des confusions quand le total change dans le titre)