### PR TITLE
RGAA 11.6 : Dans chaque formulaire, chaque regroupement de champs de même nature a-t-il une legende ?

### DIFF
--- a/frontend/src/components/MultiselectFilter.vue
+++ b/frontend/src/components/MultiselectFilter.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <DsfrModal :opened="opened" @close="opened = false">
-      <DsfrCheckboxSet v-model="selectedOptions" :options="options" />
+    <DsfrModal :opened="opened" @close="opened = false" :title="modalTitle">
+      <DsfrCheckboxSet v-model="selectedOptions" :options="options" :legend="legend" />
     </DsfrModal>
     <p class="mb-2!">
       {{ filterTitle }}
@@ -33,6 +33,8 @@ const props = defineProps({
   options: { type: Array },
   selectedString: { type: String, required: false },
   filterTitle: { type: String },
+  modalTitle: { type: String },
+  legend: { type: String },
   noFilterText: { type: String, required: false },
 })
 const selectedOptions = ref([])

--- a/frontend/src/components/StatusFilter.vue
+++ b/frontend/src/components/StatusFilter.vue
@@ -4,6 +4,8 @@
       :options="options"
       :selectedString="statusString"
       filterTitle="Types de déclaration affichés :"
+      modalTitle="Changer les déclarations affichées"
+      legend="Type de déclaration"
       noFilterText="Toutes les déclarations"
       @updateFilter="emitUpdate"
     />

--- a/frontend/src/views/NewElementsPage/index.vue
+++ b/frontend/src/views/NewElementsPage/index.vue
@@ -13,6 +13,8 @@
       <div class="border px-4 py-4 mb-2 sm:flex gap-8 items-baseline filters">
         <MultiselectFilter
           filterTitle="Statut de la demande :"
+          modalTitle="Changer les demandes affichées"
+          legend="Statut de la demande"
           :options="statusOptions"
           :selectedString="statusFilter"
           @updateFilter="(v) => updateQuery({ statut: v })"
@@ -21,6 +23,8 @@
         <div class="md:border-l md:pl-4">
           <MultiselectFilter
             filterTitle="Type :"
+            modalTitle="Changer les demandes affichées"
+            legend="Type de la demande"
             :options="typeOptions"
             :selectedString="typeFilter"
             noFilterText="Tous les types"
@@ -31,6 +35,8 @@
         <div class="md:border-l md:pl-4">
           <MultiselectFilter
             filterTitle="Statut de la déclaration :"
+            modalTitle="Changer les demandes affichées"
+            legend="Statut de la déclaration"
             :options="declarationStatusOptions"
             :selectedString="declarationStatusFilter"
             noFilterText="Toutes les déclarations ouvertes"

--- a/frontend/src/views/ProducerFormPage/ProductTab.vue
+++ b/frontend/src/views/ProducerFormPage/ProductTab.vue
@@ -157,8 +157,10 @@
       <DsfrInput is-textarea v-model="payload.warning" label-visible label="Mise en garde et avertissement" />
     </DsfrInputGroup>
 
-    <SectionTitle title="Objectifs / effets" class="mt-10!" sizeTag="h6" icon="ri-focus-2-fill" />
     <DsfrFieldset>
+      <template #legend>
+        <SectionTitle title="Objectifs / effets" class="mt-4! mb-2" sizeTag="h6" icon="ri-focus-2-fill" />
+      </template>
       <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
         <div
           v-for="effect in orderedEffects"


### PR DESCRIPTION
Cette PR contient :
- changement non visuel sur la page onglet Produit, en mettant le titre Objectifs/Effets dans le slot legend du fieldset suivant
- changement visuel sur les pages des tableaux qui contient un filtre multiselect pour ajouter un legend au fieldset dans le modal du filtre

Le titre du modale est plutôt un retour RGAA 9.1 mais vu que c'est aussi un changement visuel dans le même endroit, je l'ai inclus dans cette PR.

Je n'ai pas fait le travail de RGAA 11.5 qui est de supprimer des mauvaises utilisations des DsfrFieldsets, pour garder cette PR focus.

## Exemples de nouveau UI modal multiselect filter

<img width="787" height="754" alt="Screenshot 2026-01-13 at 11-19-31 Mes déclarations - Compl&#39;Alim" src="https://github.com/user-attachments/assets/e5e36226-d303-4271-8e55-6a9bb22a4101" />
<img width="750" height="498" alt="Screenshot 2026-01-13 at 11-22-30 Nouveaux ingrédients - Compl&#39;Alim" src="https://github.com/user-attachments/assets/310b7fe4-f074-4087-a977-24b31c0bd924" />

Tickets notion:
- https://www.notion.so/incubateur-masa/Dans-chaque-formulaire-chaque-regroupement-de-champs-de-m-me-nature-a-t-il-une-legende-26ade24614be8115a25cd57edcad172f?source=copy_link
- https://www.notion.so/incubateur-masa/Dans-chaque-formulaire-chaque-regroupement-de-champs-de-m-me-nature-a-t-il-une-legende-26ade24614be8107aca6d01e65075269?source=copy_link
- https://www.notion.so/incubateur-masa/Dans-chaque-page-web-l-information-est-elle-structuree-par-l-utilisation-appropriee-de-titres-26ade24614be8182928cf61882feac99?source=copy_link