### PR TITLE
RGAA 11.2 : rendre le choix d'activité d'ingrédient et microorganisme plus clair

### DIFF
--- a/frontend/src/components/ElementCard.vue
+++ b/frontend/src/components/ElementCard.vue
@@ -19,26 +19,29 @@
             <DsfrBadge label="Partie de plante non autorisée" type="warning" />
           </div>
         </div>
-        <div class="content-center ml-6 pl-4 sm:border-l">
+        <div class="content-center ml-6 px-4 sm:border-l sm:border-r">
           <ElementCommentModal v-model="model" :hidePrivateComments="true" />
         </div>
       </div>
 
-      <div class="flex grow">
-        <div class="grow sm:pl-4 sm:ml-4 pt-4 sm:border-l self-center">
-          <DsfrCheckbox
-            :disabled="getActivityReadonlyByType(objectType)"
-            v-model="model.active"
-            :label="model.active ? 'Actif' : 'Non actif'"
-          />
-        </div>
+      <div class="sm:ml-4 pt-4 self-center w-fit">
+        <DsfrToggleSwitch
+          :disabled="getActivityReadonlyByType(objectType)"
+          v-model="model.active"
+          label="Ingrédient actif&nbsp;?"
+          activeText="Oui"
+          inactiveText="Non"
+          labelLeft
+        />
+      </div>
 
-        <div v-if="props.canRemove">
-          <DsfrButton secondary @click="$emit('remove', model)">
-            Enlever
-            <span class="fr-sr-only">« {{ getElementName(model).toLowerCase() }} »</span>
-          </DsfrButton>
-        </div>
+      <div class="grow"></div>
+
+      <div v-if="props.canRemove" class="sm:ml-4 md:ml-6 self-center">
+        <DsfrButton secondary @click="$emit('remove', model)">
+          Enlever
+          <span class="fr-sr-only">« {{ getElementName(model).toLowerCase() }} »</span>
+        </DsfrButton>
       </div>
     </div>
 
@@ -76,16 +79,19 @@
           />
         </div>
       </div>
-      <div v-else-if="objectType === 'microorganism'" class="md:flex gap-4 items-end">
+      <div v-else-if="objectType === 'microorganism'" class="md:flex gap-4 items-center">
         <div class="mb-4 md:max-w-sm">
           <DsfrInput label-visible label="Souche" v-model="model.strain" :required="true" />
         </div>
-        <div class="md:max-w-sm">
-          <DsfrCheckbox
+        <div class="flex">
+          <DsfrToggleSwitch
             v-model="model.activated"
-            :label="model.activated ? 'Activés' : 'Ces micro-organismes ont été inactivés'"
-            hint="L'inactivation rend la réplication impossible"
+            label="Activés&nbsp;?"
+            activeText="Oui"
+            inactiveText="Non"
+            labelLeft
           />
+          <DsfrTooltip content="L'inactivation rend la réplication impossible" class="pb-3 ml-1" />
         </div>
         <div v-if="model.activated" class="mb-4">
           <NumberField label-visible v-model="model.quantity" label="Qté par DJR (en UFC)" :required="true" />


### PR DESCRIPTION
[Ticket notion](https://www.notion.so/incubateur-masa/Chaque-etiquette-associee-un-champ-de-formulaire-est-elle-pertinente-hors-cas-particuliers-26ade24614be81ad8b20d8141e4cd64c?source=copy_link)

Cette PR remplace les cases à cocher "Actif"/"Non actif" et "Activés"/"...désactivés" avec un interrupteur pour rendre le choix plus clair.

<img width="1804" height="1128" alt="Screenshot 2026-02-11 at 18-21-22 Composition - étape 2 sur 5 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/8a270395-1a62-4824-aa13-7186c24c0d0e" />

## vérsion mobile (320px)
<img width="300" alt="Screenshot 2026-02-11 at 18-22-56 Composition - étape 2 sur 5 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/b9d85e53-dce6-419d-81c2-05d7d2856d81" />
<img width="300" alt="Screenshot 2026-02-11 at 18-23-10 Composition - étape 2 sur 5 - Déclaration « test soja » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/f9eccd18-4084-4150-9f25-4fe9b4104c14" />
