### PR TITLE
:bug: Open data : écrire le fichier une fois car S3File ne soutient pas la mode "a"

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -351,3 +351,6 @@ FIXTURE_MODELS = [
 ENABLE_AUTO_VALIDATION = env("ENABLE_AUTO_VALIDATION", cast=bool, default=False)
 
 DECLARATIONS_EXPORT_BATCH_SIZE = env("DECLARATIONS_EXPORT_BATCH_SIZE", default=None)
+# un variable d'environnement utilisé pour le debuggage de l'export sans modifier les données
+# actuellement publiées
+DECLARATIONS_EXPORT_DATASET_NAME = env("DECLARATIONS_EXPORT_DATASET_NAME", default="declarations")

--- a/data/etl/declarations.py
+++ b/data/etl/declarations.py
@@ -87,4 +87,7 @@ class OpenDataDeclarationsETL:
             )
 
     def publish(self):
-        datagouv.update_resources(self.dataset_name)
+        if self.dataset_name == "declarations":
+            datagouv.update_resources(self.dataset_name)
+        # si le nom n'est pas "declarations", c'est pour debugger l'export
+        # et alors on ne veut pas publier les résultats


### PR DESCRIPTION
En fait on utilise S3Storage en prod, non pas InMemoryStorage comme évoqué avant #2413 

Mais S3File ne soutient pas la mode append : https://github.com/jschneier/django-storages/blob/ca89a94a7462a2423df460e7bfd5f847457042ca/storages/backends/s3.py#L221

J'espère que pandas dataframe est suffisamment efficace pour créer un grand dataframe et l'écrire en CSV en une fois.

Le différence avec la vérsion avant qui n'a pas marché après juin c'est le serialization est toujours fait par batch.

J'ai créé aussi un nouveau variable d'environnement pour renommer le nom du dataset, et alors le fichier qui sera créer, pour permettre de vérifier les résultats avant d'effacer les anciennes données. Les résultats seront publiés que si ce variable n'est pas redéfinit dans l'environnement.
