### PR TITLE
Enlever des dépendences inutiles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ click-repl==0.3.0
 colorama==0.4.6
 cryptography==48.0.1
 cssselect2==0.9.0
-Deprecated==1.3.1
 diff_cover==10.3.0
 distlib==0.4.0
 Django==6.0.6
@@ -115,5 +114,4 @@ vine==5.1.0
 virtualenv==21.3.3
 wcwidth==0.7.0
 webencodings==0.5.1
-wrapt==2.1.2
 xhtml2pdf==0.2.17


### PR DESCRIPTION
Ils ont été introduits dans la PR #2813 mais ils ne sont plus liés à la bibliothèque nécessaire pour la fonctionnalité.