### PR TITLE
Commentaires : afficher les paragraphes

### DIFF
--- a/frontend/src/components/ElementCommentModal.vue
+++ b/frontend/src/components/ElementCommentModal.vue
@@ -3,11 +3,11 @@
     <DsfrModal :title="elementName" size="lg" :opened="infoModalOpened" @close="infoModalOpened = false">
       <div v-if="element?.publicComments">
         <h2 class="fr-h6 mb-2!">Commentaires</h2>
-        <p>{{ element?.publicComments }}</p>
+        <p class="whitespace-pre-line">{{ element?.publicComments }}</p>
       </div>
       <div v-if="element?.privateComments && !hidePrivateComments">
         <h2 class="fr-h6 mb-2!">Commentaires privés</h2>
-        <p>{{ element?.privateComments }}</p>
+        <p class="whitespace-pre-line">{{ element?.privateComments }}</p>
       </div>
       <div v-if="hasMaxQuantities">
         <ElementDoses :maxQuantities="maxQuantities" :unit="element?.unit" />

--- a/frontend/src/views/ElementPage/ElementTextSection.vue
+++ b/frontend/src/views/ElementPage/ElementTextSection.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="text">
     <h2 class="fr-h6 mb-1!">{{ title }}</h2>
-    <p>
+    <p class="whitespace-pre-line">
       <slot>{{ text }}</slot>
     </p>
   </div>


### PR DESCRIPTION
## Avant

<img width="712" height="294" alt="Screenshot 2025-10-28 at 12-02-17 Corymbia citriodora (Hook ) K D Hill   L A S  Johnson - Compl'Alim" src="https://github.com/user-attachments/assets/bbf458fe-6a82-4991-a324-2eaa748c6d75" />
<img width="1520" height="405" alt="Screenshot 2025-10-28 at 12-01-55 Résumé - Détails de ma déclaration « test plant part status change » - Compl'Alim" src="https://github.com/user-attachments/assets/3054a260-ea63-40e2-b85d-865e87fd48cf" />


## Après

<img width="1029" height="401" alt="Screenshot 2025-10-28 at 11-58-20 Corymbia citriodora (Hook ) K D Hill   L A S  Johnson - Compl'Alim" src="https://github.com/user-attachments/assets/1f996570-5b7e-4557-9b5d-a247bd585a94" />
<img width="1470" height="481" alt="Screenshot 2025-10-28 at 11-58-58 Résumé - Détails de ma déclaration « test plant part status change » - Compl'Alim" src="https://github.com/user-attachments/assets/5fe21775-0ebe-4616-a05f-de7aca05388f" />

