### PR TITLE
RGAA 8.9 : structurer le contenu d'alertes dans la balise semantique

### DIFF
--- a/frontend/src/components/RegulatoryWarning.vue
+++ b/frontend/src/components/RegulatoryWarning.vue
@@ -1,9 +1,12 @@
 <template>
   <DsfrAlert type="warning" small>
-    La base de données des ingrédients et substances constitue un guide sur lequel les opérateurs désireux de
-    commercialiser des compléments alimentaires peuvent s’appuyer qui n'a pas force de loi. En particulier, s'agissant
-    du statut des ingrédients mis en œuvre au regard de la réglementation relative aux nouveaux aliments, les opérateurs
-    doivent être en mesure de prouver que les ingrédients disposent d'un historique de consommation dans l'Union
-    européenne avant le 15 mai 1997 ou, à défaut, qu'ils ont été autorisés au titre du règlement (UE) n°2015/2283
+    <p>
+      La base de données des ingrédients et substances constitue un guide sur lequel les opérateurs désireux de
+      commercialiser des compléments alimentaires peuvent s’appuyer qui n'a pas force de loi. En particulier, s'agissant
+      du statut des ingrédients mis en œuvre au regard de la réglementation relative aux nouveaux aliments, les
+      opérateurs doivent être en mesure de prouver que les ingrédients disposent d'un historique de consommation dans
+      l'Union européenne avant le 15 mai 1997 ou, à défaut, qu'ils ont été autorisés au titre du règlement (UE)
+      n°2015/2283
+    </p>
   </DsfrAlert>
 </template>

--- a/frontend/src/views/CompanyFormPage/ClaimSupervision.vue
+++ b/frontend/src/views/CompanyFormPage/ClaimSupervision.vue
@@ -1,12 +1,14 @@
 <template>
   <div>
     <DsfrAlert>
-      L'entreprise
-      <strong>{{ company.socialName }}</strong>
-      avec le n° {{ company.identifierType.toUpperCase() + " " }}
-      <strong>{{ company.identifier }}</strong>
-      est présente dans notre base de données, mais ne dispose actuellement d'aucun gestionnaire. Si vous souhaitez
-      revendiquer la gestion de cette entreprise, veuillez nous envoyer une demande :
+      <p>
+        L'entreprise
+        <strong>{{ company.socialName }}</strong>
+        avec le n° {{ company.identifierType.toUpperCase() + " " }}
+        <strong>{{ company.identifier }}</strong>
+        est présente dans notre base de données, mais ne dispose actuellement d'aucun gestionnaire. Si vous souhaitez
+        revendiquer la gestion de cette entreprise, veuillez nous envoyer une demande :
+      </p>
       <DsfrInputGroup>
         <DsfrInput v-model="message" label="Message (optionnel)" labelVisible isTextarea />
       </DsfrInputGroup>

--- a/frontend/src/views/CompanyFormPage/CreateCompany.vue
+++ b/frontend/src/views/CompanyFormPage/CreateCompany.vue
@@ -1,12 +1,14 @@
 <template>
   <div>
     <DsfrAlert>
-      L'entreprise dont le n°
-      {{ company.identifierType.toUpperCase() + " " }}
-      est
-      <strong>{{ company.identifier }}</strong>
-      n'est pas encore enregistrée dans notre base de données. Pour ce faire, veuillez vérifier ou compléter les
-      informations ci-dessous. À l'issue, vous en deviendrez automatiquement son gestionnaire.
+      <p>
+        L'entreprise dont le n°
+        {{ company.identifierType.toUpperCase() + " " }}
+        est
+        <strong>{{ company.identifier }}</strong>
+        n'est pas encore enregistrée dans notre base de données. Pour ce faire, veuillez vérifier ou compléter les
+        informations ci-dessous. À l'issue, vous en deviendrez automatiquement son gestionnaire.
+      </p>
     </DsfrAlert>
     <CompanyForm
       class="mt-8"

--- a/frontend/src/views/CompanyFormPage/EndClaimDone.vue
+++ b/frontend/src/views/CompanyFormPage/EndClaimDone.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <DsfrAlert type="success">
-      <div>
+      <p>
         Votre demande a bien été envoyée. Veuillez patienter. Vous recevrez un e-mail lorsque celle-ci aura été traitée.
-      </div>
+      </p>
       <DsfrButton
         class="mt-4"
         label="Retour au tableau de bord"

