### PR TITLE
Rend les avertissements supprimables depuis l'interface de modification des ingrédients 

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -271,11 +271,11 @@
       legendClass="fr-h4 mb-0!"
       class="mb-0"
     >
-      <tr v-for="(q, idx) in state.warningsOnLabel" :key="`warning-${idx}`" class="grid md:grid-cols-8 md:gap-4 mb-4">
-        <td class="col-span-7">
+      <div v-for="(q, idx) in state.warningsOnLabel" :key="`warning-${idx}`" class="grid md:grid-cols-8 md:gap-4 mb-4">
+        <span class="col-span-7">
           <DsfrInput v-model="state.warningsOnLabel[idx]" />
-        </td>
-        <td>
+        </span>
+        <span>
           <DsfrButton
             label="Supprimer"
             @click="deleteWarning(idx)"
@@ -284,8 +284,8 @@
             tertiary
             class="mt-2"
           />
-        </td>
-      </tr>
+        </span>
+      </div>
       <DsfrButton
         label="Ajouter un avertissement"
         @click="() => (state.warningsOnLabel ? state.warningsOnLabel.push('') : (state.warningsOnLabel = ['']))"


### PR DESCRIPTION
closes #2538 

## Avant 
<img width="1262" height="225" alt="image" src="https://github.com/user-attachments/assets/4b959e3e-a0e1-4f94-987b-a59ae04aad44" />

## Après
<img width="1262" height="225" alt="image" src="https://github.com/user-attachments/assets/b7a1b6b4-e196-433a-aa7e-ec10de5d38f6" />
