### PR TITLE
:bug: Open data: créer le fichier si il n'existe pas

### DIFF
--- a/data/etl/declarations.py
+++ b/data/etl/declarations.py
@@ -69,7 +69,7 @@ class OpenDataDeclarationsETL:
     # sauvegarder le dataframe dans le fichier pour l'export
     def load_dataframe(self, dataframe):
         file_exists = default_storage.exists(self.filename)
-        with default_storage.open(self.filename, "a") as csv_file:
+        with default_storage.open(self.filename, "a" if file_exists else "w") as csv_file:
             dataframe.to_csv(
                 csv_file,
                 header=not file_exists,


### PR DESCRIPTION
Erreur suite à l'export de données : https://sentry.incubateur.net/organizations/betagouv/issues/203074/?alert_rule_id=106&alert_timestamp=1758664844491&alert_type=email&environment=production&notification_uuid=60a53f51-c8c4-445c-8441-e52c4cb928b3&project=146&referrer=alert_email

Le problème n'existe pas en locale grâce à une fonctionnement different de l'API `default_storage.open` de Django.

Définit ici : https://github.com/django/django/blob/main/django/core/files/storage/base.py#L22 l'API à deux vérsions différentes selon la configuration.

Si `DEFAULT_FILE_STORAGE` est `FileSystemStorage`, il utilise directement `open` de python, qui crée un nouveau fichier si le fichier n'existe pas : https://github.com/django/django/blob/main/django/core/files/storage/filesystem.py#L65

Si c'est `InMemoryStorage`, il utilise de code en plus, qui ne crée pas le fichier sauf si le mode contient `w` : https://github.com/django/django/blob/main/django/core/files/storage/memory.py#L231

Alors cette PR change le mode à `w` si le fichier n'existe pas, et continue d'utiliser `a` une fois quand c'est créé. 
