### PR TITLE
Ajout de filtres sur les commentaires dans les pages d'admin des ingrédients

### DIFF
--- a/data/admin/abstract_admin.py
+++ b/data/admin/abstract_admin.py
@@ -39,16 +39,15 @@ class RecomputeDeclarationArticleAtIngredientSaveMixin:
             )
 
 
-class HasCommentListFilter(admin.SimpleListFilter):
-    title = "Avec commentaire"
+class HasMaxCommentListFilter(admin.SimpleListFilter):
+    title = "Avec maximum dans commentaire"
 
-    parameter_name = "has_comment"
+    parameter_name = "has_max_comment"
 
     def lookups(self, request, model_admin):
         return [
             ("public", "Public"),
             ("private", "Privé"),
-            ("none", "Aucun"),
         ]
 
     def queryset(self, request, queryset):
@@ -58,8 +57,29 @@ class HasCommentListFilter(admin.SimpleListFilter):
         `self.value()`.
         """
         if self.value() == "public":
-            return queryset.exclude(public_comments="")
+            return queryset.filter(public_comments__icontains="max")
         if self.value() == "private":
-            return queryset.exclude(private_comments="")
-        if self.value() == "none":
-            return queryset.filter(public_comments="", private_comments="")
+            return queryset.filter(private_comments__icontains="max")
+
+
+class HasWarningCommentListFilter(admin.SimpleListFilter):
+    title = "Avec avertissement dans commentaire"
+
+    parameter_name = "has_warning_comment"
+
+    def lookups(self, request, model_admin):
+        return [
+            ("public", "Public"),
+            ("private", "Privé"),
+        ]
+
+    def queryset(self, request, queryset):
+        """
+        Returns the filtered queryset based on the value
+        provided in the query string and retrievable via
+        `self.value()`.
+        """
+        if self.value() == "public":
+            return queryset.filter(public_comments__icontains="avertissement")
+        if self.value() == "private":
+            return queryset.filter(private_comments__icontains="avertissement")

--- a/data/admin/ingredient.py
+++ b/data/admin/ingredient.py
@@ -9,7 +9,8 @@ from data.models import Ingredient, IngredientSynonym
 from .abstract_admin import (
     ChangeReasonAdminMixin,
     ChangeReasonFormMixin,
-    HasCommentListFilter,
+    HasMaxCommentListFilter,
+    HasWarningCommentListFilter,
     RecomputeDeclarationArticleAtIngredientSaveMixin,
 )
 
@@ -101,7 +102,8 @@ class IngredientAdmin(RecomputeDeclarationArticleAtIngredientSaveMixin, ChangeRe
         "requires_analysis_report",
         "novel_food",
         "ingredient_type",
-        HasCommentListFilter,
+        HasMaxCommentListFilter,
+        HasWarningCommentListFilter,
     )
     show_facets = admin.ShowFacets.NEVER
     search_fields = ["id", "name"]

--- a/data/admin/microorganism.py
+++ b/data/admin/microorganism.py
@@ -8,7 +8,8 @@ from data.models import Microorganism
 from .abstract_admin import (
     ChangeReasonAdminMixin,
     ChangeReasonFormMixin,
-    HasCommentListFilter,
+    HasMaxCommentListFilter,
+    HasWarningCommentListFilter,
     RecomputeDeclarationArticleAtIngredientSaveMixin,
 )
 
@@ -83,7 +84,15 @@ class MicroorganismAdmin(RecomputeDeclarationArticleAtIngredientSaveMixin, Chang
         "requires_analysis_report",
         "novel_food",
     )
-    list_filter = ("is_obsolete", "status", "is_risky", "requires_analysis_report", "novel_food", HasCommentListFilter)
+    list_filter = (
+        "is_obsolete",
+        "status",
+        "is_risky",
+        "requires_analysis_report",
+        "novel_food",
+        HasMaxCommentListFilter,
+        HasWarningCommentListFilter,
+    )
     show_facets = admin.ShowFacets.NEVER
     readonly_fields = ("name",)
     search_fields = ["id", "name"]

--- a/data/admin/plant.py
+++ b/data/admin/plant.py
@@ -9,7 +9,8 @@ from data.models import Plant, PlantSynonym
 from .abstract_admin import (
     ChangeReasonAdminMixin,
     ChangeReasonFormMixin,
-    HasCommentListFilter,
+    HasMaxCommentListFilter,
+    HasWarningCommentListFilter,
     RecomputeDeclarationArticleAtIngredientSaveMixin,
 )
 
@@ -115,7 +116,8 @@ class PlantAdmin(RecomputeDeclarationArticleAtIngredientSaveMixin, ChangeReasonA
         "is_risky",
         "requires_analysis_report",
         "novel_food",
-        HasCommentListFilter,
+        HasMaxCommentListFilter,
+        HasWarningCommentListFilter,
     )
     show_facets = admin.ShowFacets.NEVER
     search_fields = ["id", "name"]

--- a/data/admin/substance.py
+++ b/data/admin/substance.py
@@ -11,7 +11,12 @@ from config import tasks
 from data.models.declaration import Declaration
 from data.models.substance import MaxQuantityPerPopulationRelation, Substance, SubstanceSynonym, SubstanceType
 
-from .abstract_admin import ChangeReasonAdminMixin, ChangeReasonFormMixin, HasCommentListFilter
+from .abstract_admin import (
+    ChangeReasonAdminMixin,
+    ChangeReasonFormMixin,
+    HasMaxCommentListFilter,
+    HasWarningCommentListFilter,
+)
 
 
 class SubstanceTypesForm(forms.MultipleChoiceField):
@@ -185,7 +190,8 @@ class SubstanceAdmin(ChangeReasonAdminMixin, SimpleHistoryAdmin):
         "requires_analysis_report",
         "novel_food",
         SubstanceTypeListFilter,
-        HasCommentListFilter,
+        HasMaxCommentListFilter,
+        HasWarningCommentListFilter,
     )
     show_facets = admin.ShowFacets.NEVER
     search_fields = ["id", "name"]


### PR DESCRIPTION
## Ajout de filtre de commentaires dans l'admin pour remplissage facilité des nouveaux champs
<img width="265" height="309" alt="image" src="https://github.com/user-attachments/assets/050488e8-293f-4d88-8508-39639761fa1a" />
