### PR TITLE
Modif ingrédient : option de retirer l'ingrédient

### DIFF
--- a/frontend/src/components/CompositionInfo/SummaryElementItem.vue
+++ b/frontend/src/components/CompositionInfo/SummaryElementItem.vue
@@ -16,11 +16,7 @@
             </p>
           </div>
 
-          <ElementStatusBadge
-            :text="model.element.status"
-            v-if="showElementAuthorization && model.element?.status !== 'autorisé'"
-            class="self-center ml-2"
-          />
+          <ElementStatusBadge v-if="showElementStatusBadge" :text="model.element?.status" class="self-center ml-2" />
 
           <DsfrBadge v-if="novelFood" label="Novel Food" type="new" class="self-center ml-2" small />
           <DsfrBadge
@@ -61,6 +57,7 @@
 <script setup>
 import { computed } from "vue"
 import { getElementName } from "@/utils/elements"
+import { ingredientStatuses } from "@/utils/mappings"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import ElementCommentModal from "@/components/ElementCommentModal"
@@ -137,6 +134,10 @@ const treatedRequest = computed(() => {
       type: "info",
     },
   }[model.value.requestStatus]
+})
+
+const showElementStatusBadge = computed(() => {
+  return props.showElementAuthorization && model.value.element?.status !== ingredientStatuses.AUTHORIZED.apiValue
 })
 </script>
 

--- a/frontend/src/components/CompositionInfo/SummaryElementItem.vue
+++ b/frontend/src/components/CompositionInfo/SummaryElementItem.vue
@@ -18,7 +18,7 @@
 
           <ElementStatusBadge
             :text="model.element.status"
-            v-if="showElementAuthorization && model.element?.status === 'non autorisé'"
+            v-if="showElementAuthorization && model.element?.status !== 'autorisé'"
             class="self-center ml-2"
           />
 

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -434,13 +434,16 @@
             aux déclarants concernés.
           </p>
           <p>L'ingrédient sera toujours déclarable, et les déclarations qui l'utilisent vont recevoir l'article 16.</p>
-          <DsfrInput
-            label="Raison de retrait"
-            hint="Visible par le public"
-            v-model="state.revokedDetail"
-            :isTextarea="true"
-            label-visible
-          />
+          <DsfrInputGroup :error-message="revokedDetailError">
+            <DsfrInput
+              label="Raison de retrait"
+              hint="Visible par le public"
+              v-model="state.revokedDetail"
+              :isTextarea="true"
+              label-visible
+              required
+            />
+          </DsfrInputGroup>
         </template>
       </DsfrModal>
       <DsfrButton
@@ -527,14 +530,15 @@ watch(
   }
 )
 
