### PR TITLE
RGAA 11.1 : rendre le libellé du choix d'entreprise accessible

### DIFF
--- a/frontend/src/views/DashboardPage/RoleBarBlock.vue
+++ b/frontend/src/views/DashboardPage/RoleBarBlock.vue
@@ -18,7 +18,7 @@
             :modelValue="activeCompany?.id"
             @update:modelValue="(x) => emit('changeCompany', x)"
             label="Entreprise"
-            class="-mt-5"
+            title="Entreprise"
           />
         </div>
       </div>
@@ -49,7 +49,17 @@ const roles = computed(() => {
 <style>
 @reference "../../styles/index.css";
 
+/* pris de .fr-search-bar pour caché le libellé mais le laisser visible pour les lecteurs d'écran */
 #company-select-wrapper .fr-label {
-  @apply invisible;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  display: block;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 </style>


### PR DESCRIPTION
Sur le tableau de bord, le libellé du select de l'entreprise est caché. Il faut qu'on n'utilise pas `invisible` de tailwind, car `visibility: hidden;` cache le libellé pour les lecteurs d'écran aussi. J'ai repris alors le CSS du `.fr-search-bar .fr-input` pour cacher le libellé mais le laisser accessible aux lecteurs d'écran. J'ai rajouté un `title` pour le critère [RGAA 11.1.3](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#11.1).

Pas de changements visuels sauf le libellé maintenant visible en survol

<img width="720" height="405" alt="Screenshot from 2026-02-10 12-18-22" src="https://github.com/user-attachments/assets/7d2537a5-40fd-4238-bd96-d5730b7d77ce" />

J'ai parcouru le code pour d'autres instances des libellés cachés avec `visibility: hidden;` ou la classe tailwind `invisible` et je n'ai pas retrouvé d'autres à corriger.