### PR TITLE
Recherche avancée : ajouter l'adresse mail de l'entreprise dans l'export

### DIFF
--- a/api/serializers/declaration.py
+++ b/api/serializers/declaration.py
@@ -419,6 +419,7 @@ class SimpleDeclarationSerializer(serializers.ModelSerializer):
 
 class ExcelExportDeclarationSerializer(serializers.ModelSerializer):
     company_name = serializers.CharField(read_only=True, source="company.social_name")
+    company_email = serializers.CharField(read_only=True, source="company.email")
     siret = serializers.CharField(read_only=True, source="company.siret")
     vat = serializers.CharField(read_only=True, source="company.vat")
     article = serializers.SerializerMethodField(read_only=True)
@@ -441,6 +442,7 @@ class ExcelExportDeclarationSerializer(serializers.ModelSerializer):
             "siret",
             "vat",
             "department",
+            "company_email",
             "row_color",  # Champ utilisé en interne par drf-excel
         )
         read_only_fields = fields

--- a/api/urls.py
+++ b/api/urls.py
@@ -142,7 +142,7 @@ urlpatterns = {
     path("control/declarations/", views.ControllerDeclarationsListView.as_view(), name="list_control_declarations"),
     path(
         "control/declarations-export/",
-        views.ControlDeclataionExcelView.as_view(),
+        views.ControlDeclarationExcelView.as_view(),
         name="export_excel_declarations_control",
     ),
     path(

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -27,7 +27,7 @@ from .declaration.declaration import (
     DeclarationTakeAuthorshipView,
     DeclarationAssignInstruction,
     ArticleChangeView,
-    ControlDeclataionExcelView,
+    ControlDeclarationExcelView,
 )
 from .declaration.declared_element import (
     DeclaredElementsView,

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -331,8 +331,9 @@ class OngoingDeclarationsExcelView(XLSXFileMixin, CommonOngoingDeclarationView):
             "No. SIRET",
             "No. TVA",
             "No. de département",
+            "Adresse mail de l'entreprise",
         ],
-        "column_width": [12, 12, 30, 20, 30, 25, 30, 15, 15, 15],
+        "column_width": [12, 12, 30, 20, 30, 25, 30, 15, 15, 15, 30],
         "height": 30,
         "style": common_excel_styles,
     }
@@ -367,7 +368,7 @@ class ControllerDeclarationsListView(CommonControlDeclarationView):
     serializer_class = ControllerDeclarationSerializer
 
 
-class ControlDeclataionExcelView(XLSXFileMixin, CommonControlDeclarationView):
+class ControlDeclarationExcelView(XLSXFileMixin, CommonControlDeclarationView):
     serializer_class = ExcelControlDeclarationSerializer
     renderer_classes = [XLSXRenderer]
     filename = "declarations-resultats.xlsx"


### PR DESCRIPTION
De temps en temps, le BEPIAS a besoin de contacter toutes les entreprises avec des déclarations finalisées qui contiennent un ingrédient, quand il y a un nouveau règle par exemple. Avant, on a utilisé une requête metabase pour faire l'export. En ajoutant le mail à l'export, le BEPIAS devient plus autonome à l'avenir.

Plus tard, on pourrait prévoir une fonctionnalité pour écrire le mail dans l'interface directement et envoyer le mail depuis Compl'Alim.