### PR TITLE
RGAA 5.4 : réparer le nom accessible d'un tableau

### DIFF
--- a/frontend/src/views/ProducerFormPage/CompositionTab.vue
+++ b/frontend/src/views/ProducerFormPage/CompositionTab.vue
@@ -64,7 +64,7 @@
         title="Dosage total des substances actives"
         content="Ce tableau présente les substances actives identifiées dans les ingrédients que vous avez sélectionnés. Une même substance pouvant être introduite par plusieurs sources, la quantité totale par dose journalière recommandée (DJR) est demandée pour certaines substances faisant l'objet d'une règlementation spécifique ou impliquant un risque."
       />
-      <SubstancesTable :hidePrivateComments="true" v-model="payload" title="Substances actives" />
+      <SubstancesTable :hidePrivateComments="true" v-model="payload" title="Dosage total des substances actives" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Dans #2396 j'ai donné le mauvais nom à un tableau, il faut reprendre le titre visible plus haut "Substances contenues dans la composition". Pas de changement visuel.