### PR TITLE
Correction du bug concernant la zone morte des boutons

### DIFF
--- a/frontend/src/components/TabStepper.vue
+++ b/frontend/src/components/TabStepper.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="border p-4 bg-gray-50 text-right">
+  <div class="border p-4 bg-gray-50 text-right relative">
     <slot name="content"></slot>
     <DsfrButton secondary v-if="selectedTabIndex > 0" @click="emit('back')" :label="backLabel" />
     <DsfrButton class="ml-4" v-if="selectedTabIndex < titles.length - 1" @click="emit('forward')" :label="fwdLabel" />

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -430,5 +430,6 @@ const performDuplication = (originalDeclaration) => {
 <style scoped>
 .allow-overflow {
   overflow: visible;
+  position: relative;
 }
 </style>


### PR DESCRIPTION
Les boutons utilisés par les pros pour changer de tab n'était pas cliquables sur toute leur surface.

## :movie_camera: Démo

Avant le bouton n'était activé que sur la moitié d'en bas :

https://github.com/user-attachments/assets/d58645f0-df0d-46ab-9e93-0425a02fb2c3

Maintenant le bouton est cliquable dans toute sa surface :

https://github.com/user-attachments/assets/4aaca6ae-bcfd-47e4-bd88-c7a17b65480d

## Détails techniques

À cause du `overflow: visible;` du parent (nécessaire pour les listes déroulantes), la moitié des boutons était couverte par une couche invisible. Le fix est de s'assurer que les deux encarts aient leur propre stacking context, donc simplement utiliser `position: relative;` pour indiquer qu'ils ont des contextes de stack indépendants.


Closes #2467



