### PR TITLE
Déclaration : réparer les liens modification pour les déclarants

### DIFF
--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -29,12 +29,12 @@
 
       <h3 class="fr-h6 mt-8!">
         Adresse sur l'étiquetage
-        <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(1))" />
+        <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(0))" />
       </h3>
       <AddressLine :payload="payload" />
       <h3 class="fr-h6 mt-8!">
         Pièces jointes
-        <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(editLink(2))" />
+        <SummaryModificationButton class="ml-4" v-if="!readonly" @click="router.push(attachmentLink)" />
       </h3>
       <RequiresAnalysisReportNotice :declaration="payload" class="mb-4" />
       <div class="grid grid-cols-12 gap-3 mb-8">
@@ -55,6 +55,7 @@ export default { name: "DeclarationSummary" }
 </script>
 
 <script setup>
+import { computed } from "vue"
 import AddressLine from "@/components/AddressLine"
 import ProductInfoSegment from "@/components/ProductInfoSegment"
 import ArticleInfoRow from "./ArticleInfoRow"
@@ -65,6 +66,7 @@ import { useRouter } from "vue-router"
 import SummaryModificationButton from "./SummaryModificationButton"
 import HistoryBadge from "../History/HistoryBadge.vue"
 import RequiresAnalysisReportNotice from "@/components/RequiresAnalysisReportNotice"
+import { hasNewElements } from "@/utils/elements"
 
 const router = useRouter()
 
@@ -77,6 +79,10 @@ defineProps({
 })
 
 const editLink = (tab) => ({ query: { tab } })
+
+const attachmentLink = computed(() => {
+  return hasNewElements(payload.value) ? editLink(3) : editLink(2)
+})
 </script>
 
 <style scoped>

--- a/frontend/src/utils/elements.js
+++ b/frontend/src/utils/elements.js
@@ -23,3 +23,20 @@ export const getUnitQuantityString = (declaration, units) => {
 export const getUnitString = (unitId, units) => {
   return units.value?.find?.((x) => x.id === unitId)?.name || "-"
 }
+
+export const hasNewElements = (declaration) => {
+  const hasNewPart = declaration.declaredPlants.some(
+    (x) => x.usedPart && x.element?.plantParts?.find((ep) => ep.id === x.usedPart)?.status !== "autorisé"
+  )
+  return (
+    hasNewPart ||
+    []
+      .concat(
+        declaration.declaredPlants,
+        declaration.declaredMicroorganisms,
+        declaration.declaredIngredients,
+        declaration.declaredSubstances
+      )
+      .some((x) => x.new)
+  )
+}

--- a/frontend/src/views/ProducerFormPage/index.vue
+++ b/frontend/src/views/ProducerFormPage/index.vue
@@ -116,6 +116,7 @@ import { headers } from "@/utils/data-fetching"
 import useToaster from "@/composables/use-toaster"
 import { tabTitles } from "@/utils/mappings"
 import { setDocumentTitle } from "@/utils/document"
+import { hasNewElements } from "@/utils/elements"
 
 // Il y a deux refs qui stockent des erreurs. $externalResults sert
 // lors qu'on sauvegarde la déclaration (POST ou PUT) mais qu'on ne change
@@ -202,22 +203,6 @@ watch(data, () => {
   setDocumentTitleForTab(selectedTabIndex.value, data)
 })
 
-const hasNewElements = computed(() => {
-  const hasNewPart = payload.value.declaredPlants.some(
-    (x) => x.usedPart && x.element?.plantParts?.find((ep) => ep.id === x.usedPart)?.status !== "autorisé"
-  )
-  return (
-    hasNewPart ||
-    []
-      .concat(
-        payload.value.declaredPlants,
-        payload.value.declaredMicroorganisms,
-        payload.value.declaredIngredients,
-        payload.value.declaredSubstances
-      )
-      .some((x) => x.new)
-  )
-})
 const readonly = computed(
   () =>
     !isNewDeclaration.value &&
@@ -234,7 +219,7 @@ const showWithdrawal = computed(() => payload.value.status === "AUTHORIZED")
 const components = computed(() => {
   const baseComponents = readonly.value ? [SummaryTab] : [ProductTab, CompositionTab, AttachmentTab, SummaryTab]
 
-  if (!readonly.value && hasNewElements.value) baseComponents.splice(2, 0, NewElementTab)
+  if (!readonly.value && hasNewElements(payload.value)) baseComponents.splice(2, 0, NewElementTab)
   if (showHistory.value) baseComponents.splice(0, 0, HistoryTab)
   if (showWithdrawal.value) baseComponents.push(WithdrawalTab)
   return baseComponents


### PR DESCRIPTION
https://www.notion.so/incubateur-masa/Bug-les-boutons-dans-l-onglet-soumettre-ne-renvoie-pas-au-bon-endroit-2afde24614be8083a15cd4f40abe9ca5?source=copy_link

Avant, ces liens renvoient la déclarante vers les onglets composition et nouveaux ingrédients (si il y a des nouveaux ingrédients). Maintenant, le premier renvoie l'utilisateur vers l'onglet produit, et le deuxième prend en compte si la déclaration a des nouveaux ingrédients ou non

<img width="992" height="549" alt="Screenshot 2025-11-25 at 12-19-48 Soumettre - étape 5 sur 5 - Déclaration « test edit links » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/8cf418c4-18e0-4691-bd8f-853d79203875" />
