### PR TITLE
RGAA 12.8, onglet produit : rendre l'ordre de tabulation des cases à cocher cohérent

### DIFF
--- a/frontend/src/utils/forms.js
+++ b/frontend/src/utils/forms.js
@@ -40,42 +40,6 @@ export const pushOtherChoiceFieldAtTheEnd = (choices) => {
   return choices
 }
 
-export const transformArrayByColumn = (arr, numberOfColumns) => {
-  /*
-  Transforme l'affichage d'un tableau en son équivalent d'affichage par colonnes. Par exemple,
-  [0, 1, 2, 3, 4, 5] en trois colonnes s'afficherait :
-  ---
-  0, 1, 2
-  3, 4, 5
-  ---
-  En passant par cette fonction, l'output serait :
-  [0, 2, 4, 1, 3, 5], qu'en trois colonnes s'afficherait :
-  ---
-  0, 2, 4
-  1, 3, 5
-  ---
-  Privilégiant ainsi une lecture verticale.
-  Utile pour l'affichage des checkboxes dans des grilles de colonnes.
-  */
-  const result = []
-  if (!arr) return result
-  const fullRows = Math.floor(arr.length / numberOfColumns) // Les rangées pleines
-  const remainingItems = arr.length % numberOfColumns // Les éléments qui resterons dans une dernière rangée
-
-  const numRows = remainingItems > 0 ? fullRows + 1 : fullRows
-
-  for (let row = 0; row < numRows; row++) {
-    for (let col = 0; col < numberOfColumns; col++) {
-      const index = col * fullRows + Math.min(col, remainingItems) + row
-      if (row < fullRows || (row === fullRows && col < remainingItems)) result.push(arr[index])
-    }
-  }
-
-  return result
-}
-
-export const checkboxColumnNumbers = { sm: 1, md: 2, lg: 2, xl: 3 }
-
 export const toOptions = (list) => {
   const options =
     (list || [])

--- a/frontend/src/views/ProducerFormPage/ConditionsCheckboxes.vue
+++ b/frontend/src/views/ProducerFormPage/ConditionsCheckboxes.vue
@@ -12,12 +12,8 @@
         <span class="sr-only">Population à risque, facteurs de risque,</span>
         {{ section.title }}
       </template>
-      <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
-        <div
-          v-for="condition in section.items"
-          :key="`condition-${condition.id}`"
-          class="flex col-span-6 sm:col-span-3 lg:col-span-2"
-        >
+      <div class="fr-checkbox-group input md:columns-2 lg:columns-3">
+        <div v-for="condition in section.items" :key="`condition-${condition.id}`" class="flex mb-4 last:mb-0">
           <input :id="`condition-${condition.id}`" type="checkbox" v-model="modelValue" :value="condition.id" />
           <label :for="`condition-${condition.id}`" class="fr-label">{{ condition.name }}</label>
         </div>
@@ -29,12 +25,8 @@
 
 <script setup>
 import { computed } from "vue"
-import { transformArrayByColumn, checkboxColumnNumbers } from "@/utils/forms"
-import { useCurrentBreakpoint } from "@/utils/screen"
 import { populationCategoriesMapping } from "@/utils/mappings"
 
-const currentBreakpoint = useCurrentBreakpoint()
-const numberOfColumns = computed(() => checkboxColumnNumbers[currentBreakpoint.value])
 const modelValue = defineModel()
 const props = defineProps({ conditions: { type: Array, default: Array } })
 
@@ -42,39 +34,26 @@ const ageSort = (a, b) => a.maxAge - b.maxAge
 
 const conditionsSections = computed(() => {
   const c = props.conditions
-  const cols = numberOfColumns.value
   return [
     {
       title: populationCategoriesMapping.AGE.label,
-      items: transformArrayByColumn(c?.filter((x) => x.category === "AGE").sort(ageSort), cols),
+      items: c?.filter((x) => x.category === "AGE").sort(ageSort),
     },
     {
       title: populationCategoriesMapping.MEDICAL.label,
-      items: transformArrayByColumn(
-        c?.filter((x) => x.category === "MEDICAL"),
-        cols
-      ),
+      items: c?.filter((x) => x.category === "MEDICAL"),
     },
     {
       title: populationCategoriesMapping.PREGNANCY.label,
-      items: transformArrayByColumn(
-        c?.filter((x) => x.category === "PREGNANCY"),
-        cols
-      ),
+      items: c?.filter((x) => x.category === "PREGNANCY"),
     },
     {
       title: populationCategoriesMapping.MEDICAMENTS.label,
-      items: transformArrayByColumn(
-        c?.filter((x) => x.category === "MEDICAMENTS"),
-        cols
-      ),
+      items: c?.filter((x) => x.category === "MEDICAMENTS"),
     },
     {
       title: populationCategoriesMapping.OTHER.label,
-      items: transformArrayByColumn(
-        c?.filter((x) => x.category === "OTHER"),
-        cols
-      ),
+      items: c?.filter((x) => x.category === "OTHER"),
       isOtherSection: true,
     },
   ]

--- a/frontend/src/views/ProducerFormPage/PopulationsCheckboxes.vue
+++ b/frontend/src/views/ProducerFormPage/PopulationsCheckboxes.vue
@@ -11,12 +11,8 @@
         <span class="sr-only">Population cible,</span>
         {{ section.title }}
       </template>
-      <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
-        <div
-          v-for="population in section.items"
-          :key="`pop-${population.id}`"
-          class="flex col-span-6 sm:col-span-3 lg:col-span-2"
-        >
+      <div class="fr-checkbox-group input md:columns-2 lg:columns-3">
+        <div v-for="population in section.items" :key="`pop-${population.id}`" class="flex mb-4 last:mb-0">
           <input :id="`population-${population.id}`" type="checkbox" v-model="modelValue" :value="population.id" />
           <label :for="`population-${population.id}`" class="fr-label">{{ population.name }}</label>
         </div>
@@ -27,12 +23,8 @@
 
 <script setup>
 import { computed } from "vue"
-import { transformArrayByColumn, checkboxColumnNumbers } from "@/utils/forms"
-import { useCurrentBreakpoint } from "@/utils/screen"
 import { populationCategoriesMapping } from "@/utils/mappings"
 
-const currentBreakpoint = useCurrentBreakpoint()
-const numberOfColumns = computed(() => checkboxColumnNumbers[currentBreakpoint.value])
 const modelValue = defineModel()
 const props = defineProps({ populations: { type: Array, default: Array } })
 
@@ -40,25 +32,18 @@ const ageSort = (a, b) => a.maxAge - b.maxAge
 
 const populationsSections = computed(() => {
   const p = props.populations
-  const cols = numberOfColumns.value
   return [
     {
       title: populationCategoriesMapping.AGE.label,
-      items: transformArrayByColumn(p?.filter((x) => x.category === "AGE").sort(ageSort), cols),
+      items: p?.filter((x) => x.category === "AGE").sort(ageSort),
     },
     {
       title: populationCategoriesMapping.PREGNANCY.label,
-      items: transformArrayByColumn(
-        p?.filter((x) => x.category === "PREGNANCY"),
-        cols
-      ),
+      items: p?.filter((x) => x.category === "PREGNANCY"),
     },
     {
       title: populationCategoriesMapping.OTHER.label,
-      items: transformArrayByColumn(
-        p?.filter((x) => x.category === "OTHER"),
-        cols
-      ),
+      items: p?.filter((x) => x.category === "OTHER"),
     },
   ]
 })

--- a/frontend/src/views/ProducerFormPage/ProductTab.vue
+++ b/frontend/src/views/ProducerFormPage/ProductTab.vue
@@ -162,12 +162,8 @@
       <template #legend>
         <SectionTitle title="Objectifs / effets" class="mt-4! mb-2" sizeTag="h6" icon="ri-focus-2-fill" />
       </template>
-      <div class="grid grid-cols-6 gap-4 fr-checkbox-group input">
-        <div
-          v-for="effect in orderedEffects"
-          :key="`effect-${effect.id}`"
-          class="flex col-span-6 sm:col-span-3 lg:col-span-2"
-        >
+      <div class="fr-checkbox-group input md:columns-2 lg:columns-3">
+        <div v-for="effect in effects" :key="`effect-${effect.id}`" class="flex mb-4 last:mb-0">
           <input :id="`effect-${effect.id}`" type="checkbox" v-model="payload.effects" :value="effect.id" />
           <label :for="`effect-${effect.id}`" class="fr-label">{{ effect.name }}</label>
         </div>
@@ -223,8 +219,7 @@ import { computed, watch, ref } from "vue"
 import { useRootStore } from "@/stores/root"
 import { storeToRefs } from "pinia"
 import { useVuelidate } from "@vuelidate/core"
-import { firstErrorMsg, transformArrayByColumn, checkboxColumnNumbers } from "@/utils/forms"
-import { useCurrentBreakpoint } from "@/utils/screen"
+import { firstErrorMsg } from "@/utils/forms"
 import { pushOtherChoiceFieldAtTheEnd, getAllIndexesOfRegex } from "@/utils/forms"
 import CountryField from "@/components/fields/CountryField.vue"
 import OtherChoiceField from "@/components/fields/OtherChoiceField"
@@ -318,10 +313,6 @@ watch(selectedCompany, () => {
 
 // S'il n'y a qu'une entreprise on l'assigne par défaut
 if (companies.value?.length === 1) payload.value.company = companies.value[0].id
-
-const currentBreakpoint = useCurrentBreakpoint()
-const numberOfColumns = computed(() => checkboxColumnNumbers[currentBreakpoint.value])
-const orderedEffects = computed(() => transformArrayByColumn(effects.value, numberOfColumns.value))
 </script>
 
 <style scoped>


### PR DESCRIPTION
Pour mettre les cases à cocher en colonnes, on avait utilisé `grid` avec un ordre d'options customisé pour les afficher en lecture verticale. Or, la tabulation reste horizontale avec cette solution. Ça invalide critère 12.8 du RGAA.

Cette PR utilise l'utilité de tailwind `columns` pour faire la même chose, mais plus simple et avec le bon ordre.