### PR TITLE
Search-Engine: Affiche les avertissements à faire figurer sur l'étiquetage dans le composant DsfrCallout

### DIFF
--- a/frontend/src/views/ElementPage/index.vue
+++ b/frontend/src/views/ElementPage/index.vue
@@ -98,15 +98,18 @@
         :maxQuantities="element.maxQuantities"
         :unit="element.unit"
       ></ElementDoses>
-      <div v-if="element.warningsOnLabel?.length">
-        <h2 class="fr-h6 mb-1!">Avertissement à faire figurer sur l'étiquetage</h2>
+      <DsfrCallout
+        v-if="element.warningsOnLabel?.length"
+        title="Avertissements à faire figurer sur l'étiquetage"
+        icon="ri-alarm-warning-line"
+        accent="orange-terre-battue"
+      >
         <ul>
           <li v-for="(warning, idx) in element.warningsOnLabel" :key="`warning-${idx}`">
             {{ warning }}
           </li>
         </ul>
-      </div>
-      <!-- Utiliser DsfrCallout avec une couleur particulière pour les avertissements quand cela sera possible https://github.com/dnum-mi/vue-dsfr/issues/1126 -->
+      </DsfrCallout>
 
       <ElementTextSection
         v-if="element.requiresAnalysisReport"


### PR DESCRIPTION
C'était un TODO qui attendait que ce soit possible de vue-dsfr.

## Avant
<img width="1366" height="449" alt="image" src="https://github.com/user-attachments/assets/293768a2-ae20-4035-b9e9-724f2e8fe0f7" />


## Après
<img width="1402" height="557" alt="image" src="https://github.com/user-attachments/assets/4313c5b1-2d50-4de5-b930-a2248488a1f6" />
