### PR TITLE
Ajout de la recherche dans la page admin du rôle de contrôle

### DIFF
--- a/data/admin/global_roles.py
+++ b/data/admin/global_roles.py
@@ -16,6 +16,11 @@ class VisaRoleAdmin(admin.ModelAdmin):
 @admin.register(ControlRole)
 class ControlRoleAdmin(admin.ModelAdmin):
     list_display = ("user", "persistant")
+    search_fields = (
+        "user__first_name",
+        "user__last_name",
+        "user__email",
+    )
 
     def persistant(self, obj):
         return "🔒 Reste même si absent sur Grist" if obj.always_persist else " "


### PR DESCRIPTION
Permet de trouver des personnes ayant le rôle de contrôle depuis l'admin, par nom, prénom et adresse email.

## :movie_camera: Démo

https://github.com/user-attachments/assets/2d8e1f83-c38d-4932-8484-e5984f1f7340

## Changements additionnels

Suite à la discussion avec @hfroot j'ai ajouté deux nouveaux éléments :

### Filtre par _persistant_ ou _pas persistant_

<img width="248" height="201" alt="image" src="https://github.com/user-attachments/assets/5ab61fb4-da8c-47b3-b53f-1a712b1ba0e4" />

### Vérification du domaine de l'email

Si le rôle concerne une personne qui n'a pas un email gouvernementale (finissant en _gouv.fr_) la colonne affiche un message d'avertissement.

<img width="224" height="179" alt="image" src="https://github.com/user-attachments/assets/fc16658f-ef97-4e9b-a893-643c723b4b11" />


Closes #2480