### PR TITLE
RGAA 10.7 : Dans chaque page web, pour chaque élément recevant le focus, la prise de focus est-elle visible ?

### DIFF
--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -59,7 +59,7 @@
                 :exclude="['DRAFT']"
                 @updateFilter="updateStatusFilter"
                 :statusString="filteredStatus"
-                class="my-6"
+                class="my-6 status-filter"
               />
               <DsfrFieldset legend="Cible" class="min-w-60">
                 <DsfrInputGroup>
@@ -425,6 +425,9 @@ watch(activeAccordion, (x) => setTimeout(() => (seeOverflow.value = x === 0), 50
 }
 .filter-area :deep(.fr-fieldset__element) {
   @apply my-0!;
+}
+.status-filter :deep(.fr-fieldset__element) {
+  @apply my-2!;
 }
 div.seeOverflow :deep(#filter-accordeon.fr-collapse--expanded) {
   overflow: visible;


### PR DESCRIPTION
Comme #2385, il est nécessaire de réparer l'espacement entre les statuts à selectionner sur la page recherche avancée.

Pour une autre PR, il y a un pb avec le fond grisé - la barre de navigation n'est pas grisée.

## Avant

<img width="1147" height="805" alt="Screenshot 2025-11-20 at 14-53-41 Recherche avancée - Compl&#39;Alim" src="https://github.com/user-attachments/assets/025c8206-4732-418d-9871-c9944a551f39" />


## Après

<img width="1214" height="1181" alt="Screenshot 2025-11-20 at 14-53-09 Recherche avancée - Compl&#39;Alim" src="https://github.com/user-attachments/assets/ee3c742b-29a4-4f8c-ab3d-f7369e95db2e" />
