### PR TITLE
Bug fix : ne pas donner un message d'erreur quand on gère les entreprises mandatées pour une entreprise avec un mauvais numéro

### DIFF
--- a/api/views/company.py
+++ b/api/views/company.py
@@ -270,7 +270,6 @@ class AddMandatedCompanyView(GenericAPIView):
             raise NotFound()
 
         company.mandated_companies.add(mandated_company)
-        company.save()
 
         brevo_template = 27
         for supervisor in mandated_company.supervisor_roles.all():
@@ -312,7 +311,6 @@ class RemoveMandatedCompanyView(GenericAPIView):
         try:
             mandated_company = company.mandated_companies.get(pk=mandated_company_id)
             company.mandated_companies.remove(mandated_company)
-            company.save()
         except Company.DoesNotExist as _:
             pass
 


### PR DESCRIPTION
Issu : https://sentry.incubateur.net/organizations/betagouv/issues/219827/?project=146&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream

Le problème : quand une entreprise avec un numéro de contact invalid ajout ou supprime une entreprise mandataire, il semble que la requête ne marche pas. C'est parce que on appel `save` et là, le save ne marche pas car le numéro n'est pas valide.

En fait, cet issu n'est pas bloquant car l'action de `add` et `remove` pour les django queryset n'ont pas besoin d'un `save`.

Quand même, il y a un message côté utilisateur que l'action n'a pas marché, et on reçoit l'erreur côté sentry.

Les entreprises avec des mauvaises numéros existent depuis l'import de données historique, grâce à l'appel dans `create_company_from_historic_etablissement` à `new_company.save(fields_with_no_validation=("phone_number"))`