### PR TITLE
Revert "chore(deps-dev): bump eslint-plugin-vue from 10.6.2 to 10.7.0 in /frontend"

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,7 @@
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
-        "eslint-plugin-vue": "^10.7.0",
+        "eslint-plugin-vue": "^10.6.2",
         "postcss": "^8.5.5",
         "prettier": "3.8.1",
         "tailwindcss": "^4.1.17",
@@ -7698,9 +7698,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.7.0.tgz",
-      "integrity": "sha512-r2XFCK4qlo1sxEoAMIoTTX0PZAdla0JJDt1fmYiworZUX67WeEGqm+JbyAg3M+pGiJ5U6Mp5WQbontXWtIW7TA==",
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.6.2.tgz",
+      "integrity": "sha512-nA5yUs/B1KmKzvC42fyD0+l9Yd+LtEpVhWRbXuDj0e+ZURcTtyRbMDWUeJmTAh2wC6jC83raS63anNM2YT3NPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
-    "eslint-plugin-vue": "^10.7.0",
+    "eslint-plugin-vue": "^10.6.2",
     "postcss": "^8.5.5",
     "prettier": "3.8.1",
     "tailwindcss": "^4.1.17",


### PR DESCRIPTION
Reverts betagouv/complements-alimentaires#2697

https://github.com/betagouv/complements-alimentaires/pull/2676