### PR TITLE
Modification plantes : redesign de la spécification des parties de plante pour préparer pour plus de données plus tard

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -140,7 +140,7 @@
       >
         <tr v-for="(q, idx) in state.plantParts" :key="`max-quantity-row-${idx}`">
           <td><DsfrSelect v-model="q.plantpart" :options="orderedPlantParts" /></td>
-          <td><DsfrSelect v-model.number="q.status" :options="statuses" /></td>
+          <td><DsfrSelect v-model.number="q.status" :options="plantPartStatuses" /></td>
           <td>
             <DsfrButton
               label="Supprimer"
@@ -631,6 +631,8 @@ const statuses = [
   { value: 2, text: "Non autorisé", apiValue: "non autorisé" },
   { value: 3, text: "Sans objet", apiValue: "sans objet" },
 ]
+
+const plantPartStatuses = statuses.filter((s) => s.value !== 3)
 
 const selectOption = async (result) => {
   state.value.substances.push(result)


### PR DESCRIPTION
Lié à https://www.notion.so/incubateur-masa/1bcde24614be81e0a35acb6983a06cf1?v=1e0de24614be8051afe7000c589c2b60&p=287de24614be80b58aa3d3b6996859e1&pm=s

Cette PR reprend le design de la partie quantités maximales. C'est pour préparer pour l'option de `origin_declaration` pour les parties de plantes et aussi pour l'option d'avoir un statut "retiré par l'administration" pour les parties (qui n'est pas prévu pour l'instant mais discuté)

<img width="1544" height="558" alt="Screenshot 2025-10-21 at 18-21-38 Nouvel ingrédient - Compl'Alim" src="https://github.com/user-attachments/assets/a546ecf3-97c8-4fcf-986b-3596027902ef" />
