### PR TITLE
Champ recherche : afficher les elements qui ne sont pas ajoutable aux déclarations dans les pages de recherche

### DIFF
--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -122,6 +122,7 @@
                 :hideSearchButton="true"
                 :required="false"
                 :chooseFirstAsDefault="false"
+                :searchAll="true"
               />
               <div class="mt-2">
                 <DsfrTag

--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -9,6 +9,7 @@
         @selected="goToSelectedOption"
         @search="search"
         :chooseFirstAsDefault="false"
+        :searchAll="true"
       />
     </div>
   </div>

--- a/frontend/src/views/ElementSearchResultsPage/index.vue
+++ b/frontend/src/views/ElementSearchResultsPage/index.vue
@@ -8,6 +8,7 @@
         @selected="goToSelectedOption"
         @search="search"
         :chooseFirstAsDefault="false"
+        :searchAll="true"
       />
     </div>
   </div>

--- a/frontend/src/views/ProducerHomePage/SearchBlock.vue
+++ b/frontend/src/views/ProducerHomePage/SearchBlock.vue
@@ -18,6 +18,7 @@
           @selected="goToSelectedOption"
           @search="search"
           :chooseFirstAsDefault="false"
+          :searchAll="true"
         />
         <p class="mt-6">
           Exemples :


### PR DESCRIPTION
https://www.notion.so/incubateur-masa/Afficher-les-ingr-dients-non-autos-dans-la-recherche-ingr-dients-24dde24614be80188138ccd2af48bb88?v=1e0de24614be8051afe7000c589c2b60&source=copy_link

4 pages modifiés : accueil, resultats recherche, détails d'un element, et recherche avancée (je vois l'usage où on veut identifier les déclarations qui utilisent un ingrédient recemment non-autorisé par exemple)