### PR TITLE
Validation des déclarations art 16 et 18 doivent passer par le visa

### DIFF
--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -411,6 +411,42 @@ class TestDeclarationFlowRemainingActions(APITestCase):
         self.assertEqual(latest_snapshot.action, Snapshot.SnapshotActions.AUTHORIZE_NO_VISA)
 
     @authenticate
+    def test_authorize_declaration_article_16(self):
+        """
+        Passage du ONGOING_INSTRUCTION -> AUTHORIZED
+        """
+        instructor = InstructionRoleFactory(user=authenticate.user)
+        declaration_art_16 = OngoingInstructionDeclarationFactory(
+            instructor=instructor, overridden_article=Declaration.Article.ARTICLE_16
+        )
+
+        response = self.client.post(
+            reverse("api:authorize_no_visa", kwargs={"pk": declaration_art_16.id}), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        declaration_art_16.refresh_from_db()
+        self.assertEqual(declaration_art_16.status, Declaration.DeclarationStatus.ONGOING_INSTRUCTION)
+
+    @authenticate
+    def test_authorize_declaration_article_18(self):
+        """
+        Passage du ONGOING_INSTRUCTION -> AUTHORIZED
+        """
+        instructor = InstructionRoleFactory(user=authenticate.user)
+        declaration_art_18 = OngoingInstructionDeclarationFactory(
+            instructor=instructor, overridden_article=Declaration.Article.ARTICLE_18
+        )
+
+        response = self.client.post(
+            reverse("api:authorize_no_visa", kwargs={"pk": declaration_art_18.id}), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        declaration_art_18.refresh_from_db()
+        self.assertEqual(declaration_art_18.status, Declaration.DeclarationStatus.ONGOING_INSTRUCTION)
+
+    @authenticate
     def test_authorize_declaration_unauthorized(self):
         """
         Passage du ONGOING_INSTRUCTION -> AUTHORIZED
@@ -637,6 +673,46 @@ class TestDeclarationFlowRemainingActions(APITestCase):
         self.assertEqual(declaration.status, Declaration.DeclarationStatus.AWAITING_VISA)
 
         latest_snapshot = declaration.snapshots.latest("creation_date")
+        self.assertEqual(latest_snapshot.action, Snapshot.SnapshotActions.REQUEST_VISA)
+
+    @authenticate
+    def test_authorize_with_visa_art_16(self):
+        """
+        Passage de ONGOING_INSTRUCTION à AWAITING_VISA en abboutissant sur AUTHORIZE
+        """
+        InstructionRoleFactory(user=authenticate.user)
+        declaration_art_16 = OngoingInstructionDeclarationFactory(overridden_article=Declaration.Article.ARTICLE_16)
+
+        response = self.client.post(
+            reverse("api:authorize_with_visa", kwargs={"pk": declaration_art_16.id}), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        declaration_art_16.refresh_from_db()
+        self.assertEqual(declaration_art_16.post_validation_status, Declaration.DeclarationStatus.AUTHORIZED)
+        self.assertEqual(declaration_art_16.status, Declaration.DeclarationStatus.AWAITING_VISA)
+
+        latest_snapshot = declaration_art_16.snapshots.latest("creation_date")
+        self.assertEqual(latest_snapshot.action, Snapshot.SnapshotActions.REQUEST_VISA)
+
+    @authenticate
+    def test_authorize_with_visa_art_18(self):
+        """
+        Passage de ONGOING_INSTRUCTION à AWAITING_VISA en abboutissant sur AUTHORIZE
+        """
+        InstructionRoleFactory(user=authenticate.user)
+        declaration_art_18 = OngoingInstructionDeclarationFactory(overridden_article=Declaration.Article.ARTICLE_16)
+
+        response = self.client.post(
+            reverse("api:authorize_with_visa", kwargs={"pk": declaration_art_18.id}), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        declaration_art_18.refresh_from_db()
+        self.assertEqual(declaration_art_18.post_validation_status, Declaration.DeclarationStatus.AUTHORIZED)
+        self.assertEqual(declaration_art_18.status, Declaration.DeclarationStatus.AWAITING_VISA)
+
+        latest_snapshot = declaration_art_18.snapshots.latest("creation_date")
         self.assertEqual(latest_snapshot.action, Snapshot.SnapshotActions.REQUEST_VISA)
 
     @authenticate

--- a/api/tests/test_declaration_flow.py
+++ b/api/tests/test_declaration_flow.py
@@ -701,7 +701,7 @@ class TestDeclarationFlowRemainingActions(APITestCase):
         Passage de ONGOING_INSTRUCTION à AWAITING_VISA en abboutissant sur AUTHORIZE
         """
         InstructionRoleFactory(user=authenticate.user)
-        declaration_art_18 = OngoingInstructionDeclarationFactory(overridden_article=Declaration.Article.ARTICLE_16)
+        declaration_art_18 = OngoingInstructionDeclarationFactory(overridden_article=Declaration.Article.ARTICLE_18)
 
         response = self.client.post(
             reverse("api:authorize_with_visa", kwargs={"pk": declaration_art_18.id}), format="json"

--- a/api/views/declaration/declaration_flow.py
+++ b/api/views/declaration/declaration_flow.py
@@ -3,7 +3,11 @@ from viewflow import fsm
 from api.exception_handling import ProjectAPIException
 from data.models import Declaration
 
-from .declaration_flow_validations import validate_mandatory_fields, validate_number_of_elements
+from .declaration_flow_validations import (
+    validate_article_direct_approval,
+    validate_mandatory_fields,
+    validate_number_of_elements,
+)
 
 Status = Declaration.DeclarationStatus
 
@@ -47,7 +51,7 @@ class DeclarationFlow:
 
     @status.transition(source=Status.ONGOING_INSTRUCTION, target=Status.AUTHORIZED)
     def authorize_no_visa(self):
-        pass
+        self.ensure_validators([validate_article_direct_approval])
 
     @status.transition(source=Status.ONGOING_INSTRUCTION, target=Status.AWAITING_VISA)
     def request_visa(self):

--- a/api/views/declaration/declaration_flow_validations.py
+++ b/api/views/declaration/declaration_flow_validations.py
@@ -119,6 +119,6 @@ def validate_number_of_elements(declaration) -> tuple[list, list]:
 
 def validate_article_direct_approval(declaration) -> tuple[list, list]:
     non_field_errors = []
-    if declaration.article == Declaration.Article.ARTICLE_16 or declaration.article == Declaration.Article.ARTICLE_18:
+    if declaration.article in (Declaration.Article.ARTICLE_16, Declaration.Article.ARTICLE_18):
         non_field_errors += ["Une déclaration avec article 16 ou 18 doit passer par le visa pour validation"]
     return ([], non_field_errors)

--- a/api/views/declaration/declaration_flow_validations.py
+++ b/api/views/declaration/declaration_flow_validations.py
@@ -115,3 +115,10 @@ def validate_number_of_elements(declaration) -> tuple[list, list]:
     if not has_elements:
         non_field_errors += ["Le complément doit comporter au moins un ingrédient"]
     return ([], non_field_errors)
+
+
+def validate_article_direct_approval(declaration) -> tuple[list, list]:
+    non_field_errors = []
+    if declaration.article == Declaration.Article.ARTICLE_16 or declaration.article == Declaration.Article.ARTICLE_18:
+        non_field_errors += ["Une déclaration avec article 16 ou 18 doit passer par le visa pour validation"]
+    return ([], non_field_errors)

--- a/frontend/src/components/NewBepiasViews/ProductSection/InstructionResults.vue
+++ b/frontend/src/components/NewBepiasViews/ProductSection/InstructionResults.vue
@@ -171,18 +171,28 @@ const decisionCategories = [
   },
 ]
 
-const mandatoryVisaProposals = ["objection", "rejection"]
-const disableVisaCheckbox = computed(() => !proposal.value || mandatoryVisaProposals.indexOf(proposal.value) > -1)
+const isMandatoryVisa = (proposal) => {
+  const articlesVisaForApproval = ["ART_16", "ART_18"]
+  const mandatoryVisaProposals = ["objection", "rejection"]
+  if (articlesVisaForApproval.indexOf(article.value) > -1) mandatoryVisaProposals.push("autorisation")
+  return mandatoryVisaProposals.indexOf(proposal) > -1
+}
+
+const disableVisaCheckbox = computed(() => !proposal.value || isMandatoryVisa(proposal.value))
 const disableDelayDays = computed(() => proposal.value === "rejection")
-watch(proposal, (newProposal) => {
-  if (mandatoryVisaProposals.indexOf(newProposal) > -1) needsVisa.value = true
-  else needsVisa.value = false
+const article = computed(() => declaration.value?.article)
+
+const setProposalDefaults = (newProposal) => {
+  needsVisa.value = isMandatoryVisa(newProposal)
   if (newProposal === "objection") delayDays.value = 30
   else if (newProposal === "observation") delayDays.value = window.OBSERVATION_DAYS
   else delayDays.value = null
-})
+}
 
-const needsAnsesReferal = computed(() => declaration.value?.article === "ANSES_REFERAL")
+watch(proposal, setProposalDefaults)
+watch(article, () => setProposalDefaults(proposal.value))
+
+const needsAnsesReferal = computed(() => article.value === "ANSES_REFERAL")
 const isVisor = computed(() => loggedUser.value?.globalRoles?.some((x) => x.name === "VisaRole"))
 
 const proposalOptions = [

--- a/frontend/src/components/NewBepiasViews/ProductSection/index.vue
+++ b/frontend/src/components/NewBepiasViews/ProductSection/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="p-6">
-      <ArticleInfoRow :modelValue="declaration" :allowChange="true" class="mb-4" />
+      <ArticleInfoRow v-model="declaration" :allowChange="true" class="mb-4" />
 
       <SectionHeader id="pieces-jointes" icon="ri-attachment-fill" text="Pièces jointes" />
       <RequiresAnalysisReportNotice :declaration="declaration" />
@@ -59,21 +59,22 @@ import RequiresAnalysisReportNotice from "@/components/RequiresAnalysisReportNot
 
 const router = useRouter()
 
-const props = defineProps({ declaration: Object, snapshots: Array, role: { type: String, default: "instruction" } })
+const declaration = defineModel()
+const props = defineProps({ snapshots: Array, role: { type: String, default: "instruction" } })
 
 const lastSnapshot = computed(() => props.snapshots?.findLast((x) => !!x.comment))
 
 const showComputedSubstances = computed(() => {
-  if (props.declaration?.computedSubstances?.length) return true
-  return props.declaration.declaredPlants
-    .concat(props.declaration.declaredMicroorganisms)
-    .concat(props.declaration.declaredSubstances)
-    .concat(props.declaration.declaredIngredients)
+  if (declaration.value?.computedSubstances?.length) return true
+  return declaration.value.declaredPlants
+    .concat(declaration.value.declaredMicroorganisms)
+    .concat(declaration.value.declaredSubstances)
+    .concat(declaration.value.declaredIngredients)
     .some((x) => x.requestStatus === "REPLACED" && x.element?.substances?.length)
 })
 
 const redirectToVisa = () => router.push({ name: "VisaDeclarations" })
 
-const canInstruct = computed(() => props.declaration?.status === "ONGOING_INSTRUCTION")
-const canVisa = computed(() => props.declaration?.status === "ONGOING_VISA")
+const canInstruct = computed(() => declaration.value?.status === "ONGOING_INSTRUCTION")
+const canVisa = computed(() => declaration.value?.status === "ONGOING_VISA")
 </script>

--- a/frontend/src/views/NewInstructionPage/index.vue
+++ b/frontend/src/views/NewInstructionPage/index.vue
@@ -28,6 +28,7 @@
         </div>
         <div class="col-span-12 sm:col-span-9 bg-grey-975!">
           <router-view
+            v-model="declaration"
             :declaration="declaration"
             :declarant="declarant"
             :company="company"

--- a/frontend/src/views/NewVisaPage/index.vue
+++ b/frontend/src/views/NewVisaPage/index.vue
@@ -32,6 +32,7 @@
         </div>
         <div class="col-span-12 sm:col-span-9 bg-grey-975!">
           <router-view
+            v-model="declaration"
             :declaration="declaration"
             :declarant="declarant"
             :company="company"


### PR DESCRIPTION
Closes #2997

Les déclarations article 16 et 18 nécessitent un passage obligatoire par le visa avant d'être autorisées. Cette PR met en place les garde-fous manquants côté backend et frontend pour l'imposer.

<img width="636" height="283" alt="image" src="https://github.com/user-attachments/assets/b41a89e7-eec4-4cf5-ad3f-e97d7b87288d" />

Le passage par un `v-model="declaration"` était nécessaire pour réagir au changement d'article dans _InstructionResults.vue_

### Out of scope

- La migration des autres composants enfants du router-view vers defineModel() est hors périmètre. Ces composants continuent de recevoir la  prop :declaration comme avant, ce qui reste fonctionnel.
- Le traitement spécifique de l'article ANSES est hors périmètre : la logique existante needsAnsesReferal n'est pas modifiée et ce cas fera l'objet d'une autre PR si nécessaire.
