### PR TITLE
Modification ingredient : option de le supprimer en le marquant comme obsolète

### DIFF
--- a/api/serializers/common_ingredient.py
+++ b/api/serializers/common_ingredient.py
@@ -32,6 +32,7 @@ COMMON_FIELDS = (
     "to_be_entered_in_next_decree",
     "requires_analysis_report",
     "regulatory_resource_links",
+    "is_obsolete",
 )
 
 COMMON_READ_ONLY_FIELDS = ("id",)
@@ -51,6 +52,7 @@ COMMON_FETCH_FIELDS = (
     "object_type",
     "requires_analysis_report",
     "regulatory_resource_links",
+    "is_obsolete",
     # Les suivants sont cachés si l'utilisateur.ice ne fait pas partie de l'administration
     "private_comments",
     "origin_declaration",

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -359,6 +359,29 @@
     </DsfrAlert>
     <div class="flex gap-x-2 mt-4">
       <DsfrButton label="Enregistrer ingrédient" @click="saveElement" />
+      <DsfrButton
+        v-if="!isNewIngredient"
+        tertiary
+        size="small"
+        icon="ri-delete-bin-line"
+        label="Supprimer l'ingrédient"
+        @click="deleteModalOpened = true"
+      />
+      <DsfrModal
+        v-if="!isNewIngredient"
+        :opened="deleteModalOpened"
+        @close="deleteModalOpened = false"
+        :title="`Supprimer ${element.name}`"
+        :actions="deleteActions"
+      >
+        <template #default>
+          <p>Voulez-vous supprimer l'ingrédient {{ element.name }} ?</p>
+          <p>
+            Cette action va marquer l'ingrédient comme obsolète et l'ingrédient sera toujours lié aux déclarations
+            historiques.
+          </p>
+        </template>
+      </DsfrModal>
     </div>
   </FormWrapper>
 </template>
@@ -633,6 +656,37 @@ const substanceTypeOptions = [
     label: "Métabolite secondaire de plante (automatiquement assigné)",
     value: 3,
     disabled: true,
+  },
+]
+
+const deleteModalOpened = ref(false)
+
+const deleteActions = [
+  {
+    label: "Supprimer l'ingrédient",
+    onClick: async () => {
+      const url = `/api/v1/${apiType.value}s/`
+      const { response } = await useFetch(url + elementId.value, { headers: headers() })
+        .patch({ isObsolete: true })
+        .json()
+      $externalResults.value = await handleError(response)
+
+      if (response.value.ok) {
+        useToaster().addMessage({
+          type: "success",
+          id: "element-deletion-success",
+          description: "L'ingrédient a été supprimé",
+        })
+        router.push({ name: "ElementPage", params: { urlComponent: props.urlComponent } })
+      }
+    },
+  },
+  {
+    label: "Garder l'ingredient",
+    onClick: () => {
+      deleteModalOpened.value = false
+    },
+    secondary: true,
   },
 ]
 </script>

--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -22,6 +22,7 @@
       <h1 class="fr-h4 mb-1! capitalize">
         {{ element.name }}
         <DsfrBadge v-if="novelFood" label="Novel Food" small type="new" />
+        <DsfrBadge v-if="element.isObsolete" label="Obsolète" small type="error" />
       </h1>
       <RegulatoryWarning class="mt-4" />
 


### PR DESCRIPTION
https://www.notion.so/incubateur-masa/Permettre-le-BEPIAS-de-rendre-un-ingr-dient-obsolet-284de24614be802f91b8dcd383fd45cb?source=copy_link

<img width="1050" height="198" alt="Screenshot 2025-10-08 at 14-10-35 Modification ingrédient - Lactobacillus Kefiri - Compl'Alim" src="https://github.com/user-attachments/assets/c721254f-c460-42d7-b9c7-39c4b0ef0435" />
<img width="1350" height="786" alt="Screenshot 2025-10-08 at 14-10-40 Modification ingrédient - Lactobacillus Kefiri - Compl'Alim" src="https://github.com/user-attachments/assets/e1692dda-d337-43cf-bc5e-e8f187086512" />
<img width="2496" height="784" alt="Screenshot 2025-10-08 at 14-10-27 Lactobacillus Kefiri - Compl'Alim" src="https://github.com/user-attachments/assets/bde64236-50a8-4534-a64c-c034036b8a31" />

Questions : 
- est-ce qu'il faut les marquer comme à rentrer dans le prochain décret ?
- est-ce qu'on veut ajouter une option pour remettre les ingrédients supprimés ?
- est-ce qu'on veut donner le BEPIAS le moyen de rechercher les ingrédients obsolètes ?
- est-ce qu'on veut donner le BEPIAS le moyen de rechercher les déclarations qui utilisent un ingrédient obsolète dans la recherche avancée ? CAD modifier l'autocomplete pour inclure les ingrédients marqués obsolètes ?