### PR TITLE
RGAA 13.9 : rendre le champ entreprise visible sur les petits écrans

### DIFF
--- a/frontend/src/components/CompanyTag.vue
+++ b/frontend/src/components/CompanyTag.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- on n'utilise pas directement le composant DsfrTag car il n'est pas assez personnalisable -->
-  <div class="flex items-center fr-badge fr-badge--warning fr-badge--no-icon fr-badge--sm">
+  <div class="flex items-center fr-badge fr-badge--warning fr-badge--no-icon fr-badge--sm my-1">
     <v-icon class="size-3" name="ri-home-4-line" aria-hidden />
     <div class="ml-0.5">{{ name }}</div>
   </div>

--- a/frontend/src/views/DashboardPage/RoleBarBlock.vue
+++ b/frontend/src/views/DashboardPage/RoleBarBlock.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="bg-blue-france-950 h-14 flex items-center">
+  <div class="bg-blue-france-950 py-2 flex items-center">
     <div class="fr-container">
-      <div class="flex justify-between">
+      <div class="sm:flex justify-between">
         <div class="flex items-center gap-x-2.5 gap-y-1 flex-wrap">
           <div class="flex items-center gap-x-1">
             <v-icon class="text-blue-france-sun-113" name="ri-account-circle-line" />


### PR DESCRIPTION
https://www.notion.so/incubateur-masa/Dans-chaque-page-web-le-contenu-propose-est-il-consultable-quelle-que-soit-l-orientation-de-l-ecran-26ade24614be818fa2edde8e098df045?source=copy_link

# Plusieurs entreprises

## avant
<img width="487" height="117" alt="Screenshot 2025-12-31 at 13-54-05 Tableau de bord - Cohen - Compl&#39;Alim" src="https://github.com/user-attachments/assets/c4842d4c-c552-4544-b002-35eaeb75195b" />
<img width="1692" height="121" alt="Screenshot 2025-12-31 at 13-53-49 Tableau de bord - Cohen - Compl&#39;Alim" src="https://github.com/user-attachments/assets/c87d9e54-4fce-4abb-bbb3-1d17ce292b42" />

## après
<img width="480" height="226" alt="Screenshot 2025-12-31 at 13-53-02 Tableau de bord - Cohen - Compl&#39;Alim" src="https://github.com/user-attachments/assets/47e92953-89c2-4ebc-8501-1f0a58987321" />
<img width="1692" height="120" alt="Screenshot 2025-12-31 at 13-53-34 Tableau de bord - Cohen - Compl&#39;Alim" src="https://github.com/user-attachments/assets/4ed26e85-1811-4aa6-a8a3-ad71af538748" />

# Pour une entreprise

## avant
<img width="1735" height="132" alt="Screenshot 2025-12-31 at 13-59-34 Tableau de bord - Compl&#39;Alim" src="https://github.com/user-attachments/assets/b3b2f3cc-598e-450d-b832-160f63ff74b9" />
<img width="480" height="132" alt="Screenshot 2025-12-31 at 13-59-26 Tableau de bord - Compl&#39;Alim" src="https://github.com/user-attachments/assets/9f901ee5-c9e0-492b-ac9e-a6c53c6f7a91" />

## après
<img width="1774" height="136" alt="Screenshot 2025-12-31 at 13-58-47 Tableau de bord - Compl&#39;Alim" src="https://github.com/user-attachments/assets/1ccbef52-56cc-4d75-b9f8-25fa5476cfab" />
<img width="481" height="177" alt="Screenshot 2025-12-31 at 13-59-00 Tableau de bord - Compl&#39;Alim" src="https://github.com/user-attachments/assets/1248e4e7-93ea-426b-91d1-20f0fc3b4491" />

C'est plus important quand le nom de l'entreprise est long.
