### PR TITLE
Permet de garder la décision du visa après navigation

### DIFF
--- a/frontend/src/components/NewBepiasViews/VisaValidationSegment.vue
+++ b/frontend/src/components/NewBepiasViews/VisaValidationSegment.vue
@@ -4,7 +4,7 @@
       <p>Cette déclaration est actuellement en état « {{ statusProps[declaration.status].label }} ».</p>
     </div>
     <div v-else>
-      <div class="mb-6 grid grid-cols-2">
+      <div class="mb-6 grid md:grid-cols-2">
         <div class="border p-2 h-full">
           <VisaInfoLine title="Instructeur·ice" :text="instructorName" icon="ri-account-circle-line" />
           <VisaInfoLine
@@ -50,7 +50,7 @@
         </div>
       </div>
 
-      <div class="grid grid-cols-2 gap-10">
+      <div class="grid md:grid-cols-2 gap-10">
         <div class="border p-4 flex flex-col" v-for="decision in decisionCategories" :key="decision.title">
           <h3 class="font-bold fr-h6">
             <v-icon :color="decision.iconColor" :name="decision.icon" scale="1.2" aria-hidden class="mr-1" />

--- a/frontend/src/components/NewBepiasViews/VisaValidationSegment.vue
+++ b/frontend/src/components/NewBepiasViews/VisaValidationSegment.vue
@@ -85,6 +85,7 @@ import VisaInfoLine from "./VisaInfoLine.vue"
 import ArticleInfoRow from "@/components/DeclarationSummary/ArticleInfoRow"
 import DecisionModificationForm from "./DecisionModificationForm"
 import { useStorage } from "@vueuse/core"
+
 const declaration = defineModel()
 const decisionModificationRef = ref(null)
 const getLocalStorageKey = (key) => `visa-${declaration.value?.id}-${key}`
@@ -100,7 +101,12 @@ const emit = defineEmits(["decision-done"])
 
 defineProps({ readonly: Boolean })
 
-const overriddenDecisionDefaultValue = () => ({ reasons: [] })
+const overriddenDecisionDefaultValue = () => ({
+  proposal: declaration.value?.postValidationStatus,
+  delayDays: declaration.value?.postValidationExpirationDays,
+  comment: declaration.value?.postValidationProducerMessage,
+  reasons: declaration.value?.blockingReasons || [],
+})
 
 const overriddenDecision = useStorage(
   getLocalStorageKey("overriddenDecision"),
@@ -113,6 +119,7 @@ const overriddenDecision = useStorage(
     },
   }
 )
+
 const hasOverriddenOriginalDecision = computed(
   () => modificationEnabled.value && overriddenDecision.value && Object.keys(overriddenDecision.value).length > 0
 )

--- a/frontend/src/components/NewBepiasViews/VisaValidationSegment.vue
+++ b/frontend/src/components/NewBepiasViews/VisaValidationSegment.vue
@@ -85,19 +85,19 @@ import VisaInfoLine from "./VisaInfoLine.vue"
 import ArticleInfoRow from "@/components/DeclarationSummary/ArticleInfoRow"
 import DecisionModificationForm from "./DecisionModificationForm"
 import { useStorage } from "@vueuse/core"
-
-const modificationEnabled = ref(false)
+const declaration = defineModel()
 const decisionModificationRef = ref(null)
-
 const getLocalStorageKey = (key) => `visa-${declaration.value?.id}-${key}`
 const clearLocalStorage = () => {
   const keys = ["overriddenDecision"]
   for (const key of keys) localStorage.removeItem(getLocalStorageKey(key))
 }
 
+const modificationEnabled = useStorage(getLocalStorageKey("modificationEnabled"), false)
+
 const $externalResults = ref({})
 const emit = defineEmits(["decision-done"])
-const declaration = defineModel()
+
 defineProps({ readonly: Boolean })
 
 const overriddenDecisionDefaultValue = () => ({ reasons: [] })


### PR DESCRIPTION
- Persistance des éléments via local storage.
- Pré-remplissage des champs de la modification du visa avec les champs de l'instruction

## :camera: Démos

### Persistance (commit https://github.com/betagouv/complements-alimentaires/pull/2946/commits/8d76619f5bd86bfb6e101fb7c0281d81e63198e1)

https://github.com/user-attachments/assets/5b9c32f9-b131-4188-ac99-9b9a71f57699

### Valeurs par défaut (commit https://github.com/betagouv/complements-alimentaires/pull/2946/commits/801145a8424d0c85275eaad0b966e429c3fe884c)


https://github.com/user-attachments/assets/111b3816-bd4b-4f51-810a-06e579c1d278


