### PR TITLE
RGAA 11.8 : Dans chaque formulaire, les items de même nature d'une liste de choix sont-ils regroupes de maniere pertinente ?

### DIFF
--- a/frontend/src/components/ElementCard.vue
+++ b/frontend/src/components/ElementCard.vue
@@ -64,7 +64,7 @@
         <div class="mb-4 md:max-w-sm">
           <DsfrSelect
             label="Préparation"
-            :options="store.preparations?.map((preparation) => ({ text: preparation.name, value: preparation.id }))"
+            :options="preparations"
             v-model.number="model.preparation"
             defaultUnselectedText=""
             :required="model.active"
@@ -142,8 +142,12 @@ const synonyms = computed(() => model.value.element?.synonyms?.map((x) => x.name
 
 const plantParts = computed(() => {
   const elementParts = model.value.element?.plantParts || []
-  const authorizedParts = elementParts.filter((p) => p.status === ingredientStatuses.AUTHORIZED.apiValue)
-  const unauthorizedParts = elementParts.filter((p) => p.status === ingredientStatuses.NOT_AUTHORIZED.apiValue)
+  const authorizedParts = elementParts
+    .filter((p) => p.status === ingredientStatuses.AUTHORIZED.apiValue)
+    .sort((a, b) => a.name.localeCompare(b.name))
+  const unauthorizedParts = elementParts
+    .filter((p) => p.status === ingredientStatuses.NOT_AUTHORIZED.apiValue)
+    .sort((a, b) => a.name.localeCompare(b.name))
   let parts = authorizedParts
   if (props.canAddNewPlantPart || !elementParts.length) {
     if (parts.length) {
@@ -154,11 +158,17 @@ const plantParts = computed(() => {
       }
       parts.push({ text: "Toutes les parties", disabled: true })
     }
-    parts = parts.concat(store.plantParts || [])
+    const allParts = [].concat(store.plantParts).sort((a, b) => a.name.localeCompare(b.name))
+    parts = parts.concat(allParts)
   }
   return parts.map((x) => {
     return x.text ? x : { text: x.name, value: x.id }
   })
+})
+
+const preparations = computed(() => {
+  const p = [].concat(store.preparations).sort((a, b) => a.name.localeCompare(b.name))
+  return p.map((preparation) => ({ text: preparation.name, value: preparation.id }))
 })
 
 const showFields = computed(() => {

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/IngredientFilterAccordeon.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/IngredientFilterAccordeon.vue
@@ -119,6 +119,7 @@ const quantityBLabel = computed(() => makeQuantityLabel("max"))
 
 const plantPartOptions = computed(() => {
   const options = plantParts.value?.map((x) => ({ text: x.name, value: x.id.toString() })) || []
+  options.sort((a, b) => a.text.localeCompare(b.text))
   options.unshift({ disabled: true, text: "---------" })
   options.unshift({ value: "", text: "Toutes les parties" })
   return options

--- a/frontend/src/views/AdvancedSearchPage/DoseFilterModal.vue
+++ b/frontend/src/views/AdvancedSearchPage/DoseFilterModal.vue
@@ -200,6 +200,7 @@ const makeQuantityLabel = (suffix) => {
 // Options pour les DsfrSelect
 const plantPartOptions = computed(() => {
   const options = plantParts.value?.map((x) => ({ text: x.name, value: x.id.toString() }))
+  options.sort((a, b) => a.text.localeCompare(b.text))
   options.unshift({ disabled: true, text: "---------" })
   options.unshift({ value: "", text: "Toutes les parties" })
   return options

--- a/frontend/src/views/ProducerFormPage/ProductTab.vue
+++ b/frontend/src/views/ProducerFormPage/ProductTab.vue
@@ -56,6 +56,7 @@
           <div class="max-w-md mb-4 sm:mb-0">
             <DsfrSelect
               :required="true"
+              :disabled="!galenicFormulationState"
               label="Forme"
               v-model="payload.galenicFormulation"
               :options="


### PR DESCRIPTION
Cette PR
- réorganise en ordre alphabétique les listes des options de Partie de plante et Préparation
- bloque la sélectionne de la forme galenique avant que la catégorie de la forme est selectionnée (sinon on a besoin de mettre les options dans la deuxième liste dans deux catégories)

Ces listes sont longs, alors il faut mettre les options dans un ordre logique. AMA c'est plus facile et pertinent de les mettre en ordre alphabétique que de créer des `optgroup`s dans la liste.

<img width="610" height="247" alt="Screenshot 2026-01-13 at 11-50-58 Produit - étape 1 sur 4 - Nouvelle démarche - Compl&#39;Alim" src="https://github.com/user-attachments/assets/c7672b3f-321e-4926-ae74-18626db264c5" />
<img width="578" height="265" alt="Screenshot 2026-01-13 at 11-51-14 Produit - étape 1 sur 4 - Nouvelle démarche - Compl&#39;Alim" src="https://github.com/user-attachments/assets/9fcb2b05-b86a-4683-8a63-566356e39cd1" />

<img width="529" height="685" alt="Screenshot from 2026-01-13 12-27-07" src="https://github.com/user-attachments/assets/464dc359-6840-4824-9557-5d7a580bcb19" />
<img width="529" height="685" alt="Screenshot from 2026-01-13 12-26-58" src="https://github.com/user-attachments/assets/460dcbb1-7786-4855-9368-962eb9539daf" />


Tickets notion
- https://www.notion.so/incubateur-masa/Dans-chaque-formulaire-les-items-de-m-me-nature-d-une-liste-de-choix-sont-ils-regroupes-de-maniere--26ade24614be816e89daf9eef16109a6?source=copy_link
- https://www.notion.so/incubateur-masa/Dans-chaque-formulaire-les-items-de-m-me-nature-d-une-liste-de-choix-sont-ils-regroupes-de-maniere--26ade24614be81c58039ca57164b30c0?source=copy_link