### PR TITLE
RGAA 9.2 : il ne peut pas avoir deux navigations principales

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -10,10 +10,7 @@
       </div>
     </template>
     <template #mainnav>
-      <div class="flex justify-between whitespace-nowrap">
-        <DsfrNavigation :nav-items="navItems" />
-        <DsfrNavigation v-if="store.loggedUser" :nav-items="loggedOnlyNavItems" />
-      </div>
+      <DsfrNavigation :nav-items="navItems" :class="{ 'last-link-right': store.loggedUser }" />
     </template>
   </DsfrHeader>
 </template>
@@ -27,30 +24,32 @@ defineProps({ logoText: Array })
 
 const environment = window.ENVIRONMENT
 const store = useRootStore()
-const navItems = [
-  {
-    to: "/accueil",
-    text: "Accueil",
-  },
-  {
-    to: "/entreprises",
-    text: "Recherche ingrédients",
-  },
-  {
-    to: "/blog",
-    text: "Ressources",
-  },
-  {
-    to: "/faq",
-    text: "FAQ",
-  },
-]
-const loggedOnlyNavItems = [
-  {
-    to: "/tableau-de-bord",
-    text: "Tableau de bord",
-  },
-]
+const navItems = computed(() => {
+  const links = [
+    {
+      to: "/accueil",
+      text: "Accueil",
+    },
+    {
+      to: "/entreprises",
+      text: "Recherche ingrédients",
+    },
+    {
+      to: "/blog",
+      text: "Ressources",
+    },
+    {
+      to: "/faq",
+      text: "FAQ",
+    },
+  ]
+  if (store.loggedUser)
+    links.push({
+      to: "/tableau-de-bord",
+      text: "Tableau de bord",
+    })
+  return links
+})
 
 const quickLinks = computed(() => {
   if (store.loggedUser)
@@ -77,3 +76,9 @@ const quickLinks = computed(() => {
     ]
 })
 </script>
+
+<style>
+.fr-header__menu:not(.fr-modal--opened) nav.last-link-right > ul > li:last-child {
+  margin-left: auto;
+}
+</style>


### PR DESCRIPTION
Avant on a utilisé deux `DsfrNavigation` pour mettre le lien tableau de bord à droit de la barre de navigation. Ça pose un problème d'accessibilité car il y a deux elements `nav` avec le même label `Menu principale`.

https://www.notion.so/incubateur-masa/Dans-chaque-page-web-la-structure-du-document-est-elle-coherente-hors-cas-particuliers-26ade24614be8137ac9edd01368e2505?source=copy_link

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#9.2

J'ai fait un changement alors pour mettre le lien vers le tableau de bord dans la même liste que les autres liens, et j'ai ajouté du CSS pour garder le même alignement.

Il y a quelques petits changements visuels

## Avant, vue desktop

<img width="2155" height="340" alt="Screenshot 2026-01-09 at 11-33-38 Tableau de bord - Compl&#39;Alim" src="https://github.com/user-attachments/assets/1b46a0eb-0ee8-4c2f-99b5-c562320d3a45" />

## Après, vue desktop

<img width="2155" height="334" alt="Screenshot 2026-01-09 at 11-33-45 Tableau de bord - Cohen - Compl&#39;Alim" src="https://github.com/user-attachments/assets/100c0b1d-6d75-4e6c-80b4-9d7f55922b1d" />

## Avant, vue menu mobile
<img width="736" height="1050" alt="Screenshot 2026-01-09 at 11-33-18 Tableau de bord - ROOT ACCESS - Compl&#39;Alim" src="https://github.com/user-attachments/assets/371f62cd-1950-4ab4-9c84-ade4cb5c614f" />


## Avant, vue menu mobile
<img width="736" height="1050" alt="Screenshot 2026-01-09 at 10-34-49 Tableau de bord - Cohen - Compl&#39;Alim" src="https://github.com/user-attachments/assets/4b167192-ffd9-4d22-a3ac-4ce4fa29e495" />