### PR TITLE
Fix du bug montrant l'onglet pour les nouveaux ingrédients

### DIFF
--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -204,7 +204,7 @@ watch(data, () => {
 
 const hasNewElements = computed(() => {
   const hasNewPart = payload.value.declaredPlants.some(
-    (x) => x.usedPart && x.element?.plantParts?.find((ep) => ep.id === x.usedPart)?.status !== "AUTHORIZED"
+    (x) => x.usedPart && x.element?.plantParts?.find((ep) => ep.id === x.usedPart)?.status !== "autorisé"
   )
   return (
     hasNewPart ||


### PR DESCRIPTION
Lors qu'on sélectionne une plante, l'onglet « Nouveaux ingrédients » est toujours visible, même lors qu'on choisit une partie de plante autorisée.

Le bug vient d'une petite confusion entre `AUTHORIZED` et `autorisé`

Closes #2517
