### PR TITLE
Onglet composition : améliorer le bouton/infobulle

### DIFF
--- a/frontend/src/components/ElementCommentModal.vue
+++ b/frontend/src/components/ElementCommentModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex border w-8 aspect-square rounded-full content-center justify-center">
-    <DsfrModal :title="elementName" size="lg" :opened="infoModalOpened" @close="infoModalOpened = false">
+    <DsfrModal :title="elementName" size="lg" :opened="infoModalOpened" @close="closeModal">
       <div v-if="element?.publicComments">
         <h2 class="fr-h6 mb-2!">Commentaires</h2>
         <p class="whitespace-pre-line">{{ element?.publicComments }}</p>
@@ -50,7 +50,6 @@
     </button>
     <span
       :id="tooltipContentId"
-      class="fr-tooltip fr-placement"
       :class="tooltipClass"
       :style="tooltipStyle"
       role="tooltip"
@@ -186,6 +185,7 @@ const tooltipStyle = computed(
     `transform: translate(${translateX.value}, ${translateY.value}); --arrow-x: ${arrowX.value}; opacity: ${opacity.value};'`
 )
 const tooltipClass = computed(() => ({
+  "fr-tooltip fr-placement": true,
   "fr-tooltip--shown": showTooltip.value,
   "fr-placement--top": top.value,
   "fr-placement--bottom": !top.value,
@@ -216,4 +216,11 @@ const onMouseLeaveTooltipContent = () => {
 document.addEventListener("keydown", (event) => {
   if (event.key === "Escape") showTooltip.value = false
 })
+
+const closeModal = () => {
+  infoModalOpened.value = false
+  // utiliser setTimeout car le focus est mis sur le bouton une fois que le modal est fermé
+  // pour s'assurer que le tooltip ferme quand même, on utilise ce timeout
+  setTimeout(() => (showTooltip.value = false), 10)
+}
 </script>


### PR DESCRIPTION
Cette PR ajoute un bouton-tooltip. C'est un composant qui affiche le contenu d'un tooltip en survol et focus, et ouvre un modal en clic.

Avant, on avait imbriqué un bouton dans un tooltip, qui n'etait pas accessible. Ça a été remplacé par un bouton avec un `title`, mais ce n'est pas complètement accessible non plus, et c'est une dégradation de l'experience utilisateur.

Avec cette PR on a bien un seul element interactif, le bouton, qui a un nom accessible, unique et explicite. Le bouton est décrit par le contenu du tooltip. Le tooltip s'affiche en survol, et le contenu peut être survoler, copier etc. Le tooltip se cache une fois que le souris quitte le bouton et le contenu, ou quand l'utilisateur fait `esc`. 

L'UI et UX originel sont restaurés.

<img width="682" height="366" alt="Screenshot from 2026-03-20 12-36-09" src="https://github.com/user-attachments/assets/ea8d05a9-f33c-493f-8661-001f609dd0b5" />