--- a/frontend/src/views/CompanyFormPage/EndCompanyCreated.vue
+++ b/frontend/src/views/CompanyFormPage/EndCompanyCreated.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <DsfrAlert type="success">
-      <div>L'entreprise « {{ company.socialName }} » a bien été créée et vous en avez les droits de gestion.</div>
+      <p>L'entreprise « {{ company.socialName }} » a bien été créée et vous en avez les droits de gestion.</p>
       <div class="mt-4 flex gap-x-4">
         <DsfrButton
           :label="`Accéder à « ${company.socialName} »`"

--- a/frontend/src/views/CompanyFormPage/NothingToDo.vue
+++ b/frontend/src/views/CompanyFormPage/NothingToDo.vue
@@ -1,12 +1,13 @@
 <template>
   <div>
     <DsfrAlert>
-      L'entreprise
-      <strong>{{ company.socialName }}</strong>
-      avec le n° {{ company.identifierType.toUpperCase() + " " }}
-      <strong>{{ company.identifier }}</strong>
-      fait déjà partie des entreprises dont vous êtes le gestionnaire.
-
+      <p>
+        L'entreprise
+        <strong>{{ company.socialName }}</strong>
+        avec le n° {{ company.identifierType.toUpperCase() + " " }}
+        <strong>{{ company.identifier }}</strong>
+        fait déjà partie des entreprises dont vous êtes le gestionnaire.
+      </p>
       <!-- TODO: changer la redirection quand la page d'entreprise particulière existe -->
       <div class="mt-4 flex gap-x-4">
         <DsfrButton

--- a/frontend/src/views/DeclaredElementPage/ElementAlert.vue
+++ b/frontend/src/views/DeclaredElementPage/ElementAlert.vue
@@ -1,16 +1,18 @@
 <template>
   <DsfrAlert v-if="alert" v-bind="alert" class="mb-4">
-    <span v-if="alert.description">{{ alert.description }}</span>
-    <span v-else-if="element.isPartRequest && element.requestStatus === 'REPLACED'">
-      Partie de plante autorisée pour
-      <router-link :to="elementLink">{{ element.element.name }}</router-link>
-      dans la composition de la déclaration.
-    </span>
-    <span v-else-if="element.requestStatus === 'REPLACED'">
-      Ingrédient initial remplacé par
-      <router-link :to="elementLink">{{ element.element.name }}</router-link>
-      dans la composition de la déclaration.
-    </span>
+    <p>
+      <span v-if="alert.description">{{ alert.description }}</span>
+      <span v-else-if="element.isPartRequest && element.requestStatus === 'REPLACED'">
+        Partie de plante autorisée pour
+        <router-link :to="elementLink">{{ element.element.name }}</router-link>
+        dans la composition de la déclaration.
+      </span>
+      <span v-else-if="element.requestStatus === 'REPLACED'">
+        Ingrédient initial remplacé par
+        <router-link :to="elementLink">{{ element.element.name }}</router-link>
+        dans la composition de la déclaration.
+      </span>
+    </p>
   </DsfrAlert>
 </template>
 

--- a/frontend/src/views/ProducerHomePage/SearchBlock.vue
+++ b/frontend/src/views/ProducerHomePage/SearchBlock.vue
@@ -8,8 +8,10 @@
         <h1>Tester ma composition de compléments alimentaires</h1>
         <p>Vérifier la conformité de vos ingrédients en amont de vos développements produits.</p>
         <DsfrAlert small class="mb-4">
-          <b>Non exhaustivité des données</b>
-          : Cette base est en amélioration continue, nous faisons notre possible pour la mettre à jour régulièrement.
+          <p>
+            <b>Non exhaustivité des données</b>
+            : Cette base est en amélioration continue, nous faisons notre possible pour la mettre à jour régulièrement.
+          </p>
         </DsfrAlert>
         <ElementAutocomplete
           autocomplete="nothing"


### PR DESCRIPTION
https://www.notion.so/incubateur-masa/Dans-chaque-page-web-les-balises-ne-doivent-pas-tre-utilisees-uniquement-des-fins-de-presentatio-26ade24614be81958ecdfe0c51f8337d?source=copy_link

Pas de changement visuel

Cette PR a fait l'audit de toutes les utilisations de DsfrAlert, et corriger quelques instances où le contenu n'a pas été dans la balise semantique `p`