### PR TITLE
Bug fix open data : gérer le cas où les plantes déclarées n'ont pas d'unité

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -581,7 +581,7 @@ class OpenDataDeclarationSerializer(serializers.ModelSerializer):
                 "partie": declared_plant.used_part.name if declared_plant.used_part else None,
                 "preparation": declared_plant.preparation.name if declared_plant.preparation else None,
                 "quantité_par_djr": declared_plant.quantity if declared_plant.quantity else None,
-                "unite": declared_plant.unit.name,
+                "unite": declared_plant.unit.name if declared_plant.unit else None,
             }
             if active
             else declared_plant.plant.name


### PR DESCRIPTION
Issu: 
- https://sentry.incubateur.net/organizations/betagouv/issues/202194/?project=146&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream
- https://sentry.incubateur.net/organizations/betagouv/issues/214038/events/001d5e7972934909b9eb0b421bba8854/?referrer=issue_details.related_trace_issue

Pas de MAJ de données depuis 3 novembre, bug introduit dans https://github.com/betagouv/complements-alimentaires/commit/fcc01e2ec6a1d89fd5dc8f03a7469a7987b41b4c