### PR TITLE
RGAA 9.3 : le informations regroupées devront être structurées dans une liste

### DIFF
--- a/frontend/src/components/BlogCard.vue
+++ b/frontend/src/components/BlogCard.vue
@@ -5,6 +5,7 @@
     :detail="isoToPrettyDate(props.post.displayDate)"
     :description="blogDescription(props.post)"
     :link="{ name: 'BlogPostPage', params: { id: props.post.id } }"
+    titleTag="h2"
   />
 </template>
 

--- a/frontend/src/components/DeclarationAlert.vue
+++ b/frontend/src/components/DeclarationAlert.vue
@@ -5,24 +5,28 @@
       <v-icon name="ri-error-warning-line"></v-icon>
       Sans retour de votre part, ce dossier expirera le {{ isoToPrettyDate(displayData.expirationDate) }}.
     </p>
-    <div v-if="displayData.canDownloadCertificate">
-      <a download="true" :href="`/declarations/${declaration.id}/certificate`" class="fr-link fr-link--download">
-        Télécharger
-        <span class="lowercase">{{ displayData.documentName || "l'attestation" }}</span>
-        <span class="fr-link__detail">&nbsp;PDF</span>
-      </a>
-      <a
-        :href="`/declarations/${declaration.id}/certificate.html`"
-        target="_blank"
-        rel="noopener external"
-        class="ml-4 relative"
-        :title="`${displayData.documentName || 'L\'attestation'} (HTML) - nouvelle fenêtre`"
-      >
-        {{ displayData.documentName || "L'attestation" }}
-        <span class="link-detail">HTML</span>
-        <span class="fr-sr-only">&nbsp;- nouvelle fenêtre</span>
-      </a>
-    </div>
+    <ul v-if="displayData.canDownloadCertificate" class="inline-list">
+      <li>
+        <a download="true" :href="`/declarations/${declaration.id}/certificate`" class="fr-link fr-link--download">
+          Télécharger
+          <span class="lowercase">{{ displayData.documentName || "l'attestation" }}</span>
+          <span class="fr-link__detail">&nbsp;PDF</span>
+        </a>
+      </li>
+      <li>
+        <a
+          :href="`/declarations/${declaration.id}/certificate.html`"
+          target="_blank"
+          rel="noopener external"
+          class="ml-4 relative"
+          :title="`${displayData.documentName || 'L\'attestation'} (HTML) - nouvelle fenêtre`"
+        >
+          {{ displayData.documentName || "L'attestation" }}
+          <span class="link-detail">HTML</span>
+          <span class="fr-sr-only">&nbsp;- nouvelle fenêtre</span>
+        </a>
+      </li>
+    </ul>
   </DsfrAlert>
 </template>
 

--- a/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/DeclarationsTableSection/index.vue
@@ -57,17 +57,17 @@
       </div>
     </div>
     <!-- Zone des filtres actifs -->
-    <div class="mb-4">
-      <DsfrTag
-        v-for="(item, idx) in activeFilters"
-        :key="`active-filters-${idx}`"
-        :label="item.text"
-        tagName="button"
-        @click="item.callback"
-        :aria-label="`Retirer le filtre « ${item.text} »`"
-        class="mx-1 fr-tag--dismiss"
-      ></DsfrTag>
-    </div>
+    <ul class="inline-list mb-4">
+      <li v-for="(item, idx) in activeFilters" :key="`active-filters-${idx}`">
+        <DsfrTag
+          :label="item.text"
+          tagName="button"
+          @click="item.callback"
+          :aria-label="`Retirer le filtre « ${item.text} »`"
+          class="mx-1 fr-tag--dismiss"
+        ></DsfrTag>
+      </li>
+    </ul>
 
     <DsfrAccordionsGroup v-model="activeAccordion">
       <DsfrAccordion title="Filtres avancés">

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -232,3 +232,7 @@
 #app {
   @import 'tailwindcss/utilities' layer(utilities) important;
 }
+
+ul.inline-list {
+  @apply list-none sm:flex p-0 m-0;
+}

--- a/frontend/src/views/AdvancedSearchPage/index.vue
+++ b/frontend/src/views/AdvancedSearchPage/index.vue
@@ -124,19 +124,19 @@
                 :chooseFirstAsDefault="false"
                 :searchAll="true"
               />
