### PR TITLE
Inclusion du SIRET et TVA dans l'export pour les SD

### DIFF
--- a/api/serializers/company.py
+++ b/api/serializers/company.py
@@ -167,9 +167,6 @@ class DeclarantRoleSerializer(BaseRoleSerializer):
 
 
 class ControlCompanyExcelSerializer(serializers.ModelSerializer):
-    siret = serializers.CharField(read_only=True, source="company.siret")
-    vat = serializers.CharField(read_only=True, source="company.vat")
-
     # Champ spécial utilisé par drf-excel documenté ici : https://github.com/django-commons/drf-excel
     row_color = serializers.SerializerMethodField()
 

--- a/api/tests/test_company_control_excel.py
+++ b/api/tests/test_company_control_excel.py
@@ -49,3 +49,9 @@ class TestCompanyControlExcel(APITestCase):
         self.assertGreaterEqual(len(data_rows), 2)
         self.assertIn(c1.social_name, [row[headers.index("Nom de l'entreprise")] for row in data_rows])
         self.assertIn(c2.social_name, [row[headers.index("Nom de l'entreprise")] for row in data_rows])
+
+        self.assertIn(c1.siret, [row[headers.index("No. SIRET")] for row in data_rows])
+        self.assertIn(c2.siret, [row[headers.index("No. SIRET")] for row in data_rows])
+
+        self.assertIn(c1.vat, [row[headers.index("No. de TVA")] for row in data_rows])
+        self.assertIn(c2.vat, [row[headers.index("No. de TVA")] for row in data_rows])

--- a/frontend/src/components/DeclarationSummary/index.vue
+++ b/frontend/src/components/DeclarationSummary/index.vue
@@ -68,13 +68,10 @@ import ArticleInfoRow from "./ArticleInfoRow"
 import CompositionInfo from "@/components/CompositionInfo"
 import ComputedSubstancesInfo from "@/components/ComputedSubstancesInfo"
 import FilePreview from "@/components/FilePreview"
-import { useRouter } from "vue-router"
 import SummaryModificationButton from "./SummaryModificationButton"
 import HistoryBadge from "../History/HistoryBadge.vue"
 import RequiresAnalysisReportNotice from "@/components/RequiresAnalysisReportNotice"
 import { hasNewElements } from "@/utils/elements"
-
-const router = useRouter()
 
 const payload = defineModel()
 defineProps({


### PR DESCRIPTION
Cette PR inclut le SIRET et le No. de TVA des entreprises contenues dans les exports des SD.

Au passage j'ai enlevé un warning UI d'une propriété non utilisé (`vue-router`)

### :camera: Capture d'écran
<img width="946" height="252" alt="image" src="https://github.com/user-attachments/assets/6eb2eb27-73ac-480a-8a28-37f10f75dd7c" />
