### PR TITLE
Exclu une route de Matomo pour rendre à nouveau ouvertes nos stats

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -226,7 +226,7 @@ export const routes = [
     meta: {
       title: "Vérification envoyée",
       // Pas d'envoi des infos perso UserId, Email à Matomo
-      matomo: false,
+      analyticsIgnore: true,
     },
   },
   {


### PR DESCRIPTION
Ignorer une route de manière simple documenté [ici](https://dev.to/webdeasy/how-to-integrate-matomo-into-your-vue-js-application-3oho) et [ici]( https://github.com/AmazingDreams/vue-matomo/tree/52f6a8dc3bc333b1218dd1b51295a10f544a28bf?tab=readme-ov-file#ignoring-routes)

1 autre méthode était possible : https://fr.matomo.org/faq/how-to/faq_89/

### à faire ensuite

- [ ] réactiver l'accès public à notre matomo
- [ ] vérifier que les stats sont bien accessibles sur la page [stats](https://compl-alim.beta.gouv.fr/stats) et [mentions légales](https://compl-alim.beta.gouv.fr/mentions-legales)