### PR TITLE
Bug fix : ne pas bloquer l'affichage des déclarations quand il y a un statut inconnu

### DIFF
--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/utils.js
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/utils.js
@@ -11,7 +11,7 @@ export const getStatusTagForCell = (status) => {
   return {
     component: "DsfrTag",
     label: status,
-    class: tagData[status].color,
-    icon: tagData[status].icon,
+    class: tagData[status]?.color,
+    icon: tagData[status]?.icon,
   }
 }


### PR DESCRIPTION
Pour les déclarations retirées par l'administration, on n'a pas encore définit le bon statut simplifié pour afficher aux contrôleurs. 

Pour ne pas faire tomber tout la page, j'ajoute ce petit fix qui rend l'util plus flexible.

Pour vraiment réparer le bug, il faut modifier SimplifiedStatusHelper du back, mais c'est en attente pour plus d'info côté besoins.

Ici, "Especially dream" est retirée, et ce fix va simplement afficher une bulle vide, où avant aucune déclaration est affichée.

## Avant
<img width="2269" height="640" alt="Screenshot 2025-11-24 at 15-00-39 Tableau des compléments alimentaires - Compl&#39;Alim" src="https://github.com/user-attachments/assets/8bc5001a-588b-49db-a8f9-1c27d7c5772d" />


## Après
<img width="2258" height="1254" alt="Screenshot 2025-11-24 at 14-59-23 Tableau des compléments alimentaires - Compl&#39;Alim" src="https://github.com/user-attachments/assets/5599d64c-fd3c-4109-af0a-4945df8a13d9" />
