### PR TITLE
:beetle: Asterix manquant pour champ required

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -79,7 +79,8 @@
           <DsfrCheckboxSet
             v-model="state.substanceTypes"
             :options="substanceTypeOptions"
-            legend="Types de la substance"
+            legend="Type(s) de la substance"
+            required
           />
         </div>
       </div>


### PR DESCRIPTION
## Avant
<img width="1008" height="285" alt="Capture d’écran du 2025-09-25 18-28-09" src="https://github.com/user-attachments/assets/50093d9c-4b69-4772-a673-6401c91658ca" />
<img width="480" height="270" alt="Capture d’écran du 2025-09-25 18-27-34" src="https://github.com/user-attachments/assets/be300e81-4926-4c83-8096-4d8faf7bfcae" />


## Après
<img width="1008" height="285" alt="image" src="https://github.com/user-attachments/assets/3117ddb3-59a4-4b24-94b9-b2b964dabf09" />
