### PR TITLE
Enlever des dépendances obsolèts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ amqp==5.3.1
 arabic-reshaper==3.0.0
 asgiref==3.11.1
 asn1crypto==1.5.1
-asttokens==3.0.1
 async-timeout==5.0.1
 autopep8==2.3.2
 beautifulsoup4==4.14.3
@@ -24,7 +23,6 @@ click-repl==0.3.0
 colorama==0.4.6
 cryptography==47.0.0
 cssselect2==0.9.0
-decorator==5.2.1
 Deprecated==1.3.1
 diff_cover==10.2.0
 distlib==0.4.0
@@ -48,7 +46,6 @@ djangorestframework-camel-case==1.4.2
 drf-excel==2.5.3
 drf_base64==2.0
 et_xmlfile==2.0.0
-executing==2.2.1
 factory_boy==3.3.3
 Faker==40.13.0
 filelock==3.29.0
@@ -58,25 +55,18 @@ html5lib==1.1
 identify==2.6.16
 idna==3.11
 iniconfig==2.3.0
-ipdb==0.13.13
-ipython==9.13.0
-ipython_pygments_lexers==1.1.1
-jedi==0.19.2
 Jinja2==3.1.6
 jmespath==1.1.0
 kombu==5.6.2
 lxml==6.1.0
 MarkupSafe==3.0.3
-matplotlib-inline==0.2.1
 nodeenv==1.10.0
 numpy==2.4.4
 openpyxl==3.1.5
 oscrypto==1.3.0
 packaging==26.0
 pandas==3.0.2
-parso==0.8.6
 pathspec==1.0.3
-pexpect==4.9.0
 phonenumbers==9.0.24
 pikepdf==10.5.1
 pillow==12.2.0
@@ -86,8 +76,6 @@ pluggy==1.6.0
 pre_commit==4.5.1
 prompt_toolkit==3.0.52
 psycopg2==2.9.12
-ptyprocess==0.7.0
-pure_eval==0.2.3
 pycairo==1.29.0
 pycodestyle==2.14.0
 pycparser==3.0
@@ -98,6 +86,7 @@ pypdf==6.11.0
 pytest==9.0.3
 python-bidi==0.6.7
 python-dateutil==2.9.0.post0
+python-discovery==1.3.1
 python-magic==0.4.27
 pytz==2026.2
 PyYAML==6.0.3
@@ -116,12 +105,10 @@ six==1.17.0
 soupsieve==2.8.3
 sqlfluff==4.1.0
 sqlparse==0.5.5
-stack-data==0.6.3
 svglib==1.6.0
 tblib==3.2.2
 tinycss2==1.5.1
 tqdm==4.67.3
-traitlets==5.14.3
 typing_extensions==4.15.0
 tzdata==2025.3
 tzlocal==5.3.1
@@ -129,6 +116,7 @@ Unidecode==1.4.0
 uritools==6.0.1
 urllib3==2.7.0
 vine==5.1.0
+virtualenv==21.3.3
 wcwidth==0.7.0
 webencodings==0.5.1
 wrapt==2.1.2


### PR DESCRIPTION
Tout qui est supprimé vient des dépendances `ipdb`.

Après avoir reconstruit mon image docker, j'ai fait un `pip freeze` pour vérifier si il y a d'autres dépendances ajoutés. Il y a deux, qui vient des autres dans la liste.