### PR TITLE
MAJ nom du ministère

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -41,7 +41,7 @@ import AppHeader from "@/components/AppHeader.vue"
 
 const route = useRoute()
 const { messages, removeMessage } = useToaster()
-const logoText = ["Ministère", "de l’Agriculture", "et de la Souveraineté", "Alimentaire"]
+const logoText = ["Ministère", "de l'Agriculture,", "de l'Agro-alimentaire", "et de la Souveraineté", "Alimentaire"]
 
 watch(route, (to) => {
   const suffix = "Compl'Alim"


### PR DESCRIPTION
Nouveau nom côté site web agriculture.gouv.fr :

<img width="2874" height="320" alt="Screenshot 2025-10-14 at 17-19-36 Ministère de l'Agriculture et de la Souveraineté alimentaire" src="https://github.com/user-attachments/assets/347499ff-d121-48e5-a4dc-2e8385b4cf3d" />

MAJ notre header et footer:

<img width="2874" height="312" alt="Screenshot 2025-10-14 at 17-19-31 Tableau de bord - Cohen - Compl'Alim" src="https://github.com/user-attachments/assets/4d8ce8b0-30f7-471e-83d1-1e7d91d24e54" />
