### PR TITLE
:bug: Reparer la demande de renvoie de mail de vérification

### DIFF
--- a/frontend/src/views/LoginPage.vue
+++ b/frontend/src/views/LoginPage.vue
@@ -94,7 +94,7 @@ const submit = async () => {
   // ⛔️ TODO: change this dirty hack: we use error message until having appropriate error codes in responses
   if ($externalResults.value?.nonFieldErrors?.[0]?.includes("vérifié")) {
     showSendNewConfirmationMail.value = true
-    userIdForNewConfirmationMail.value = $externalResults.value.extra.id
+    userIdForNewConfirmationMail.value = `${$externalResults.value.extra.userId}`
   }
 
   if (response.value.ok) {


### PR DESCRIPTION
dans `api/views/authentication.py` `LoginView` envoie `extra={"user_id": user.id},`

Mais je ne comprends pas comment ça a marché assez pour avoir ces erreurs dans sentry ... https://sentry.incubateur.net/organizations/betagouv/issues/199424/events/?query=transaction%3A%2Fapi%2Fv1%2Fsend-new-signup-verification-email%2F%7Buser_id%7D (on peut agrandir la colonne URL pour voir que les URLs sont bien remplit avec un id, et non pas `undefined` comme je vois quand je le test en prod)