### PR TITLE
Téchnique : rendre un 400 et non pas un 500 quand des mauvaises données sont envoyés à l'API de recherche

### DIFF
--- a/api/views/search.py
+++ b/api/views/search.py
@@ -36,7 +36,7 @@ class SearchView(APIView):
 
         try:
             limit = int(self.request.data.get("limit", 0))
-        except ValueError:
+        except (TypeError, ValueError):
             raise ParseError("Limit devrait être un chiffre entier")
 
         if limit > self.max_pagination_limit:
@@ -56,7 +56,7 @@ class SearchView(APIView):
         try:
             self.limit = int(self.request.data.get("limit", self.default_pagination_limit))
             self.offset = int(self.request.data.get("offset", 0))
-        except TypeError:
+        except (TypeError, ValueError):
             raise ParseError("Limit et offset devront être des chiffres entiers")
 
         self.count = len(results)


### PR DESCRIPTION
Pour réparer :
- https://sentry.incubateur.net/organizations/betagouv/issues/220277/?project=146&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream
- https://sentry.incubateur.net/organizations/betagouv/issues/220275/?project=146&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream

