### PR TITLE
Affichage des substances des ingrédients seulement

### DIFF
--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -518,6 +518,16 @@ class Declaration(Historisable, TimeStampable):
         ).distinct()
 
     @property
+    def inactive_declared_ingredients(self):
+        """Ingrédients déclarés qui ne sont pas de type FORM_OF_SUPPLY ou ACTIVE_INGREDIENT."""
+        return self.declared_ingredients.exclude(
+            ingredient__ingredient_type__in=[
+                IngredientType.FORM_OF_SUPPLY,
+                IngredientType.ACTIVE_INGREDIENT,
+            ]
+        )
+
+    @property
     def has_risky_ingredients(self):
         return (
             self.risky_ingredients.exists()

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -510,22 +510,19 @@ class Declaration(Historisable, TimeStampable):
     def active_ingredient_computed_substances(self):
         """Computed substances qui proviennent d'une source de type FORM_OF_SUPPLY ou ACTIVE_INGREDIENT."""
         return self.computed_substances.filter(
-            substance__ingredientsubstancerelation__ingredient__ingredient_type__in=[
-                IngredientType.FORM_OF_SUPPLY,
-                IngredientType.ACTIVE_INGREDIENT,
-            ],
+            substance__ingredientsubstancerelation__ingredient__ingredient_type__in=IngredientType.active_types(),
             substance__ingredientsubstancerelation__ingredient__declaredingredient__declaration=self,
         ).distinct()
 
     @property
+    def active_declared_ingredients(self):
+        """Ingrédients déclarés de type FORM_OF_SUPPLY ou ACTIVE_INGREDIENT."""
+        return self.declared_ingredients.filter(ingredient__ingredient_type__in=IngredientType.active_types())
+
+    @property
     def inactive_declared_ingredients(self):
         """Ingrédients déclarés qui ne sont pas de type FORM_OF_SUPPLY ou ACTIVE_INGREDIENT."""
-        return self.declared_ingredients.exclude(
-            ingredient__ingredient_type__in=[
-                IngredientType.FORM_OF_SUPPLY,
-                IngredientType.ACTIVE_INGREDIENT,
-            ]
-        )
+        return self.declared_ingredients.exclude(ingredient__ingredient_type__in=IngredientType.active_types())
 
     @property
     def has_risky_ingredients(self):

--- a/data/models/declaration.py
+++ b/data/models/declaration.py
@@ -34,6 +34,7 @@ from data.models import (
     VisaRole,
 )
 from data.models.ingredient_status import IngredientStatus
+from data.models.ingredient_type import IngredientType
 from data.models.substance import SubstanceMaxQuantityPerPopulationRelation
 
 logger = logging.getLogger(__name__)
@@ -504,6 +505,17 @@ class Declaration(Historisable, TimeStampable):
     @property
     def risky_computed_substances(self):
         return self.computed_substances.filter(substance__is_risky=True)
+
+    @property
+    def active_ingredient_computed_substances(self):
+        """Computed substances qui proviennent d'une source de type FORM_OF_SUPPLY ou ACTIVE_INGREDIENT."""
+        return self.computed_substances.filter(
+            substance__ingredientsubstancerelation__ingredient__ingredient_type__in=[
+                IngredientType.FORM_OF_SUPPLY,
+                IngredientType.ACTIVE_INGREDIENT,
+            ],
+            substance__ingredientsubstancerelation__ingredient__declaredingredient__declaration=self,
+        ).distinct()
 
     @property
     def has_risky_ingredients(self):

--- a/data/models/ingredient_type.py
+++ b/data/models/ingredient_type.py
@@ -17,3 +17,7 @@ class IngredientType(models.IntegerChoices):
     AROMA = 3, "Arôme"  # TODO les arômes devraient peut-être disparaître à terme car tous non actifs
     ACTIVE_INGREDIENT = 4, "Autre ingrédient actif"
     NON_ACTIVE_INGREDIENT = 5, "Autre ingrédient"
+
+    @classmethod
+    def active_types(cls):
+        return [cls.FORM_OF_SUPPLY, cls.ACTIVE_INGREDIENT]

--- a/web/templates/certificates/certificate-base-template.html
+++ b/web/templates/certificates/certificate-base-template.html
@@ -99,8 +99,9 @@
                     -pdf-frame-content: footer
                 }
             }
-            .ingredient-source span + span::before {
-                content: ", ";
+            .ingredient-source ul {
+                margin: 0;
+                padding: 0;
             }
             .sans-serif {
                 font-family: sans-serif;

--- a/web/templates/certificates/certificate-base-template.html
+++ b/web/templates/certificates/certificate-base-template.html
@@ -99,6 +99,12 @@
                     -pdf-frame-content: footer
                 }
             }
