### PR TITLE
Bug fix : afficher un lien vers la page recherche ingrédients dans le fil d'Ariane de la page de résultats

### DIFF
--- a/frontend/src/views/ElementSearchResultsPage/index.vue
+++ b/frontend/src/views/ElementSearchResultsPage/index.vue
@@ -15,7 +15,10 @@
   <div class="fr-container pb-6">
     <DsfrBreadcrumb
       class="mb-8"
-      :links="[{ to: '/', text: 'Accueil' }, { text: `Recherche : « ${currentSearch} »` }]"
+      :links="[
+        { to: { name: 'ProducerHomePage' }, text: 'Recherche ingrédients' },
+        { text: `Recherche : « ${currentSearch} »` },
+      ]"
     />
     <div v-if="isFetching" class="flex justify-center my-24">
       <ProgressSpinner />


### PR DESCRIPTION
Petite PR pour rendre le fil d'ariane cohérent

avant
<img width="484" height="202" alt="Screenshot 2026-01-20 at 16-12-40 Eucalyptus - page 1 sur 2 - Résultats de recherche - Compl&#39;Alim" src="https://github.com/user-attachments/assets/ce008480-12ed-4976-b533-f945dd5ffb0a" />


après

<img width="874" height="216" alt="Screenshot 2026-01-20 at 16-10-52 Eucalyptus - page 1 sur 2 - Résultats de recherche - Compl&#39;Alim" src="https://github.com/user-attachments/assets/a019176f-5bde-44a2-b00c-873aa168b8c3" />

la page fiche ingrédient a déjà le bon lien

<img width="777" height="196" alt="Screenshot 2026-01-20 at 16-10-59 Corymbia citriodora (Hook ) K D Hill   L A S  Johnson - Compl&#39;Alim" src="https://github.com/user-attachments/assets/21fbc743-eb8c-4442-a5ed-a33ca7de319e" />
