### PR TITLE
RGAA 13.9 : rendre les valeurs selectionnées pour les champs dans l'onglet produit visibles pour les petits écrans

### DIFF
--- a/frontend/src/views/ProducerFormPage/ProductTab.vue
+++ b/frontend/src/views/ProducerFormPage/ProductTab.vue
@@ -88,8 +88,8 @@
     <div class="grid grid-cols-2 gap-4">
       <div class="col-span-2 md:col-span-1 max-w-md mt-6">
         <DsfrFieldset legend="Poids ou volume d'une unité de consommation">
-          <div class="flex">
-            <div class="max-w-64">
+          <div class="sm:flex">
+            <div class="max-w-64 mb-4 sm:mb-0">
               <NumberField
                 label="Quantité"
                 label-visible
@@ -98,7 +98,7 @@
                 :required="true"
               />
             </div>
-            <div class="max-w-32 ml-4">
+            <div class="max-w-32 sm:ml-4">
               <DsfrSelect
                 label="Unité"
                 label-visible
@@ -111,7 +111,7 @@
           </div>
         </DsfrFieldset>
       </div>
-      <div class="col-span-2 md:col-span-1 max-w-md pt-0 sm:pt-8">
+      <div class="col-span-2 md:col-span-1 max-w-md pt-0 sm:pt-12">
         <DsfrInputGroup>
           <DsfrInput v-model="payload.conditioning" label-visible label="Conditionnement" />
         </DsfrInputGroup>


### PR DESCRIPTION
J'affiche l'exemple le plus complèxe : quand "autre" est selectionné

https://www.notion.so/incubateur-masa/Dans-chaque-page-web-le-contenu-propose-est-il-consultable-quelle-que-soit-l-orientation-de-l-ecran-26ade24614be81cfa7c1e4d32454f853?source=copy_link

# Forme galenique

## avant

<img width="1831" height="298" alt="Screenshot 2025-12-31 at 14-46-47 Produit - étape 1 sur 4 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/e0fbecc2-4cbc-4051-99f1-99b9006daf28" />
<img width="465" height="378" alt="Screenshot 2025-12-31 at 14-47-02 Produit - étape 1 sur 4 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/b4a83023-8f6f-477d-ae50-f5b0f9c9e0f1" />

ici le pb principal - quand l'écran est petit, on ne voit plus les valeurs selectionnées

## après
<img width="1848" height="319" alt="Screenshot 2025-12-31 at 14-45-21 Produit - étape 1 sur 4 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/5698758e-65de-4556-957a-126d7d6c75c7" />
<img width="456" height="639" alt="Screenshot 2025-12-31 at 14-45-10 Produit - étape 1 sur 4 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/e60c0d36-c70b-4049-a1a9-882e700138cf" />

J'ai modifié aussi l'espacement après le legende car je trouve que c'est bizarre quand c'est à 0

# Unité

## Avant
<img width="462" height="444" alt="Screenshot 2025-12-31 at 14-59-03 Produit - étape 1 sur 4 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/f43156c1-dc67-46bd-9c8c-87ee901d79a6" />
<img width="1860" height="210" alt="Screenshot 2025-12-31 at 14-58-54 Produit - étape 1 sur 4 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/1198e7b6-f840-4146-9bc2-221dc421bfff" />

## Après
<img width="469" height="585" alt="Screenshot 2025-12-31 at 14-58-02 Produit - étape 1 sur 4 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/30ebf553-62c6-4552-97e6-aa70ff3c0aa5" />
<img width="1866" height="237" alt="Screenshot 2025-12-31 at 14-57-40 Produit - étape 1 sur 4 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/c2a58d79-ea91-411f-9d53-fa9854f11435" />