+            .ingredient-source span + span::before {
+                content: ", ";
+            }
+            .sans-serif {
+                font-family: sans-serif;
+            }
         </style>
         <title>
             {% block 'title' %}

--- a/web/templates/certificates/certificate-composition.html
+++ b/web/templates/certificates/certificate-composition.html
@@ -25,7 +25,7 @@
                 {% if dp.preparation %}{{ dp.preparation.name }}{% else %}—{% endif %}
             </td>
             <td class="align-right">
-                {% if dp.quantity %}{{ dp.quantity }}{% if dp.unit %}<span style="font-family: sans-serif;"> {{ dp.unit.name }}</span>{% endif %}{% else %}—{% endif %}
+                {% if dp.quantity %}{{ dp.quantity }}{% if dp.unit %}<span class="sans-serif"> {{ dp.unit.name }}</span>{% endif %}{% else %}—{% endif %}
             </td>
         </tr>
         {% endfor %}
@@ -77,7 +77,45 @@
                 {% if ds.new %}{{ ds.new_name }}{% else %}{{ ds.substance.name }}{% endif %}
             </td>
             <td class="align-right">
-                {% if ds.quantity %}{{ ds.quantity }}{% if ds.unit %}<span style="font-family: sans-serif;"> {{ ds.unit.name }}</span>{% endif %}{% else %}—{% endif %}
+                {% if ds.quantity %}{{ ds.quantity }}{% if ds.unit %}<span class="sans-serif"> {{ ds.unit.name }}</span>{% endif %}{% else %}—{% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endif %}
+
+{% if active_ingredient_computed_substances %}
+<table>
+    <caption>Ingrédients actifs :</caption>
+    <thead>
+        <tr>
+            <th>Substance</th>
+            <th>Ingrédients</th>
+            <th class="align-right">Quantité par DJR</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for cs in active_ingredient_computed_substances %}
+        <tr>
+            <td>{{ cs.substance.name }}</td>
+            <td class="ingredient-source">
+                {% for di in declared_ingredients %}
+                    {% if di.ingredient.ingredient_type == 1 or di.ingredient.ingredient_type == 4 %}
+                        {% if cs.substance in di.ingredient.substances.all %}
+                            <span>
+                                {% if di.new %}
+                                    {{ di.new_name }}
+                                {% else %}
+                                    {{ di.ingredient.name }}
+                                {% endif %}
+                                &nbsp;
+                            </span>
+                        {% endif %}
+                    {% endif %}
+                {% endfor %}</td>
+            <td class="align-right">
+                {% if cs.quantity %}{{ cs.quantity }}{% if cs.unit %}<span class="sans-serif"> {{ cs.unit.name }}</span>{% endif %}{% else %}—{% endif %}
             </td>
         </tr>
         {% endfor %}
@@ -96,14 +134,16 @@
     </thead>
     <tbody>
         {% for di in declared_ingredients %}
+        {% if di.ingredient.ingredient_type == 1 or di.ingredient.ingredient_type == 4 %}{% else %}
         <tr>
             <td>
                 {% if di.new %}{{ di.new_name }}{% else %}{{ di.ingredient.name }}{% endif %}
             </td>
             <td class="align-right">
-                {% if di.quantity %}{{ di.quantity }}{% if di.unit %}<span style="font-family: sans-serif;"> {{ di.unit.name }}</span>{% endif %}{% else %}—{% endif %}
+                {% if di.quantity %}{{ di.quantity }}{% if di.unit %}<span class="sans-serif"> {{ di.unit.name }}</span>{% endif %}{% else %}—{% endif %}
             </td>
         </tr>
+        {% endif %}
         {% endfor %}
     </tbody>
 </table>

--- a/web/templates/certificates/certificate-composition.html
+++ b/web/templates/certificates/certificate-composition.html
@@ -100,20 +100,16 @@
         <tr>
             <td>{{ cs.substance.name }}</td>
             <td class="ingredient-source">
+                <ul>
                 {% for di in declared_ingredients %}
                     {% if di.ingredient.ingredient_type == 1 or di.ingredient.ingredient_type == 4 %}
                         {% if cs.substance in di.ingredient.substances.all %}
-                            <span>
-                                {% if di.new %}
-                                    {{ di.new_name }}
-                                {% else %}
-                                    {{ di.ingredient.name }}
-                                {% endif %}
-                                &nbsp;
-                            </span>
+                            <li>{{ di.ingredient.name }}</li>
                         {% endif %}
                     {% endif %}
-                {% endfor %}</td>
+                {% endfor %}
+                </ul>
+            </td>
             <td class="align-right">
                 {% if cs.quantity %}{{ cs.quantity }}{% if cs.unit %}<span class="sans-serif"> {{ cs.unit.name }}</span>{% endif %}{% else %}—{% endif %}
             </td>

--- a/web/templates/certificates/certificate-composition.html
+++ b/web/templates/certificates/certificate-composition.html
@@ -1,4 +1,4 @@
-{% with declared_plants=declaration.declared_plants.all declared_microorganisms=declaration.declared_microorganisms.all declared_substances=declaration.declared_substances.all declared_ingredients=declaration.declared_ingredients.all %}
+{% with declared_plants=declaration.declared_plants.all declared_microorganisms=declaration.declared_microorganisms.all declared_substances=declaration.declared_substances.all declared_ingredients=declaration.declared_ingredients.all inactive_declared_ingredients=declaration.inactive_declared_ingredients %}
 <div id="composition">
 {% if declared_plants %}
 
@@ -119,7 +119,7 @@
 </table>
 {% endif %}
 
-{% if declared_ingredients %}
+{% if inactive_declared_ingredients %}
 <table>
     <caption>Autres ingrédients :</caption>
     <thead>
@@ -129,8 +129,7 @@
         </tr>
     </thead>
     <tbody>
-        {% for di in declared_ingredients %}
-        {% if di.ingredient.ingredient_type == 1 or di.ingredient.ingredient_type == 4 %}{% else %}
+        {% for di in inactive_declared_ingredients %}
         <tr>
             <td>
                 {% if di.new %}{{ di.new_name }}{% else %}{{ di.ingredient.name }}{% endif %}
@@ -139,7 +138,6 @@
                 {% if di.quantity %}{{ di.quantity }}{% if di.unit %}<span class="sans-serif"> {{ di.unit.name }}</span>{% endif %}{% else %}—{% endif %}
             </td>
         </tr>
-        {% endif %}
         {% endfor %}
     </tbody>
 </table>

--- a/web/templates/certificates/certificate-composition.html
+++ b/web/templates/certificates/certificate-composition.html
@@ -87,7 +87,7 @@
 
 {% if active_ingredient_computed_substances %}
 <table>
-    <caption>Ingrédients actifs :</caption>
+    <caption>Substances provenant des formes d'apport et autres ingrédients actifs :</caption>
     <thead>
         <tr>
             <th>Substance</th>

--- a/web/templates/certificates/certificate-composition.html
+++ b/web/templates/certificates/certificate-composition.html
@@ -1,4 +1,4 @@
-{% with declared_plants=declaration.declared_plants.all declared_microorganisms=declaration.declared_microorganisms.all declared_substances=declaration.declared_substances.all declared_ingredients=declaration.declared_ingredients.all inactive_declared_ingredients=declaration.inactive_declared_ingredients %}
+{% with declared_plants=declaration.declared_plants.all declared_microorganisms=declaration.declared_microorganisms.all declared_substances=declaration.declared_substances.all declared_ingredients=declaration.declared_ingredients.all active_declared_ingredients=declaration.active_declared_ingredients inactive_declared_ingredients=declaration.inactive_declared_ingredients %}
 <div id="composition">
 {% if declared_plants %}
 
@@ -101,11 +101,9 @@
             <td>{{ cs.substance.name }}</td>
             <td class="ingredient-source">
                 <ul>
-                {% for di in declared_ingredients %}
-                    {% if di.ingredient.ingredient_type == 1 or di.ingredient.ingredient_type == 4 %}
-                        {% if cs.substance in di.ingredient.substances.all %}
-                            <li>{{ di.ingredient.name }}</li>
-                        {% endif %}
+                {% for di in active_declared_ingredients %}
+                    {% if cs.substance in di.ingredient.substances.all %}
+                        <li>{{ di.ingredient.name }}</li>
                     {% endif %}
                 {% endfor %}
                 </ul>

--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -4,7 +4,7 @@ import logging
 from rest_framework.exceptions import NotFound
 
 from api.permissions import CanAccessIndividualDeclaration
-from data.models import Declaration, IngredientType, Snapshot
+from data.models import Declaration, Snapshot
 
 from .pdfview import PdfView
 
@@ -149,16 +149,8 @@ class CertificateView(PdfView):
                     f"Declaration with ID {declaration.id} is withdrawn but has no withdrawal snapshots associated with it"
                 )
 
-        computed_substances = declaration.computed_substances.filter(
-            substance__ingredientsubstancerelation__ingredient__ingredient_type__in=[
-                IngredientType.FORM_OF_SUPPLY,
-                IngredientType.ACTIVE_INGREDIENT,
-            ],
-            substance__ingredientsubstancerelation__ingredient__declaredingredient__declaration=declaration,
-        ).distinct()
-
         return {
-            "active_ingredient_computed_substances": computed_substances,
+            "active_ingredient_computed_substances": declaration.active_ingredient_computed_substances,
             "date": date,
             "last_submission_date": last_submission_date,
             "include_recipient_address": declaration.status == Declaration.DeclarationStatus.REJECTED,

--- a/web/views/certificate.py
+++ b/web/views/certificate.py
@@ -4,7 +4,7 @@ import logging
 from rest_framework.exceptions import NotFound
 
 from api.permissions import CanAccessIndividualDeclaration
-from data.models import Declaration, Snapshot
+from data.models import Declaration, IngredientType, Snapshot
 
 from .pdfview import PdfView
 
@@ -149,7 +149,16 @@ class CertificateView(PdfView):
                     f"Declaration with ID {declaration.id} is withdrawn but has no withdrawal snapshots associated with it"
                 )
 
+        computed_substances = declaration.computed_substances.filter(
+            substance__ingredientsubstancerelation__ingredient__ingredient_type__in=[
+                IngredientType.FORM_OF_SUPPLY,
+                IngredientType.ACTIVE_INGREDIENT,
+            ],
+            substance__ingredientsubstancerelation__ingredient__declaredingredient__declaration=declaration,
+        ).distinct()
+
         return {
+            "active_ingredient_computed_substances": computed_substances,
             "date": date,
             "last_submission_date": last_submission_date,
             "include_recipient_address": declaration.status == Declaration.DeclarationStatus.REJECTED,

--- a/web/views/summary.py
+++ b/web/views/summary.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from api.permissions import CanAccessIndividualDeclaration
-from data.models import Declaration, Snapshot
+from data.models import Declaration, IngredientType, Snapshot
 
 from .pdfview import PdfView
 
@@ -55,7 +55,13 @@ class SummaryView(PdfView):
             "declared_microorganisms": declaration.declared_microorganisms.all(),
             "declared_ingredients": declaration.declared_ingredients.all(),
             "declared_substances": declaration.declared_substances.all(),
-            "computed_substances": declaration.computed_substances.all(),
+            "active_ingredient_computed_substances": declaration.computed_substances.filter(
+                substance__ingredientsubstancerelation__ingredient__ingredient_type__in=[
+                    IngredientType.FORM_OF_SUPPLY,
+                    IngredientType.ACTIVE_INGREDIENT,
+                ],
+                substance__ingredientsubstancerelation__ingredient__declaredingredient__declaration=declaration,
+            ).distinct(),
             "attachments": declaration.attachments.all(),
             "submission_date": submission_date,
             "now": timezone.now(),

--- a/web/views/summary.py
+++ b/web/views/summary.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from api.permissions import CanAccessIndividualDeclaration
-from data.models import Declaration, IngredientType, Snapshot
+from data.models import Declaration, Snapshot
 
 from .pdfview import PdfView
 
@@ -55,13 +55,7 @@ class SummaryView(PdfView):
             "declared_microorganisms": declaration.declared_microorganisms.all(),
             "declared_ingredients": declaration.declared_ingredients.all(),
             "declared_substances": declaration.declared_substances.all(),
-            "active_ingredient_computed_substances": declaration.computed_substances.filter(
-                substance__ingredientsubstancerelation__ingredient__ingredient_type__in=[
-                    IngredientType.FORM_OF_SUPPLY,
-                    IngredientType.ACTIVE_INGREDIENT,
-                ],
-                substance__ingredientsubstancerelation__ingredient__declaredingredient__declaration=declaration,
-            ).distinct(),
+            "active_ingredient_computed_substances": declaration.active_ingredient_computed_substances,
             "attachments": declaration.attachments.all(),
             "submission_date": submission_date,
             "now": timezone.now(),


### PR DESCRIPTION
Cette PR montre les substances liées aux ingrédients.

Elle vient de la requête [faite ici](https://mattermost.incubateur.net/ruche/pl/5wuqt8epd3bf7mjnri5hpi3yqh) et [validée ici](https://mattermost.incubateur.net/ruche/pl/5wuqt8epd3bf7mjnri5hpi3yqh).

## Description

Les substances liées aux _formes d'apport_ et aux _autres ingrédients actifs_ sont désormais affichées via les `computed_substances`. Les plantes, micro-organismes et autres ingrédients ne sont pas concernés. 

<img width="996" height="898" alt="image" src="https://github.com/user-attachments/assets/b497fb26-304d-417d-98d3-6ecd539ab945" />

## Limitation connues

- La règle CSS `.ingredient-source span + span::before { content: ", "; }` n'a pas d'effet dans le rendu PDF, seulement dans l'HTML. Le PDF affiche des espaces, ce qui est acceptable.