-              <div class="mt-2">
-                <DsfrTag
-                  v-for="([id, name, type], idx) in ingredientsToFilter"
-                  :key="`ingredient-${id}`"
-                  class="m-1 fr-tag--dismiss"
-                  @click="removeIngredient(idx)"
-                  :aria-label="`Retirer ${name}`"
-                  tagName="button"
-                >
-                  <v-icon scale="0.85" class="mr-1" :name="getTypeIcon(type)" :aria-label="getTypeInFrench(type)" />
-                  {{ name }}
-                </DsfrTag>
-              </div>
+              <ul class="inline-list mt-2">
+                <li v-for="([id, name, type], idx) in ingredientsToFilter" :key="`ingredient-${id}`">
+                  <DsfrTag
+                    class="m-1 fr-tag--dismiss"
+                    @click="removeIngredient(idx)"
+                    :aria-label="`Retirer ${name}`"
+                    tagName="button"
+                  >
+                    <v-icon scale="0.85" class="mr-1" :name="getTypeIcon(type)" :aria-label="getTypeInFrench(type)" />
+                    {{ name }}
+                  </DsfrTag>
+                </li>
+              </ul>
               <div class="mt-4">
                 <label for="dose-filter" class="fr-label">Dose</label>
                 <DoseFilterModal :modelValue="dose" @update:modelValue="updateDose" id="dose-filter" />

--- a/frontend/src/views/CompanySearchPage/index.vue
+++ b/frontend/src/views/CompanySearchPage/index.vue
@@ -36,17 +36,17 @@
     </div>
 
     <!-- Zone des filtres actifs -->
-    <div class="mb-4">
-      <DsfrTag
-        v-for="(item, idx) in activeFilters"
-        :key="`active-filters-${idx}`"
-        :label="item.text"
-        tagName="button"
-        @click="item.callback"
-        :aria-label="`Retirer le filtre « ${item.text} »`"
-        class="mx-1 fr-tag--dismiss"
-      ></DsfrTag>
-    </div>
+    <ul class="inline-list mb-4">
+      <li v-for="(item, idx) in activeFilters" :key="`active-filters-${idx}`">
+        <DsfrTag
+          :label="item.text"
+          tagName="button"
+          @click="item.callback"
+          :aria-label="`Retirer le filtre « ${item.text} »`"
+          class="mx-1 fr-tag--dismiss"
+        ></DsfrTag>
+      </li>
+    </ul>
 
     <div class="grid grid-cols-4 gap-4 mb-6">
       <div class="col-span-4 md:col-span-2 lg:col-span-1">

--- a/frontend/src/views/ElementForm/FormFields.vue
+++ b/frontend/src/views/ElementForm/FormFields.vue
@@ -182,17 +182,17 @@
           :searchAll="true"
           :required="false"
         />
-        <div class="md:ml-4 md:my-7 md:col-span-2">
-          <DsfrTag
-            v-for="(substance, idx) in state.substances"
-            :key="`substance-${substance.id}`"
-            :label="substance.name"
-            tagName="button"
-            @click="state.substances.splice(idx, 1)"
-            :aria-label="`Retirer ${substance.name}`"
-            class="mx-1 fr-tag--dismiss"
-          ></DsfrTag>
-        </div>
+        <ul class="list-none p-0 m-0 md:ml-4 md:my-7 md:col-span-2">
+          <li v-for="(substance, idx) in state.substances" :key="`substance-${substance.id}`">
+            <DsfrTag
+              :label="substance.name"
+              tagName="button"
+              @click="state.substances.splice(idx, 1)"
+              :aria-label="`Retirer ${substance.name}`"
+              class="mx-1 fr-tag--dismiss"
+            ></DsfrTag>
+          </li>
+        </ul>
       </div>
       <div class="grid sm:grid-cols-2 lg:grid-cols-3 mb-6">
         <DsfrInputGroup>

--- a/frontend/src/views/ElementForm/index.vue
+++ b/frontend/src/views/ElementForm/index.vue
@@ -9,7 +9,13 @@
     </div>
     <div v-if="isNewIngredient && !type" class="fr-container">
       <div class="grid sm:grid-cols-2 gap-8 sm:p-8 m-8">
-        <DsfrTile v-for="(title, type) in forms" :key="type" :title="title" :to="{ query: { type: type } }" />
+        <DsfrTile
+          v-for="(title, type) in forms"
+          :key="type"
+          :title="title"
+          :to="{ query: { type: type } }"
+          titleTag="h2"
+        />
       </div>
     </div>
     <div v-else class="fr-container">

--- a/frontend/src/views/ElementSearchResultsPage/index.vue
+++ b/frontend/src/views/ElementSearchResultsPage/index.vue
@@ -39,6 +39,7 @@
           :key="result.id"
           class="col-span-12 sm:col-span-6 md:col-span-4"
           :result="result"
+          titleTag="h2"
         />
       </div>
       <DsfrPagination


### PR DESCRIPTION
[Notion](https://app.notion.com/p/incubateur-masa/Crit-re-9-3-Certaines-listes-sont-incorrectement-structur-es-dans-le-code-356de24614be80068e61d7d8ed75f075?v=356de24614be809396f2000cb8f51b04&source=copy_link)

J'ai réparé le dernier issu soulevé dans ce critère (les liens téléchargement d'attestation) et j'ai fait un audit sur les cas restants de `v-for` pour retrouver et réparer quelques issus restants niveau structuration de nos pages. Normalement il n'y a pas de changement visuel ni comportemental.

Je modifie aussi deux exemples de titre sauté que j'ai retrouvé pendant cet audit.