### PR TITLE
RGAA 13.9 : Dans chaque page web, le contenu propose est-il consultable quelle que soit l'orientation de l'ecran (portrait ou paysage) (hors cas particuliers) ?

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,7 +8,7 @@
       ]"
     />
 
-    <p v-if="environment !== 'prod'" id="env-banner" :class="`${environment} mb-0`">
+    <p v-if="environment !== 'prod'" id="env-banner" :class="`${environment} mb-0 sm:hidden`">
       Environnement de {{ environment }}
     </p>
     <AppHeader :logo-text="logoText" id="navigation" />

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -3,6 +3,12 @@
     <template #operator>
       <div class="flex items-center">
         <img :src="require('@/assets/logo.svg')" alt="Compl'Alim" class="h-20" />
+
+        <div class="hidden sm:inline">
+          <DsfrBadge v-if="environment === 'dev'" :label="environment" type="info" />
+          <DsfrBadge v-if="environment === 'demo'" :label="environment" type="new" />
+          <DsfrBadge v-if="environment === 'staging'" :label="environment" type="warning" />
+        </div>
       </div>
     </template>
     <template #mainnav>
@@ -18,6 +24,7 @@ import { logOut } from "@/utils/auth"
 
 defineProps({ logoText: Array })
 
+const environment = window.ENVIRONMENT
 const store = useRootStore()
 const navItems = computed(() => {
   const links = [


### PR DESCRIPTION
Cette PR répare une anomalie dans ce critère. En vue mobile, je remplace le badge avec le nom de l'environnement avec un bannière tout au début du site pour que le bouton menu en vue mobile soit visible pour les écrans de 320 px.

Pas de changement pour la vue desktop/mobile mode paysage.

## Avant

Dans ce capteur d'écran on voit comment le bouton hamburger du menu n'est pas visible car le badge pousse le composant hors de l'écran

<img width="320 " alt="Screenshot 2026-01-13 at 13-08-31 Accueil - Compl&#39;Alim" src="https://github.com/user-attachments/assets/541a7ce7-999b-4a20-9f65-1be7d913a717" />

## Après

<img width="200" alt="Screenshot 2026-01-13 at 13-11-00 Accueil - Compl&#39;Alim" src="https://github.com/user-attachments/assets/eaed92bc-ff8d-49db-98a9-3cbefb3e68a3" />
<img width="200" alt="Screenshot 2026-01-13 at 13-03-59 Accueil - Compl&#39;Alim" src="https://github.com/user-attachments/assets/68b4ebda-4395-4f2c-82ee-c6ee74e14710" />
<img width="200" alt="Screenshot 2026-01-13 at 13-02-47 Accueil - Compl&#39;Alim" src="https://github.com/user-attachments/assets/e68b60e4-1dc5-4451-8ea2-dbf224a86eb9" />

