### PR TITLE
Téchnique : plus besoin de supprimer le fichier export en amont

### DIFF
--- a/data/etl/declarations.py
+++ b/data/etl/declarations.py
@@ -26,10 +26,6 @@ class OpenDataDeclarationsETL:
         )
         self.filename = f"{self.dataset_name}.csv"
 
-        # supprimer l'ancien fichier pour preparer l'action d'append du load_dataframe
-        if default_storage.exists(self.filename):
-            default_storage.delete(self.filename)
-
     def export(self):
         logger.info("OpenDataDeclarationsETL: Starting export")
         paginated_queryset = self.extract_paginated_queryset()


### PR DESCRIPTION
Avant, le mode a été `a` mais maintenant qu'on utilise que le mode `w` on n'a plus besoin de supprimer le fichier en amont. En supprimant ces lignes, on ne va plus supprimer les données publiées si il y a une erreur avec l'export