### PR TITLE
Vérsion HTML des documents : réparer des issus du code, pas d'impacte côté utilisateur

### DIFF
--- a/web/templates/certificates/certificate-base-template.html
+++ b/web/templates/certificates/certificate-base-template.html
@@ -1,4 +1,5 @@
 {% load static %}
+<!doctype html>
 <html lang="fr">
     <head>
         <style nonce="{{ csp_nonce }}">

--- a/web/views/pdfview.py
+++ b/web/views/pdfview.py
@@ -18,13 +18,12 @@ class PdfView(GenericAPIView, ABC):
 
     def get(self, request, *args, **kwargs):
         obj = self.get_object()
-        template = get_template(self.get_template_path(obj))
-        html = template.render(self.get_context(obj))
 
         if self.as_html:
-            html = "<!doctype html>" + html
-            return HttpResponse(html, status=200)
+            return render(request, self.get_template_path(obj), self.get_context(obj))
 
+        template = get_template(self.get_template_path(obj))
+        html = template.render(self.get_context(obj))
         response = HttpResponse(content_type="application/pdf")
         filename = self.get_pdf_file_name(obj)
         response["Content-Disposition"] = f'attachment; filename="{filename}"'


### PR DESCRIPTION
Cette PR n'a pas de changements visuels.

L'extension Tanaguru qui aide avec la détéction de pbs d'accessibilité soulève deux issus avec la vérsion HTML des attestations :

<img width="1078" height="208" alt="Screenshot 2026-01-27 at 11-56-27 Historique - Détails de ma déclaration « test empty compo » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/43b9f239-b442-4255-be21-fa7847998563" />
<img width="1088" height="376" alt="Screenshot from 2026-01-27 11-56-17" src="https://github.com/user-attachments/assets/a7bf0c45-6ba5-4d16-9fa8-f34772d81b06" />