+const REQUIRED_FIELDS_ERROR =
+  "Merci de vérifier que les champs obligatoires, signalés par une astérix *, ont bien été remplis"
+
 const saveElement = async () => {
   v$.value.$reset()
   v$.value.$validate()
   validateMaxQuantities()
   if (v$.value.$error || maxQuantitiesError.value) {
-    useToaster().addErrorMessage(
-      "Merci de vérifier que les champs obligatoires, signalés par une astérix *, ont bien été remplis"
-    )
+    useToaster().addErrorMessage(REQUIRED_FIELDS_ERROR)
     window.scrollTo(0, 0)
     return
   }
@@ -803,6 +807,7 @@ const deleteActions = [
 ]
 
 const revokeModalOpened = ref(false)
+const revokedDetailError = ref("")
 
 const AUTHORIZATION_REVOKED_STATUS = 99
 
@@ -810,6 +815,12 @@ const revokeActions = [
   {
     label: "Retirer l'ingrédient",
     onClick: async () => {
+      if (!state.value.revokedDetail) {
+        revokedDetailError.value = "Ce champ doit être rempli"
+        useToaster().addErrorMessage(REQUIRED_FIELDS_ERROR)
+        return
+      } else revokedDetailError.value = ""
+
       const url = `/api/v1/${apiType.value}s/`
       const { response } = await useFetch(url + elementId.value, { headers: headers() })
         .patch({ status: AUTHORIZATION_REVOKED_STATUS, revokedDetail: state.value.revokedDetail })

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -436,8 +436,8 @@
           <p>L'ingrédient sera toujours déclarable, et les déclarations qui l'utilisent vont recevoir l'article 16.</p>
           <DsfrInputGroup :error-message="revokedDetailError">
             <DsfrInput
-              label="Raison de retrait"
-              hint="Visible par le public"
+              label="Détail du retrait"
+              hint="Visible par le public. Penser à noter le fondement juridique du changement de statut, les mesures à mettre en place retrait et/ou rappel, toute autre info pertinente à ajouter au cas par cas."
               v-model="state.revokedDetail"
               :isTextarea="true"
               label-visible

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -430,7 +430,7 @@
           <p>Voulez-vous retirer l'ingredient {{ element.name }} du marché ?</p>
           <p>
             Cette action va marquer l'ingrédient comme "retiré par l'administration" et elle va marquer toutes les
-            déclarations autorisées qui utilisent l'ingrédient comme retirées par l'administration, avec un mail envoyé
+            déclarations autorisées qui utilisent l'ingrédient comme "retirées par l'administration", un mail sera envoyé
             aux déclarants concernés.
           </p>
           <p>L'ingrédient sera toujours déclarable, et les déclarations qui l'utilisent vont recevoir l'article 16.</p>

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -412,7 +412,7 @@
     <div class="flex gap-x-2 mt-4">
       <DsfrButton label="Enregistrer ingrédient" @click="saveElement" />
       <DsfrButton
-        v-if="!isNewIngredient"
+        v-if="canRevokeIngredient"
         tertiary
         size="small"
         icon="ri-error-warning-line"
@@ -420,7 +420,7 @@
         @click="revokeModalOpened = true"
       />
       <DsfrModal
-        v-if="!isNewIngredient"
+        v-if="canRevokeIngredient"
         :opened="revokeModalOpened"
         @close="revokeModalOpened = false"
         :title="`Retirer ${element.name} du marché`"
@@ -834,6 +834,10 @@ const revokeActions = [
     secondary: true,
   },
 ]
+
+const canRevokeIngredient = computed(() => {
+  return !isNewIngredient.value && state.value.status === 1
+})
 </script>
 
 <style scoped>

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -430,8 +430,8 @@
           <p>Voulez-vous retirer l'ingredient {{ element.name }} du marché ?</p>
           <p>
             Cette action va marquer l'ingrédient comme "retiré par l'administration" et elle va marquer toutes les
-            déclarations autorisées qui utilisent l'ingrédient comme "retirées par l'administration", un mail sera envoyé
-            aux déclarants concernés.
+            déclarations autorisées qui utilisent l'ingrédient comme "retirées par l'administration", un mail sera
+            envoyé aux déclarants concernés.
           </p>
           <p>L'ingrédient sera toujours déclarable, et les déclarations qui l'utilisent vont recevoir l'article 16.</p>
           <DsfrInputGroup :error-message="revokedDetailError">


### PR DESCRIPTION
lié https://www.notion.so/incubateur-masa/Cr-ation-d-un-nouveau-statut-Retir-par-l-administration-217de24614be80919bc8ed72f0aedc66?source=copy_link

basé sur #2547 

Cette PR donne l'option aux instructrices de retirer un ingrédient depuis la page modification ingrédient. Cette option est que visible quand l'ingrédient est déjà existant, et quand le statut est autorisé. Le champ détail de retrait est obligatoire.

Elle ajoute aussi un badge pour le statut retiré sur les ingrédients dans la composition pour la vue instructrice/viseuse, cohérent avec le badge non autorisé.

Autre travail à faire dans d'autres PRs : 
- [refont page modif ingrédient](https://www.notion.so/incubateur-masa/Refont-de-la-page-modif-ingr-dient-2b0de24614be80159925ea61d88fbd35?source=copy_link), car elle est devenue très long et les champs ne sont pas forcement regroupés de manière intuitif (genre les champs relié au statut sont partout)
- comment afficher le champ statut pour les ingrédients retirés ?


## Vue action

<img width="858" height="385" alt="Screenshot 2025-11-19 at 11-29-53 Modification ingrédient - Plante à retirer - Compl&#39;Alim" src="https://github.com/user-attachments/assets/70d01b87-cea9-4dbc-8042-f9efd62bbfa3" />
<img width="1541" height="1405" alt="Screenshot 2025-11-19 at 11-29-44 Modification ingrédient - Plante à retirer - Compl&#39;Alim" src="https://github.com/user-attachments/assets/c985ac81-f2e0-499b-88f2-3201546ef327" />
<img width="2143" height="1710" alt="Screenshot 2025-11-19 at 11-50-33 Modification ingrédient - Corymbia citriodora (Hook ) K D Hill   L A S  Johnson - Compl&#39;Alim" src="https://github.com/user-attachments/assets/43ae78d0-17ea-4f86-aea4-b049b2810847" />

## Vérification des MAJ
Les MAJ des déclarations - du statut pour les déclarations autorisées et d'article pour les déclarations en cours, sont visibles aux instructrices depuis la page recherche avancée si on filtre sur l'ingrédient en question. L'ingredient est sauvegardé pour être affiché sur la page déclaration. Ces trucs ont été traités dans des PRs précedentes mais maintenant on peut tester la fonctionnalité end-to-end
À noter qu'il y a [un bug avec le lien déclarations concernées](https://www.notion.so/incubateur-masa/Bug-lien-page-d-clarations-li-es-un-ingr-dient-2afde24614be80239932fafad3293a6d?source=copy_link) qui sera traité en deuxième temps. 

### avant retrait
<img width="2269" height="532" alt="Screenshot 2025-11-19 at 11-29-02 Recherche avancée - Compl&#39;Alim" src="https://github.com/user-attachments/assets/46512995-7160-4791-a6a4-38d27a28765a" />

### après
<img width="2269" height="629" alt="Screenshot 2025-11-19 at 11-31-25 Recherche avancée - Compl&#39;Alim" src="https://github.com/user-attachments/assets/563c08e2-1007-4638-9165-25c636bdf706" />

### Vue déclaration - banière avec nom de l'ingrédient retiré

<img width="2098" height="312" alt="Screenshot 2025-11-19 at 12-24-27 Test autorisée PR 2548 - Instruction - Compl&#39;Alim" src="https://github.com/user-attachments/assets/e213fbd2-9ca3-4c2e-8227-ab7bb90b8089" />


## Vue instruction

<img width="1349" height="543" alt="Screenshot 2025-11-19 at 11-37-44 Test en cours PR 2548 - Instruction - Compl&#39;Alim" src="https://github.com/user-attachments/assets/09d5d49e-fb93-4ad0-9959-3e33731689d9" />
