### PR TITLE
Encodage des caractères spéciaux dans la recherche SD/ANSES

### DIFF
--- a/api/utils/filters.py
+++ b/api/utils/filters.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import unquote
 
 from django.db.models import Q
 
@@ -132,12 +133,12 @@ class MultiFieldSearchFilter(BaseFilterBackend):
         company = request.query_params.get("search_company")
 
         if name:
-            queryset = queryset.filter(name__unaccent__icontains=name)
+            queryset = queryset.filter(name__unaccent__icontains=unquote(name))
 
         if brand:
-            queryset = queryset.filter(brand__unaccent__icontains=brand)
+            queryset = queryset.filter(brand__unaccent__icontains=unquote(brand))
 
         if company:
-            queryset = queryset.filter(company__social_name__unaccent__icontains=company)
+            queryset = queryset.filter(company__social_name__unaccent__icontains=unquote(company))
 
         return queryset

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
@@ -207,14 +207,14 @@ const commonApiParams = computed(() => {
   if (ordering.value) apiParams += `&ordering=${ordering.value}`
   if (simplifiedStatus.value) apiParams += `&simplifiedStatus=${simplifiedStatus.value}`
   if (surveillanceOnly.value) apiParams += `&surveillanceOnly=${surveillanceOnly.value}`
-  if (searchTerm.value) apiParams += `&search=${searchTerm.value}`
+  if (searchTerm.value) apiParams += `&search=${encodeURIComponent(searchTerm.value)}`
   if (props.companyId) apiParams += `&company=${props.companyId}`
   if (population.value) apiParams += `&population=${population.value}`
   if (condition.value) apiParams += `&condition=${condition.value}`
   if (galenicFormulation.value) apiParams += `&galenic_formulation=${galenicFormulation.value}`
-  if (searchTermProduct.value) apiParams += `&search_name=${searchTermProduct.value}`
-  if (searchTermBrand.value) apiParams += `&search_brand=${searchTermBrand.value}`
-  if (searchTermCompany.value) apiParams += `&search_company=${searchTermCompany.value}`
+  if (searchTermProduct.value) apiParams += `&search_name=${encodeURIComponent(searchTermProduct.value)}`
+  if (searchTermBrand.value) apiParams += `&search_brand=${encodeURIComponent(searchTermBrand.value)}`
+  if (searchTermCompany.value) apiParams += `&search_company=${encodeURIComponent(searchTermCompany.value)}`
   if (submissionDateAfter.value) apiParams += `&submission_date_after=${submissionDateAfter.value}`
   if (doses.value) for (let i = 0; i < doses.value.length; i++) apiParams += `&dose=${doses.value[i].split("****")[0]}`
   return apiParams


### PR DESCRIPTION
Cette PR permet l'utilisation de caractères spéciaux dans la recherche SD/ANSES.

##  :movie_camera: Démo

https://github.com/user-attachments/assets/5505102a-f811-4c7d-94e1-bba8fc8702a5

## Détails techniques

Dans le filtre custom `MultiFieldSearchFilter` le caractère "+" était considéré un espace à cause de la non gestion de l'encodage des params URL.

Étant la seule vue qu'utilise ce search filter, le changement UI se fait seulement dans `DeclarationsTableSection`


Closes #2409 