### PR TITLE
Refacto : utiliser un enum pour la gestion d'ids template

### DIFF
--- a/api/views/company.py
+++ b/api/views/company.py
@@ -271,11 +271,10 @@ class AddMandatedCompanyView(GenericAPIView):
 
         company.mandated_companies.add(mandated_company)
 
-        brevo_template = 27
         for supervisor in mandated_company.supervisor_roles.all():
             try:
                 email.send_sib_template(
-                    brevo_template,
+                    email.EmailTemplateID.COMPANY_GIVEN_MANDATE.value,
                     {
                         "COMPANY_NAME": company.social_name,
                         "MANDATED_COMPANY_NAME": mandated_company.social_name,

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -581,7 +581,7 @@ class DeclarationSubmitView(DeclarationFlowView):
     transition = "submit"
     create_snapshot = True
     snapshot_action = Snapshot.SnapshotActions.SUBMIT
-    brevo_template_id = 3
+    brevo_template_id = email.EmailTemplateID.DECLARATION_SUBMISSION_CONFIRMATION.value
 
 
 class DeclarationTakeForInstructionView(DeclarationFlowView):
@@ -623,7 +623,7 @@ class DeclarationObserveView(DeclarationFlowView):
     transition = "observe_no_visa"
     create_snapshot = True
     snapshot_action = Snapshot.SnapshotActions.OBSERVE_NO_VISA
-    brevo_template_id = 4
+    brevo_template_id = email.EmailTemplateID.DECLARATION_OBSERVATION.value
 
     def on_transition_success(self, request, declaration):
         declaration.instructor = InstructionRole.objects.get(user=request.user)
@@ -639,7 +639,7 @@ class DeclarationAuthorizeView(DeclarationFlowView):
     transition = "authorize_no_visa"
     create_snapshot = True
     snapshot_action = Snapshot.SnapshotActions.AUTHORIZE_NO_VISA
-    brevo_template_id = 6
+    brevo_template_id = email.EmailTemplateID.DECLARATION_AUTHORIZED.value
 
     def on_transition_success(self, request, declaration):
         declaration.instructor = InstructionRole.objects.get(user=request.user)
@@ -679,7 +679,7 @@ class DeclarationWithdrawView(DeclarationFlowView):
     transition = "withdraw"
     create_snapshot = True
     snapshot_action = Snapshot.SnapshotActions.WITHDRAW
-    brevo_template_id = 8
+    brevo_template_id = email.EmailTemplateID.DECLARATION_WITHDRAWN.value
 
     def perform_snapshot_creation(self, request, declaration):
         """
@@ -793,10 +793,10 @@ class DeclarationAcceptVisaView(VisaDecisionView):
 
     def get_brevo_template_id(self, request, declaration):
         template_map = {
-            Declaration.DeclarationStatus.AUTHORIZED: 6,
-            Declaration.DeclarationStatus.REJECTED: 7,
-            Declaration.DeclarationStatus.OBJECTION: 5,
-            Declaration.DeclarationStatus.OBSERVATION: 4,
+            Declaration.DeclarationStatus.AUTHORIZED: email.EmailTemplateID.DECLARATION_AUTHORIZED.value,
+            Declaration.DeclarationStatus.REJECTED: email.EmailTemplateID.DECLARATION_REJECTED.value,
+            Declaration.DeclarationStatus.OBJECTION: email.EmailTemplateID.DECLARATION_OBJECTION.value,
+            Declaration.DeclarationStatus.OBSERVATION: email.EmailTemplateID.DECLARATION_OBSERVATION.value,
         }
         return template_map.get(self.get_validation_status(request, declaration))
 

--- a/api/views/solicitation.py
+++ b/api/views/solicitation.py
@@ -102,9 +102,8 @@ class AddNewCollaboratorView(APIView):
                     role_class.objects.get_or_create(company=company, user=recipient)
 
                 try:
-                    brevo_template_id = 18
                     email.send_sib_template(
-                        brevo_template_id,
+                        email.EmailTemplateID.USER_ADDED_TO_COMPANY.value,
                         {
                             "SENDER_NAME": sender.get_full_name(),
                             "COMPANY_NAME": company.social_name,

--- a/api/views/user.py
+++ b/api/views/user.py
@@ -34,10 +34,9 @@ logger = logging.getLogger(__name__)
 def _send_verification_mail(user):
     new_token = MagicLinkToken.objects.create(user=user, usage=MagicLinkUsage.VERIFY_EMAIL_ADDRESS)
     verification_url = urljoin(get_base_url(), new_token.as_url(key=new_token.key))
-    brevo_template_id = 19
     try:
         email.send_sib_template(
-            brevo_template_id,
+            email.EmailTemplateID.CONFIRM_EMAIL.value,
             {"CONFIRMATION_LINK": verification_url},
             user.email,
             user.get_full_name(),

--- a/config/email.py
+++ b/config/email.py
@@ -1,3 +1,4 @@
+import enum
 from django.conf import settings
 
 import sib_api_v3_sdk
@@ -6,6 +7,28 @@ configuration = sib_api_v3_sdk.Configuration()
 configuration.api_key["api-key"] = settings.ANYMAIL.get("SENDINBLUE_API_KEY")
 api_client = sib_api_v3_sdk.ApiClient(configuration)
 email_api_instance = sib_api_v3_sdk.TransactionalEmailsApi(api_client)
+
+
+class EmailTemplateID(enum.Enum):
+    USER_ADDED_TO_COMPANY = 18
+    CONFIRM_EMAIL = 19
+    REQUEST_TO_JOIN_EMPTY_COMPANY = 15
+    REQUEST_TO_JOIN_COMPANY = 12
+    ACCEPT_REQUEST_TO_JOIN_COMPANY = 13
+    REFUSE_REQUEST_TO_JOIN_COMPANY = 14
+    INVITE_TO_JOIN_COMPANY = 16
+    COMPANY_INVITATION_ACCEPTED = 17
+    COMPANY_GIVEN_MANDATE = 27
+    # Declaration flow
+    DECLARATION_SUBMISSION_CONFIRMATION = 3
+    DECLARATION_OBSERVATION = 4
+    DECLARATION_OBJECTION = 5
+    DECLARATION_AUTHORIZED = 6
+    DECLARATION_WITHDRAWN = 8
+    DECLARATION_AUTHORIZATION_REVOKED = 37
+    DECLARATION_REJECTED = 7
+    DECLARATION_EXPIRATION_REMINDER = 10
+    DECLARATION_EXPIRED = 9
 
 
 def send_sib_template(template_id, parameters, to_email, to_name):

--- a/data/models/solicitation.py
+++ b/data/models/solicitation.py
@@ -104,11 +104,10 @@ class SupervisionClaim(BaseSolicitation, models.Model):
     def create_hook(self):
         recipients = User.objects.filter(is_staff=True)
         self.recipients.set(recipients)  # TODO: Je ne pense pas que le self.recipients sert à quelque chose
-        brevo_template_id = 15
         for recipient in recipients:
             try:
                 email.send_sib_template(
-                    brevo_template_id,
+                    email.EmailTemplateID.REQUEST_TO_JOIN_EMPTY_COMPANY.value,
                     {
                         "REQUESTER_NAME": self.sender.get_full_name(),
                         "COMPANY_NAME": self.company.social_name,
@@ -174,11 +173,10 @@ class CompanyAccessClaim(BaseSolicitation, models.Model):
     def create_hook(self):
         recipients = self.company.supervisors.all()
         self.recipients.set(recipients)
-        brevo_template_id = 12
         for recipient in self.recipients.all():
             try:
                 email.send_sib_template(
-                    brevo_template_id,
+                    email.EmailTemplateID.REQUEST_TO_JOIN_COMPANY.value,
                     {
                         "REQUESTER_NAME": self.sender.get_full_name(),
                         "COMPANY_NAME": self.company.social_name,
@@ -199,10 +197,9 @@ class CompanyAccessClaim(BaseSolicitation, models.Model):
         if self.declarant_role:
             self.company.declarants.add(self.sender)
 
-        brevo_template_id = 13
         try:
             email.send_sib_template(
-                brevo_template_id,
+                email.EmailTemplateID.ACCEPT_REQUEST_TO_JOIN_COMPANY.value,
                 {
                     "REQUESTER_NAME": self.sender.get_full_name(),
                     "COMPANY_NAME": self.company.social_name,
@@ -217,10 +214,9 @@ class CompanyAccessClaim(BaseSolicitation, models.Model):
 
     @processable_action
     def refuse(self, processor):
-        brevo_template_id = 14
         try:
             email.send_sib_template(
-                brevo_template_id,
+                email.EmailTemplateID.REFUSE_REQUEST_TO_JOIN_COMPANY.value,
                 {
                     "COMPANY_NAME": self.company.social_name,
                 },
@@ -257,10 +253,9 @@ class CollaborationInvitation(BaseSolicitation, models.Model):
         return f"{self.sender.name} vous invite à créer un compte Compl'Alim et rejoindre l'entreprise {self.company.social_name}."
 
     def create_hook(self):
-        brevo_template_id = 16
         try:
             email.send_sib_template(
-                brevo_template_id,
+                email.EmailTemplateID.INVITE_TO_JOIN_COMPANY.value,
                 {
                     "COMPANY_NAME": self.company.social_name,
                     "SENDER_NAME": self.sender.name,
@@ -281,9 +276,8 @@ class CollaborationInvitation(BaseSolicitation, models.Model):
             role_class.objects.get_or_create(company=self.company, user=processor)
 
         try:
-            brevo_template_id = 17
             email.send_sib_template(
-                brevo_template_id,
+                email.EmailTemplateID.COMPANY_INVITATION_ACCEPTED.value,
                 {
                     "COMPANY_NAME": self.company.social_name,
                     "NEW_COLLABORATOR": processor.get_full_name(),


### PR DESCRIPTION
J'ai eu la réflexion que ce serait plus nette d'utiliser un enum pour la gestion de template ids de brevo dans notre code. J'ai laissé les tests avec les valeurs utilisées directement. Si vous n'êtes pas d'accord avec ce changement, n'hesitez pas t'exprimer 