### PR TITLE
RGAA 7.3 et 10.8 : rendre la suppression des rôles atteignable par clavier

### DIFF
--- a/frontend/src/components/RoleTag.vue
+++ b/frontend/src/components/RoleTag.vue
@@ -1,22 +1,25 @@
 <template>
   <!-- on n'utilise pas directement le composant DsfrTag car il n'est pas assez personnalisable -->
-  <div class="flex items-center fr-badge fr-badge--new fr-badge--no-icon fr-badge--sm">
-    <v-icon class="size-3.5" name="ri-user-settings-line" />
-    <div class="ml-0.5">{{ roleNameDisplayNameMapping[role] }}</div>
-    <v-icon
-      v-if="showActions"
-      role="button"
-      aria-label="Enlèver ce rôle"
-      @click="$emit('remove')"
-      class="size-4 ml-1 hover:text-red-marianne-425 hover:cursor-pointer"
-      name="ri-close-circle-line"
-    />
+  <div>
+    <component
+      :is="showActions ? 'button' : 'p'"
+      class="flex items-center fr-badge fr-badge--new fr-badge--no-icon fr-badge--sm"
+      :aria-label="showActions && `Retirer le rôle ${roleName} à ${user.firstName} ${user.lastName}`"
+      @click="showActions && $emit('remove')"
+    >
+      <v-icon class="size-3.5" name="ri-user-settings-line" />
+      <div class="ml-0.5">{{ roleName }}</div>
+      <v-icon v-if="showActions" class="size-4 ml-1" name="ri-close-circle-line" />
+    </component>
   </div>
 </template>
 
 <script setup>
+import { computed } from "vue"
 import { roleNameDisplayNameMapping } from "@/utils/mappings"
 
-defineProps({ role: String, showActions: { type: Boolean, default: false } })
+const props = defineProps({ role: String, showActions: { type: Boolean, default: false }, user: Object })
 defineEmits(["remove"])
+
+const roleName = computed(() => roleNameDisplayNameMapping[props.role])
 </script>

--- a/frontend/src/views/CollaboratorsPage/index.vue
+++ b/frontend/src/views/CollaboratorsPage/index.vue
@@ -31,6 +31,7 @@
               v-for="role in user.roles"
               :key="role.name"
               :role="role.name"
+              :user="user"
               :show-actions="!(role.name == 'SupervisorRole' && user.id == loggedUser.id)"
               @remove="changeRole(role.name, user, 'remove')"
             />


### PR DESCRIPTION
Aujourd'hui sur la page gestion de collaborateurs, on utilise un composant customisé pour afficher les rôles et les rendre supprimables. Or, la fonctionnalité rattaché à l'icône croix n'est pas atteignable par clavier. Pour réparer ça, j'ai rendu tout le tag/badge avec le rôle clickable avec l’élément natif `button` quand c'est actionnable. Sinon, c'est simplement un `p`.

Le changement visuel n'est pas énorme. D'abord on voit toujours la même chose :

<img width="804" height="400" alt="Screenshot 2026-01-12 at 12-37-06 Gestion des collaborateurs - Compl&#39;Alim" src="https://github.com/user-attachments/assets/8dea4d1d-37e6-4992-abf3-15c3aad36fcb" />

Mais, avec survol d'un tag, le fond du tag change :

<img width="768" height="400" alt="Screenshot from 2026-01-12 12-37-19" src="https://github.com/user-attachments/assets/04471a45-9b99-4f1d-bb9d-8d1c4671527b" />

Et c'est maintenant atteignable par clavier :

<img width="768" height="400" alt="image" src="https://github.com/user-attachments/assets/d5da6d97-b90e-4f17-bc41-351dee651f7f" />

Tickets notion :
- https://www.notion.so/incubateur-masa/Pour-chaque-page-web-les-contenus-caches-ont-ils-vocation-tre-ignores-par-les-technologies-d-ass-26ade24614be8129884bccea280f4243?source=copy_link
- https://www.notion.so/incubateur-masa/Chaque-script-est-il-contr-lable-par-le-clavier-et-par-tout-dispositif-de-pointage-hors-cas-particu-26ade24614be813f8272dba6c519cceb?source=copy_link