### PR TITLE
Bug fix : permettre la recherche par ingrédient avec & dans le nom

### DIFF
--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
@@ -341,7 +341,7 @@ const addIngredient = async (ingredient) => {
   // Temporairement on traite les ajouts d'ingrédients comme ayant une dose supérieure ou égale
   // à 0. Par la suite on pourra spécifier également la dose précise recherchée et la partie de
   // plante
-  let newFilterString = `${ingredient.objectType}||${ingredient.name}||${ingredient.id}`
+  let newFilterString = `${ingredient.objectType}||${encodeURIComponent(ingredient.name)}||${ingredient.id}`
 
   if (ingredient.objectType === "plant") newFilterString += "|-|Toutes les parties"
 

--- a/frontend/src/views/AdvancedSearchPage/DoseFilterModal.vue
+++ b/frontend/src/views/AdvancedSearchPage/DoseFilterModal.vue
@@ -102,7 +102,9 @@
     <div class="flex mt-2 mb-4" v-if="filterString">
       <v-icon class="self-center mr-3" :name="getTypeIcon(filterString.split('||')[0])"></v-icon>
       <div>
-        <p class="mb-0 font-medium" v-for="line in filterTextLines" :key="`line-${line}`">{{ line }}</p>
+        <p class="mb-0 font-medium" v-for="line in filterTextLines" :key="`line-${line}`">
+          {{ decodeURIComponent(line) }}
+        </p>
       </div>
     </div>
     <p class="mb-2 italic" v-else>Aucun filtrage par dose n'est appliqué.</p>
@@ -237,7 +239,7 @@ const setFilter = () => {
 
   // "<type d'élément>||<nom de l'élément>||<ID de l'élément (partie de plante optionnelle)>||<opération>||<quantité>||<ID de l'unité>"
   // "plant||Camomille||<ID de la plante>|<ID de la partie>|<nom de la partie>||<opération>||<quantité>||<ID de l'unité>"
-  let newFilterString = `${selectedIngredient.value.objectType}||${selectedIngredient.value.name}||${selectedIngredient.value.id}`
+  let newFilterString = `${selectedIngredient.value.objectType}||${encodeURIComponent(selectedIngredient.value.name)}||${selectedIngredient.value.id}`
 
   // Ajout de l'info sur la partie de plante en cas de ingrédient plante
   if (ingredientIsPlant.value) {


### PR DESCRIPTION
Bug vu : https://sentry.incubateur.net/organizations/betagouv/issues/221101/?project=146&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream

On envoie le nom de l'ingrédient vers le back dans les query params. Quand un nom contient un & c'est vu comme un nouveau query param. Cette PR modifie l'appel pour encoder les noms et éviter ce problème.
