### PR TITLE
Modification/création ingrédient : afficher les champs parties de plante que pour les plantes

### DIFF
--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -136,7 +136,7 @@
       </div>
     </DsfrFieldset>
 
-    <div class="my-8 sm:mt-0">
+    <div class="my-8 sm:mt-0" v-if="type === 'plant'">
       <DsfrTable
         v-if="formForType.plantParts"
         title="Parties de plante"


### PR DESCRIPTION
Dans l'interface aujourd'hui on voit l'option d'ajouter des parties de plantes même pour les autres types d'ingrédient. Cette petite PR enlève ça pour l'afficher que pour le type plante.

Pour tester : ouvrir l'interface modif ingrédient depuis un fiche ingrédient ou depuis le tableaux Nouveaux ingrédients. Vérifier que c'est que possible d'ajouter les parties pour les plantes.

<img width="679" height="196" alt="Screenshot 2026-05-18 at 16-28-34 Modification ingrédient - Méthylcobalamine - Compl&#39;Alim" src="https://github.com/user-attachments/assets/5c6aca9b-a997-4352-af5f-a4ce79e1fd19" />
