### PR TITLE
Ne pas demander les infos additionnelles des plantes inactives

### DIFF
--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -122,6 +122,7 @@ class TestDeclarationFlowSubmit(APITestCase):
             company=company,
         )
         first_declared_plant = missing_composition_data_declaration.declared_plants.first()
+        first_declared_plant.active = True
         first_declared_plant.used_part = None
         first_declared_plant.save()
         response = self.client.post(
@@ -136,6 +137,12 @@ class TestDeclarationFlowSubmit(APITestCase):
         self.assertEqual(
             "Merci de renseigner les informations manquantes des plantes ajoutées", json_errors["nonFieldErrors"][0]
         )
+        first_declared_plant.active = False
+        first_declared_plant.save()
+        response = self.client.post(
+            reverse("api:submit_declaration", kwargs={"pk": missing_composition_data_declaration.id}), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @authenticate
     def test_submit_declaration_eu_mode(self):

--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -28,9 +28,9 @@ from data.models import Attachment, Declaration, Snapshot
 from .utils import authenticate
 
 
-class TestDeclarationFlow(APITestCase):
+class TestDeclarationFlowSubmit(APITestCase):
     @authenticate
-    def test_submit_declaration(self):
+    def test_submit_declaration_success(self):
         """
         Passage du DRAFT -> AWAITING_INSTRUCTION
         Possible seulement si les données sont complètes
@@ -43,7 +43,14 @@ class TestDeclarationFlow(APITestCase):
         response = self.client.post(reverse("api:submit_declaration", kwargs={"pk": declaration.id}), format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Si la pièce jointe pour l'étiquetage manque, on ne peut pas continuer
+    @authenticate
+    def test_submit_declaration_missing_label(self):
+        """
+        Si la pièce jointe pour l'étiquetage manque, on ne peut pas continuer
+        """
+        declarant_role = DeclarantRoleFactory(user=authenticate.user)
+        company = declarant_role.company
+
         missing_field_label = InstructionReadyDeclarationFactory(
             author=authenticate.user, company=company, attachments=[]
         )
@@ -55,7 +62,14 @@ class TestDeclarationFlow(APITestCase):
         self.assertEqual(len(json_errors["fieldErrors"]), 1)
         self.assertIn("attachments", json_errors["fieldErrors"][0])
 
-        # Si un champ obligatoire pour l'instruction manque, on le spécifie
+    @authenticate
+    def test_submit_declaration_missing_required_field(self):
+        """
+        Si un champ obligatoire pour l'instruction manque, on le spécifie
+        """
+        declarant_role = DeclarantRoleFactory(user=authenticate.user)
+        company = declarant_role.company
+
         missing_field_declaration = InstructionReadyDeclarationFactory(
             author=authenticate.user, daily_recommended_dose="", company=company
         )
@@ -67,7 +81,14 @@ class TestDeclarationFlow(APITestCase):
         self.assertEqual(len(json_errors["fieldErrors"]), 1)
         self.assertIn("dailyRecommendedDose", json_errors["fieldErrors"][0])
 
-        # S'il n'y a pas d'éléments dans la déclaration, on ne peut pas la soumettre pour instruction
+    @authenticate
+    def test_submit_declaration_missing_elements(self):
+        """
+        S'il n'y a pas d'éléments dans la déclaration, on ne peut pas la soumettre pour instruction
+        """
+        declarant_role = DeclarantRoleFactory(user=authenticate.user)
+        company = declarant_role.company
+
         missing_elements_declaration = InstructionReadyDeclarationFactory(
             author=authenticate.user,
             declared_plants=[],
@@ -87,8 +108,15 @@ class TestDeclarationFlow(APITestCase):
         # le frontend car il y a de la logique effectuée avec une comparaison de String
         self.assertEqual("Le complément doit comporter au moins un ingrédient", json_errors["nonFieldErrors"][0])
 
-        # Si un des éléments de la composition manque des informations obligatoires, on ne peut pas soumettre
-        # pour instruction
+    @authenticate
+    def test_submit_declaration_missing_element_data(self):
+        """
+        Si un des éléments de la composition manque des informations obligatoires, on ne peut pas soumettre
+        pour instruction
+        """
+        declarant_role = DeclarantRoleFactory(user=authenticate.user)
+        company = declarant_role.company
+
         missing_composition_data_declaration = InstructionReadyDeclarationFactory(
             author=authenticate.user,
             company=company,
@@ -204,6 +232,8 @@ class TestDeclarationFlow(APITestCase):
         response = self.client.post(reverse("api:submit_declaration", kwargs={"pk": declaration.id}), format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+
+class TestDeclarationFlowRemainingActions(APITestCase):
     @authenticate
     def test_take_declaration_for_instruction(self):
         """

--- a/api/views/declaration/declaration_flow_validations.py
+++ b/api/views/declaration/declaration_flow_validations.py
@@ -90,7 +90,7 @@ def validate_mandatory_fields(declaration) -> tuple[list, list]:
 
 def declared_plant_is_complete(plant):
     if not plant.active:
-        return plant.used_part and plant.quantity and plant.unit
+        return True
     return plant.used_part and plant.quantity and plant.unit and plant.preparation
 
 

--- a/frontend/src/components/ElementCard.vue
+++ b/frontend/src/components/ElementCard.vue
@@ -186,7 +186,7 @@ const preparations = computed(() => {
 })
 
 const showFields = computed(() => {
-  if (props.objectType === "plant") return true
+  if (props.objectType === "plant" && model.value.active) return true
   if (model.value.active && props.objectType === "microorganism") return true
   if (
     model.value.active &&


### PR DESCRIPTION
[Notion](https://www.notion.so/incubateur-masa/Interface-d-claration-supprimer-la-possibilit-de-renseigner-une-dose-pour-les-plantes-non-active-299de24614be80658629e1d2995928bd?v=356de24614be809396f2000cb8f51b04&source=copy_link)

<img width="1749" height="604" alt="Screenshot 2026-05-04 at 14-57-19 Composition - étape 2 sur 4 - Déclaration « test plante inactive » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/d4fcb059-af17-4b61-b8dc-904b569b4038" />

La partie de ne pas afficher les champs dans un sommaire de la déclaration est déjà en place (`<p class="my-2" v-if="model.active">` de `SummaryElementItem`)

<img width="1756" height="348" alt="Screenshot 2026-05-04 at 14-57-28 Soumettre - étape 4 sur 4 - Déclaration « test plante inactive » - Compl&#39;Alim" src="https://github.com/user-attachments/assets/279302cf-fe01-41e0-aa0e-103fb1d06b77" />

J'ai aussi fait une refacto des tests un peu pour rendre le testing plus rapide pour ce cas.
