### PR TITLE
Changement de wording pour le badge des ingrédients autorisés

### DIFF
--- a/frontend/src/components/ElementStatusBadge.vue
+++ b/frontend/src/components/ElementStatusBadge.vue
@@ -1,5 +1,6 @@
 <template>
-  <DsfrBadge v-if="text === 'autorisé'" :label="text" small type="success" />
+  <!-- Nous n'utilisons pas le mot "autorisé" pour ne pas donner une fausse idée d'acceptation sure de l'ingrédient -->
+  <DsfrBadge v-if="text === 'autorisé'" label="déclarable" small type="info" />
   <DsfrBadge v-else-if="text === 'non autorisé'" :label="text" small type="error" />
   <DsfrBadge v-else-if="text === 'retiré par l\'administration'" :label="text" small type="error" />
 </template>


### PR DESCRIPTION
Suite à une demande urgente de changement de wording et couleur pour les ingrédients autorisés.

Closes #2533 

Avant : 
<img width="1220" height="561" alt="image" src="https://github.com/user-attachments/assets/7ac0d545-7dfd-4169-9848-ada8341b0bad" />


Après :

<img width="1243" height="755" alt="image" src="https://github.com/user-attachments/assets/1e8e98ea-1401-4e65-aa2b-fc4ab886f72d" />
