### PR TITLE
Ajouter un interval de cooldown pour les MAJ dependences

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     target-branch: "staging"
     directory: "/frontend"


### PR DESCRIPTION
Inspiré par https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns

Un cooldown de 7 jours peut éviter la majorité de problèmes de sécu
