### PR TITLE
Customisation de l'URL de l'admin Django

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ GRIST_SD_CONTROL_DOC_ID (optionnel)= L'identifiant du document utilisé pour rec
 GRIST_SD_CONTROL_TABLE_ID (optionnel)= L'identifiant du tableau utilisé dans GRIST_SD_CONTROL_DOC_ID. Retrouvable depuis settings -> API console de grist
 GRIST_ANSES_CONTROL_DOC_ID (optionnel)= L'identifiant du document utilisé pour recuperer les mails du role contrôle. Retrouvable depuis settings -> API console de grist
 GRIST_ANSES_CONTROL_TABLE_ID (optionnel)= L'identifiant du tableau utilisé dans GRIST_ANSES_CONTROL_DOC_ID. Retrouvable depuis settings -> API console de grist
+ADMIN_URL (optionnel)= Permet de customiser l'URL de l'admin Django
 ```
 
 #### Créer les différents modèles Django dans la base de données

--- a/config/settings.py
+++ b/config/settings.py
@@ -135,6 +135,8 @@ WEBPACK_LOADER = {
     }
 }
 
+ADMIN_URL = os.environ.get("ADMIN_URL", "admin")
+
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 

--- a/config/tests/test_urls.py
+++ b/config/tests/test_urls.py
@@ -1,0 +1,21 @@
+from importlib import reload
+
+from django.test import TestCase, override_settings
+from django.urls import clear_url_caches, reverse
+
+import config.urls
+
+
+class TestAdminUrlOverride(TestCase):
+    def reload_urlconf(self):
+        """Mise à jour des URLs suite à un changement dans les settings"""
+        clear_url_caches()
+        reload(config.urls)
+
+    @override_settings(ADMIN_URL="test-admin")
+    def test_admin_url_from_env(self):
+        """
+        L'URL de l'admin doit être pris de la variable d'environnement
+        """
+        self.reload_urlconf()
+        self.assertEqual(reverse("admin:index"), "/test-admin/")

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,7 +7,7 @@ from django.urls import path, re_path
 from web.views import VueAppDisplayView
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
+    path(f"{settings.ADMIN_URL}/", admin.site.urls),
     path("prose/", include("prose.urls")),
     path("hijack/", include("hijack.urls")),
 ]


### PR DESCRIPTION
Closes #2655 

Permet de customiser l'URL de l'admin Django. Nécessaire pour l'audit d'homologation de sécurité.

La variable d'environnement `ADMIN_URL` est utilisé à ce propos.