### PR TITLE
Possibilité d'automatiser le visa

### DIFF
--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -626,6 +626,32 @@ class TestDeclarationFlow(APITestCase):
         self.assertEqual(declaration.status, Declaration.DeclarationStatus.ONGOING_INSTRUCTION)
 
     @authenticate
+    def test_authorize_with_visa_auto_validate(self):
+        """
+        Un utilisateur ayant à la fois le rôle instructeur et viseuse peut valider
+        automatiquement le visa en passant le queryparam auto-validate=true.
+        La déclaration doit passer directement à AUTHORIZED sans rester en AWAITING_VISA.
+        """
+        InstructionRoleFactory(user=authenticate.user)
+        VisaRoleFactory(user=authenticate.user)
+        declaration = OngoingInstructionDeclarationFactory()
+
+        response = self.client.post(
+            reverse("api:authorize_with_visa", kwargs={"pk": declaration.id}) + "?auto-validate=true",
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        declaration.refresh_from_db()
+        self.assertEqual(declaration.status, Declaration.DeclarationStatus.AUTHORIZED)
+
+        snapshot_actions = list(declaration.snapshots.order_by("creation_date").values_list("action", flat=True))
+        self.assertIn(Snapshot.SnapshotActions.REQUEST_VISA, snapshot_actions)
+        self.assertIn(Snapshot.SnapshotActions.TAKE_FOR_VISA, snapshot_actions)
+        self.assertIn(Snapshot.SnapshotActions.ACCEPT_VISA, snapshot_actions)
+
+    @authenticate
     def test_refuse_visa(self):
         """
         Passage de ONGOING_VISA à AWAITING_INSTRUCTION

--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -638,7 +638,7 @@ class TestDeclarationFlow(APITestCase):
 
         response = self.client.post(
             reverse("api:authorize_with_visa", kwargs={"pk": declaration.id}) + "?auto-validate=true",
-            {"comment": "Tout est OK"},
+            {"comment": "Ne pas sauvegarder ce comment"},
             format="json",
         )
 
@@ -660,6 +660,9 @@ class TestDeclarationFlow(APITestCase):
         self.assertEqual(request_visa_snapshot.comment, "")
         self.assertEqual(take_visa_snapshot.comment, "")
         self.assertEqual(accept_visa_snapshot.comment, "")
+
+        declaration.refresh_from_db()
+        self.assertEqual(declaration.post_validation_producer_message, "")
 
     @authenticate
     def test_observe_with_visa_auto_validate(self):

--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -638,6 +638,7 @@ class TestDeclarationFlow(APITestCase):
 
         response = self.client.post(
             reverse("api:authorize_with_visa", kwargs={"pk": declaration.id}) + "?auto-validate=true",
+            {"comment": "Tout est OK"},
             format="json",
         )
 
@@ -650,6 +651,90 @@ class TestDeclarationFlow(APITestCase):
         self.assertIn(Snapshot.SnapshotActions.REQUEST_VISA, snapshot_actions)
         self.assertIn(Snapshot.SnapshotActions.TAKE_FOR_VISA, snapshot_actions)
         self.assertIn(Snapshot.SnapshotActions.ACCEPT_VISA, snapshot_actions)
+
+        request_visa_snapshot = declaration.snapshots.get(action=Snapshot.SnapshotActions.REQUEST_VISA)
+        take_visa_snapshot = declaration.snapshots.get(action=Snapshot.SnapshotActions.TAKE_FOR_VISA)
+        accept_visa_snapshot = declaration.snapshots.get(action=Snapshot.SnapshotActions.ACCEPT_VISA)
+
+        # On vérifie que le commentaire ne s'est pas propagé (dans une validation le commentaire n'est pas présent)
+        self.assertEqual(request_visa_snapshot.comment, "")
+        self.assertEqual(take_visa_snapshot.comment, "")
+        self.assertEqual(accept_visa_snapshot.comment, "")
+
+    @authenticate
+    def test_observe_with_visa_auto_validate(self):
+        """
+        En auto-validation, le commentaire, expiration_days et blocking_reasons envoyés
+        dans la requête initiale doivent être correctement accessibles sur le modèle.
+        """
+        InstructionRoleFactory(user=authenticate.user)
+        VisaRoleFactory(user=authenticate.user)
+        declaration = OngoingInstructionDeclarationFactory()
+
+        response = self.client.post(
+            reverse("api:observe_with_visa", kwargs={"pk": declaration.id}) + "?auto-validate=true",
+            {"comment": "Des observations à prendre en compte", "expiration": 30, "reasons": ["raison-1", "raison-2"]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        declaration.refresh_from_db()
+        self.assertEqual(declaration.status, Declaration.DeclarationStatus.OBSERVATION)
+        self.assertEqual(declaration.last_administration_comment, "Des observations à prendre en compte")
+        self.assertEqual(declaration.blocking_reasons, ["raison-1", "raison-2"])
+        # expiration_days est effacé du modèle par VisaDecisionView.on_transition_success après
+        # la création du snapshot ; on le vérifie directement sur ce dernier
+        accept_visa_snapshot = declaration.snapshots.get(action=Snapshot.SnapshotActions.ACCEPT_VISA)
+        self.assertEqual(accept_visa_snapshot.expiration_days, 30)
+
+    @authenticate
+    def test_object_with_visa_auto_validate(self):
+        """
+        En auto-validation, le commentaire, expiration_days et blocking_reasons envoyés
+        dans la requête initiale doivent être correctement accessibles sur le modèle.
+        """
+        InstructionRoleFactory(user=authenticate.user)
+        VisaRoleFactory(user=authenticate.user)
+        declaration = OngoingInstructionDeclarationFactory()
+
+        response = self.client.post(
+            reverse("api:object_with_visa", kwargs={"pk": declaration.id}) + "?auto-validate=true",
+            {"comment": "Des objections à prendre en compte", "expiration": 60, "reasons": ["raison-3"]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        declaration.refresh_from_db()
+        self.assertEqual(declaration.status, Declaration.DeclarationStatus.OBJECTION)
+        self.assertEqual(declaration.last_administration_comment, "Des objections à prendre en compte")
+        self.assertEqual(declaration.blocking_reasons, ["raison-3"])
+        accept_visa_snapshot = declaration.snapshots.get(action=Snapshot.SnapshotActions.ACCEPT_VISA)
+        self.assertEqual(accept_visa_snapshot.expiration_days, 60)
+
+    @authenticate
+    def test_reject_with_visa_auto_validate(self):
+        """
+        En auto-validation, le commentaire et blocking_reasons envoyés
+        dans la requête initiale doivent être correctement accessibles sur le modèle.
+        """
+        InstructionRoleFactory(user=authenticate.user)
+        VisaRoleFactory(user=authenticate.user)
+        declaration = OngoingInstructionDeclarationFactory()
+
+        response = self.client.post(
+            reverse("api:reject_with_visa", kwargs={"pk": declaration.id}) + "?auto-validate=true",
+            {"comment": "Dossier non conforme", "reasons": ["raison-4", "raison-5"]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        declaration.refresh_from_db()
+        self.assertEqual(declaration.status, Declaration.DeclarationStatus.REJECTED)
+        self.assertEqual(declaration.last_administration_comment, "Dossier non conforme")
+        self.assertEqual(declaration.blocking_reasons, ["raison-4", "raison-5"])
 
     @authenticate
     def test_refuse_visa(self):

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -839,7 +839,38 @@ class VisaRequestFlowView(DeclarationFlowView):
         if not self.post_validation_status:
             raise Exception("VisaRequestFlowView doit être sous-classée et doit spécifier le post_validation_status")
         declaration.post_validation_status = self.post_validation_status
+
         return super().on_transition_success(request, declaration)
+
+    def should_automatically_validate_visa(self, request):
+        auto_validate = request.query_params.get("auto-validate", "").lower() == "true"
+        if not auto_validate:
+            return False
+        has_instruction_role = InstructionRole.objects.filter(user=request.user).exists()
+        has_visa_role = VisaRole.objects.filter(user=request.user).exists()
+        return has_instruction_role and has_visa_role
+
+    def post(self, request, *args, **kwargs):
+        """
+        Si la personne effectuant la demande de visa le souhaite, elle peut aussi
+        approuver le visa automatiquement.
+        """
+        response = super().post(request, *args, **kwargs)
+        if self.should_automatically_validate_visa(request):
+            # D'abord on automatise la prise du dossier pour le visa :
+            take_view = DeclarationTakeForVisaView()
+            take_view.kwargs = self.kwargs
+            take_view.request = request
+            take_view.format_kwarg = self.format_kwarg
+            take_view.post(request, *args, **kwargs)
+
+            # Puis on automatise l'approbation du visa
+            visa_view = DeclarationAcceptVisaView()
+            visa_view.kwargs = self.kwargs
+            visa_view.request = request
+            visa_view.format_kwarg = self.format_kwarg
+            response = visa_view.post(request, *args, **kwargs)
+        return response
 
 
 class DeclarationObserveWithVisa(VisaRequestFlowView):

--- a/api/views/declaration/declaration.py
+++ b/api/views/declaration/declaration.py
@@ -53,7 +53,7 @@ from api.utils.filters import (
 from api.utils.search import UnaccentSearchFilter
 from api.views.declaration.declaration_filter_set import DeclarationFilterSet
 from api.views.declaration.declaration_flow import DeclarationFlow
-from api.views.utils import ControlExcelPagination, common_excel_styles
+from api.views.utils import ControlExcelPagination, EmptyDataRequest, common_excel_styles
 from config import email
 from data.models import Company, Declaration, InstructionRole, Snapshot, User, VisaRole
 
@@ -857,19 +857,21 @@ class VisaRequestFlowView(DeclarationFlowView):
         """
         response = super().post(request, *args, **kwargs)
         if self.should_automatically_validate_visa(request):
+            clean_request = EmptyDataRequest(request)
+
             # D'abord on automatise la prise du dossier pour le visa :
             take_view = DeclarationTakeForVisaView()
             take_view.kwargs = self.kwargs
-            take_view.request = request
+            take_view.request = clean_request
             take_view.format_kwarg = self.format_kwarg
-            take_view.post(request, *args, **kwargs)
+            take_view.post(clean_request, *args, **kwargs)
 
             # Puis on automatise l'approbation du visa
             visa_view = DeclarationAcceptVisaView()
             visa_view.kwargs = self.kwargs
-            visa_view.request = request
+            visa_view.request = clean_request
             visa_view.format_kwarg = self.format_kwarg
-            response = visa_view.post(request, *args, **kwargs)
+            response = visa_view.post(clean_request, *args, **kwargs)
         return response
 
 

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -51,3 +51,15 @@ common_excel_styles = {
 class ControlExcelPagination(LimitOffsetPagination):
     default_limit = 2000
     max_limit = 2000
+
+
+class EmptyDataRequest:
+    """Proxy autour d'un request DRF qui expose un data vide, pour éviter les effets de bord
+    lors de la réutilisation du request dans des sous-vues (ex. le champ 'comment')."""
+
+    def __init__(self, request):
+        self._wrapped = request
+        self.data = {}
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)

--- a/frontend/src/components/NewBepiasViews/ProductSection/InstructionResults.vue
+++ b/frontend/src/components/NewBepiasViews/ProductSection/InstructionResults.vue
@@ -66,6 +66,9 @@
         <DsfrInputGroup class="mb-0">
           <DsfrCheckbox label="À viser" v-model="needsVisa" :disabled="disableVisaCheckbox" />
         </DsfrInputGroup>
+        <DsfrInputGroup class="mb-0" v-if="needsVisa && isVisor">
+          <DsfrCheckbox label="Visa automatique" v-model="automaticallyApproveVisa" />
+        </DsfrInputGroup>
         <div class="border-l ml-4 pl-4">
           <DsfrButton
             label="Soumettre"
@@ -106,8 +109,12 @@ import { blockingReasons } from "@/utils/mappings"
 import { statusProps } from "@/utils/mappings"
 import { useRouter } from "vue-router"
 import { useStorage } from "@vueuse/core"
+import { storeToRefs } from "pinia"
+import { useRootStore } from "@/stores/root"
 
 const router = useRouter()
+const store = useRootStore()
+const { loggedUser } = storeToRefs(store)
 
 const rules = computed(() => {
   if (decisionCategory.value !== "modify") return {}
@@ -124,7 +131,15 @@ defineProps({ readonly: Boolean })
 const getLocalStorageKey = (key) => `instruction-${declaration.value?.id}-${key}`
 
 const clearLocalStorage = () => {
-  const keys = ["proposal", "delayDays", "comment", "reasons", "decisionCategory", "needsVisa"]
+  const keys = [
+    "proposal",
+    "delayDays",
+    "comment",
+    "reasons",
+    "decisionCategory",
+    "needsVisa",
+    "automaticallyApproveVisa",
+  ]
   for (const key of keys) localStorage.removeItem(getLocalStorageKey(key))
 }
 
@@ -134,6 +149,7 @@ const comment = useStorage(getLocalStorageKey("comment"), "")
 const reasons = useStorage(getLocalStorageKey("reasons"), [])
 const decisionCategory = useStorage(getLocalStorageKey("decisionCategory"), null)
 const needsVisa = useStorage(getLocalStorageKey("needsVisa"), false)
+const automaticallyApproveVisa = useStorage(getLocalStorageKey("automaticallyApproveVisa"), false)
 
 watch(decisionCategory, () => (proposal.value = decisionCategory.value === "approve" ? "autorisation" : null))
 
@@ -167,6 +183,7 @@ watch(proposal, (newProposal) => {
 })
 
 const needsAnsesReferal = computed(() => declaration.value?.article === "ANSES_REFERAL")
+const isVisor = computed(() => loggedUser.value?.globalRoles?.some((x) => x.name === "VisaRole"))
 
 const proposalOptions = [
   { text: "Observation", value: "observation" },
@@ -183,7 +200,9 @@ const url = computed(() => {
   }
   const visaPath = needsVisa.value ? "with-visa" : "no-visa"
   const urlPath = `${actions[proposal.value]}-${visaPath}`
-  return `/api/v1/declarations/${declaration.value?.id}/${urlPath}/`
+  const url = `/api/v1/declarations/${declaration.value?.id}/${urlPath}/`
+  if (automaticallyApproveVisa.value) return `${url}?auto-validate=true`
+  return url
 })
 
 const requestPayload = computed(() =>


### PR DESCRIPTION
Closes #2883 

Si une personne a les rôles instruction et visa en même temps, la possibilité d'appliquer le visa automatiquement lui est presentée au moment de l'instruction.

## :camera: Captures d'écran

<img width="906" height="644" alt="image" src="https://github.com/user-attachments/assets/6b728df1-e459-416b-a59c-61c2b768354d" />

La case à cocher "Visa automatique" simule la prise de la déclaration pour le visa et l'approbation du visa de façon automatique : 

<img width="462" height="91" alt="image" src="https://github.com/user-attachments/assets/21205353-e0b9-4657-960d-e5e9a75d8f89" />


